### PR TITLE
Fixed dynamic array mismatch new[] & delete -> delete[]

### DIFF
--- a/src/dlg_filter.cpp
+++ b/src/dlg_filter.cpp
@@ -211,8 +211,8 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
 //-------------------------------------------------------------------------
 FilterDlg::~FilterDlg()
 {
-    delete m_MicInMagdB;
-    delete m_SpkOutMagdB;
+    delete[] m_MicInMagdB;
+    delete[] m_SpkOutMagdB;
 
     // Disconnect Events
 

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2733,8 +2733,8 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         }
         else {
             // FreeDV clean up
-            delete g_error_hist;
-            delete g_error_histn;
+            delete[] g_error_hist;
+            delete[] g_error_histn;
             codec2_fifo_destroy(g_error_pattern_fifo);
             freedv_close(g_pfreedv);
             speex_preprocess_state_destroy(g_speex_st);

--- a/src/fdmdv2_plot_scalar.cpp
+++ b/src/fdmdv2_plot_scalar.cpp
@@ -80,7 +80,7 @@ PlotScalar::PlotScalar(wxFrame* parent,
 //----------------------------------------------------------------
 PlotScalar::~PlotScalar()
 {
-    delete m_mem;
+    delete[] m_mem;
 }
 
 //----------------------------------------------------------------


### PR DESCRIPTION
Dynamic arrays are not freed with matching delete e.g
https://github.com/drowe67/freedv-gui/blob/ad08dae7b2efa836d901ef2db2d5f2235f5fab71/src/dlg_filter.cpp#L133
https://github.com/drowe67/freedv-gui/blob/ad08dae7b2efa836d901ef2db2d5f2235f5fab71/src/dlg_filter.cpp#L214

Should be eg
```
  SomeType xxxx = new SomeType[];
  delete[] xxxx;
```
But I would suggest using std::vector to take care of memory allocation and cleanup