### PR TITLE
Building for windows using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
  # Building FreeDV GUI
 
-This document describes how to build the FreeDV GUI program for
-various operating systems.  FreeDV GUI is developed on Ubuntu Linux,
-and then cross compiled for Windows using Fedora Linux (Fedora has great
-cross compiling support).
+This document describes how to build the FreeDV GUI program for various operating systems.  FreeDV GUI is developed on Ubuntu Linux, and then cross compiled for Windows using Fedora Linux (Fedora has great cross compiling support).
 
 # Further Reading
 
@@ -32,8 +29,7 @@ cross compiling support).
    $ ./build_linux/src/freedv
    ```
 
-The ```wav``` directory contains test files of modulated audio that
-you can use to test FreeDV (see USER_MANUAL.txt)
+The ```wav``` directory contains test files of modulated audio that you can use to test FreeDV (see USER_MANUAL.txt)
 
 ## Building for Windows on Fedora (Cross compiling)
 
@@ -98,6 +94,10 @@ Testing FreeDV API:
   $ WINEPATH=$HOME/freedv-gui/LPCNet/build_win/src';'$HOME/freedv-gui/build_win/_CPack_Packages/win64/NSIS/FreeDV-1.4.0-devel-win64/bin/ wine freedv_rx 2020 ~/freedv-gui/wav/all_2020.wav out.raw
   $ play -t .s16 -r 16000 -b 16 out.raw
 ```
+
+## Building for Windows using Docker
+
+The Windows build process above has been automated using a Docker container, see docker/README.md
 
 ## Building and installing on OSX
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -300,7 +300,7 @@ than FreeDV 1600 on fading channels, and is competitive with SSB at
 low SNRs.  The FEC provides some protection from urban HF noise.
 
 FreeDV 700D is sensitive to tuning.  To obtain sync you must be within
-+/- 20Hz of the transmit frequency.  This is straightforward with
++/- 60Hz of the transmit frequency.  This is straightforward with
 modern radios which are generally accurate to +/-1 Hz, but requires
 skill and practice when used with older, VFO based radios.
 
@@ -365,7 +365,7 @@ You may encounter the following limitations with FreeDV 2020:
 
 1. Some voices may sound very rough.  In early testing
 about 90% of speakers tested work well.
-1. Like 700D, you must tune within -/+ 20Hz for FreeDV 2020 to sync.
+1. Like 700D, you must tune within -/+ 60Hz for FreeDV 2020 to sync.
 1. With significant fading, sync may take a few seconds.
 1. There is a 2 second end-end latency.  You are welcome to try tuning
    this (Tools - Options - FIFO size, also see Sound Card Debug
@@ -561,10 +561,16 @@ LDPC | Low Density Parity Check Codes, a powerful family of FEC codes
 
 ## Release Notes
 
-Version | Date | Notes
---- | --- | ---
-V1.4 | June 2019 | Project Horus Binary Mode, FreeDV 2020
-V1.3 | May 2018 | FreeDV 700D
+### V1.4 June-August 2019
+
+1. FreeDV 2020 Beta, Project Horus Binary Mode.
+1. [Improved OFDM Modem Acquisition](http://www.rowetel.com/?p=6824), this will improve sync time on
+   FreeDV 700D and 2020 on HF fading channels.  We can also handle +/- 60 Hz frequency offsets now.
+1. Fixed FreeDV 700C frequency offset bug fix, was losing sync at certain frequency offsets.
+
+### V1.3 May 2018
+
+* FreeDV 700D
 
 ## References 
 

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # build_windows.sh
 #
 # Script that cross compiles freedv-gui for Windows on Fedora
@@ -8,7 +8,6 @@
 # override this at the command line for a 32 bit build
 #   $ CMAKE=mingw32-cmake ./build_windows.sh
 : ${CMAKE=mingw64-cmake}
-: ${CLEAN=1}
 
 if [ $CMAKE = "mingw64-cmake" ]; then
     BUILD_DIR=build_win64
@@ -23,24 +22,21 @@ export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 cd $FREEDVGUIDIR
 git clone https://github.com/drowe67/codec2.git
 cd codec2 && git checkout master && git pull
-mkdir -p $BUILD_DIR && cd $BUILD_DIR
-if [ $CLEAN = "1" ]; then rm -Rf *; fi
+mkdir -p $BUILD_DIR && cd $BUILD_DIR && rm -Rf *
 $CMAKE .. && make
 
 # OK, build and test LPCNet
 cd $FREEDVGUIDIR
 git clone https://github.com/drowe67/LPCNet.git
 cd $LPCNETDIR && git checkout master && git pull
-mkdir -p $BUILD_DIR && cd $BUILD_DIR
-if [ $CLEAN = "1" ]; then rm -Rf *; fi
+mkdir -p $BUILD_DIR && cd $BUILD_DIR && rm -Rf *
 $CMAKE -DCODEC2_BUILD_DIR=$CODEC2DIR/$BUILD_DIR ..
 make
 # sanity check test
 #cd src &&  ../../wav/wia.wav -t raw -r 16000 - | ./lpcnet_enc -s | ./lpcnet_dec -s > /dev/null
 
 # Re-build codec2 with LPCNet and test FreeDV 2020 support
-cd $CODEC2DIR/$BUILD_DIR
-if [ $CLEAN = "1" ]; then rm -Rf *; fi
+cd $CODEC2DIR/$BUILD_DIR && rm -Rf *
 $CMAKE -DLPCNET_BUILD_DIR=$LPCNETDIR/$BUILD_DIR ..
 make VERBOSE=1
 # sanity check test

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # build_windows.sh
 #
 # Script that cross compiles freedv-gui for Windows on Fedora
@@ -8,6 +8,7 @@
 # override this at the command line for a 32 bit build
 #   $ CMAKE=mingw32-cmake ./build_windows.sh
 : ${CMAKE=mingw64-cmake}
+: ${CLEAN=1}
 
 if [ $CMAKE = "mingw64-cmake" ]; then
     BUILD_DIR=build_win64
@@ -22,21 +23,24 @@ export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 cd $FREEDVGUIDIR
 git clone https://github.com/drowe67/codec2.git
 cd codec2 && git checkout master && git pull
-mkdir -p $BUILD_DIR && cd $BUILD_DIR && rm -Rf *
+mkdir -p $BUILD_DIR && cd $BUILD_DIR
+if [ $CLEAN = "1" ]; then rm -Rf *; fi
 $CMAKE .. && make
 
 # OK, build and test LPCNet
 cd $FREEDVGUIDIR
 git clone https://github.com/drowe67/LPCNet.git
 cd $LPCNETDIR && git checkout master && git pull
-mkdir -p $BUILD_DIR && cd $BUILD_DIR && rm -Rf *
+mkdir -p $BUILD_DIR && cd $BUILD_DIR
+if [ $CLEAN = "1" ]; then rm -Rf *; fi
 $CMAKE -DCODEC2_BUILD_DIR=$CODEC2DIR/$BUILD_DIR ..
 make
 # sanity check test
 #cd src &&  ../../wav/wia.wav -t raw -r 16000 - | ./lpcnet_enc -s | ./lpcnet_dec -s > /dev/null
 
 # Re-build codec2 with LPCNet and test FreeDV 2020 support
-cd $CODEC2DIR/$BUILD_DIR && rm -Rf *
+cd $CODEC2DIR/$BUILD_DIR
+if [ $CLEAN = "1" ]; then rm -Rf *; fi
 $CMAKE -DLPCNET_BUILD_DIR=$LPCNETDIR/$BUILD_DIR ..
 make VERBOSE=1
 # sanity check test

--- a/docker/README_docker.md
+++ b/docker/README_docker.md
@@ -1,0 +1,33 @@
+# Building freedv-gui for Windows using docker
+
+## Requirements
+* docker
+* docker-compose
+
+## Building the docker images
+Building is only required once
+```bash
+docker-compose -f docker-compose-win.yml build
+```
+## Running the image(s)
+```bash
+export DEV_STLINK=`./get_stlink.sh`
+export GIT_REF=my-super-branch
+export GIT_REPO=http://github.com/dummy/codec2.git
+docker-compose -f docker-compose-win.yml up 
+```
+
+You can optionally control via the environment variables GIT_REPO and GIT_REF which branch/commit from which repo is being built. The if these are not defined default is the `master` branch  of (https://github.com/drowe67/freedv-gui.git) and does not have to be specified explicitly.
+
+```bash
+export GIT_REF=my-super-branch
+export GIT_REPO=http://github.com/dummy/freedv-gui.git
+docker-compose -f docker-compose-win.yml up 
+
+```
+## Accessing created output
+If you started the docker services using `docker up`, you can easily access the compiled output from the docker container.  Using the .exe file name on the last line of the Docker log:
+
+```
+docker cp fdv_win_fed28_c:/home/build/freedv-gui/build_windows/FreeDV-1.4.0-devel-20190725-7cd03db-win64.exe .
+```

--- a/docker/README_docker.md~
+++ b/docker/README_docker.md~
@@ -1,0 +1,42 @@
+# Testing Codec2 using docker
+Currently the docker containers build and run tests for codec2.
+The build results are not accessible directly.
+
+## Requirements
+* docker
+* docker-compose
+* the StdPeripheral Lib V1.8.0 unpacked in the codec2_build_ubuntu dir ( the name of 
+  the top level dir must be STM32F4xx_DSP_StdPeriph_Lib_V1.8.0
+* An internet connection
+* A STM32F4 devboard connected via ST-LINK/V2
+
+## Building the docker images
+Building is only required once
+```bash
+docker-compose -f docker-compose1604.yml  build
+```
+## Running the image(s)
+The environment variable DEV_STLINK must contain the path to the 
+device of the connected ST-LINK. A script `get_stlink.sh` is provided 
+for this purpose.
+
+You can control via the environment variables GIT_REPO and GIT_REF 
+which branch/commit from which repo is being built.
+The if these are not defined default is the `master` branch 
+of (https://github.com/drowe67/codec2.git) and does not have to
+be specified explicitly.
+
+```bash
+export DEV_STLINK=`./get_stlink.sh`
+export GIT_REF=my-super-branch
+export GIT_REPO=http://github.com/dummy/codec2.git
+docker-compose -f docker-compose1604.yml up 
+
+```
+## Accessing created output
+If you started the docker services using `docker up`, you can easily access 
+the compiled output from the docker container.
+
+```
+docker cp codec2_ub1604_c:/tmp/build/codec2 .
+```

--- a/docker/docker-compose-win.yml
+++ b/docker/docker-compose-win.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  fdv_win_fed_28_s:
+    environment:
+        - FDV_GIT_REPO
+        - FDV_GIT_REF
+    build: 
+      context: fdv_win_fedora
+      args:
+         - FED_REL=28
+
+    image:  fdv_win_fed28_i
+    container_name: 'fdv_win_fed28_c'
+    volumes:
+            - win_fed28_v:/home/build/
+
+volumes:
+  win_fed28_v:

--- a/docker/docker-compose-win.yml
+++ b/docker/docker-compose-win.yml
@@ -4,7 +4,9 @@ services:
   fdv_win_fed_28_s:
     environment:
         - FDV_GIT_REPO
-        - FDV_GIT_REF
+        - FDV_GIT_BRANCH
+        - FDV_CLEAN
+        - FDV_CMAKE
     build: 
       context: fdv_win_fedora
       args:

--- a/docker/fdv_win_fedora/Dockerfile
+++ b/docker/fdv_win_fedora/Dockerfile
@@ -1,0 +1,22 @@
+ARG FED_REL=28
+
+FROM fedora:${FED_REL}
+
+# Build & Test Linux: cmake build-essential git libspeexdsp-dev libsamplerate0-dev octave-common octave gnuplot sox ca-cacert octave-signal
+# Build OpenOCD: automake libtool libusb-1.0-0-dev wget which?
+# Build & Test STM32: libc6-i386 p7zip-full python3-numpy bc  
+# tar: bzip2
+# arm-none-eabi-gdb: ncurses-compat-libs
+
+RUN dnf -y install --setopt=install_weak_deps=False @development-tools cmake git speexdsp-devel libsamplerate-devel octave octave-signal gnuplot sox python3-numpy automake libtool libusb1-devel wget bc glibc.i686 which bzip2 ncurses-compat-libs && useradd -m build 
+
+# specific for windows mingw build
+RUN dnf install -y dnf-plugins-core && dnf -y copr enable hobbes1069/mingw && dnf install -y mingw{32,64}-filesystem mingw{32,64}-binutils mingw{32,64}-gcc mingw{32,64}-crt mingw{32,64}-headers mingw32-nsis mingw{32,64}-speex mingw{32,64}-wxWidgets3 mingw{32,64}-hamlib mingw{32,64}-portaudio mingw{32,64}-libsndfile mingw{32,64}-libsamplerate.noarch svn
+
+
+# finally, this is the build script.
+COPY entrypoint.sh /
+
+USER build
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/fdv_win_fedora/entrypoint.sh
+++ b/docker/fdv_win_fedora/entrypoint.sh
@@ -3,13 +3,29 @@
 BUILDROOT=/home/build
 mkdir -p $BUILDROOT 
 cd $BUILDROOT 
+
+# variables that can be passed in to Docker process ------------------
+
+# note this is just teh freedv-gui repo, codec2 and LPCNet repos are hard coded in build_windows.sh
 GIT_REPO=${FDV_GIT_REPO:-http://github.com/drowe67/freedv-gui.git}
 GIT_REF=${FDV_GIT_REF:-master}
+
+# if FDV_CLEAN -eq "1" rm's all previous cmake config and binaries (i.e. a complete rebuild from scratch)
+# if FDV_CLEAN -eq "0" just runs make which gives a faster build if only minor changes
+CLEAN=$(FDV_CLEAN:1}
+
+# override with "mingw32-cmake" for a 32 bit build
+CMAKE=$(FDV_CMAKE:mingw64-cmake}
+
 echo "FDV_GIT_REPO=$GIT_REPO"
 echo "FDV_GIT_REF=$GIT_REF"
+echo "FDV_CLEAN=$CLEAN"
+echo "FDV_CMAKE=$CMAKE"
 
-if [ ! -d freedv-gui ] ; then git clone --depth=1 https://github.com/drowe67/freedv-gui ; fi
-cd freedv-gui && git checkout master && git pull
+# OK lets get started -----------------------------------------------
+
+if [ ! -d freedv-gui ] ; then git clone --depth=1 $GIT_REPO ; fi
+cd freedv-gui && git checkout $GIT_REF && git pull
 echo "--------------------- starting build_windows.sh ---------------------"
-./build_windows.sh
+GIT_REPO=$GIT_REPO GIT_REF=$GIT_REF CLEAN=$CLEAN CMAKE=$CMAKE ./build_windows.sh
 cd build_win64 && make package

--- a/docker/fdv_win_fedora/entrypoint.sh
+++ b/docker/fdv_win_fedora/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+BUILDROOT=/home/build
+mkdir -p $BUILDROOT 
+cd $BUILDROOT 
+GIT_REPO=${FDV_GIT_REPO:-http://github.com/drowe67/freedv-gui.git}
+GIT_REF=${FDV_GIT_REF:-master}
+echo "FDV_GIT_REPO=$GIT_REPO"
+echo "FDV_GIT_REF=$GIT_REF"
+
+if [ ! -d freedv-gui ] ; then git clone --depth=1 https://github.com/drowe67/freedv-gui ; fi
+cd freedv-gui && git checkout master && git pull
+echo "--------------------- starting build_windows.sh ---------------------"
+./build_windows.sh
+cd build_win64 && make package

--- a/docker/fdv_win_fedora/entrypoint.sh
+++ b/docker/fdv_win_fedora/entrypoint.sh
@@ -10,10 +10,6 @@ cd $BUILDROOT
 GIT_REPO=${FDV_GIT_REPO:-http://github.com/drowe67/freedv-gui.git}
 GIT_BRANCH=${FDV_GIT_BRANCH:-master}
 
-# if FDV_CLEAN -eq "1" rm's all previous cmake config and binaries (i.e. a complete rebuild from scratch)
-# if FDV_CLEAN -eq "0" just runs make which gives a faster build if only minor changes
-CLEAN=${FDV_CLEAN:-1}
-
 # override with "mingw32-cmake" for a 32 bit build
 CMAKE=${FDV_CMAKE:-mingw64-cmake}
 
@@ -27,7 +23,7 @@ echo "FDV_CMAKE=$CMAKE"
 if [ ! -d freedv-gui ] ; then git clone --depth=1 $GIT_REPO ; fi
 cd freedv-gui && git checkout $GIT_BRANCH && git pull
 echo "--------------------- starting build_windows.sh ---------------------"
-GIT_REPO=$GIT_REPO GIT_REF=$GIT_REF CLEAN=$CLEAN CMAKE=$CMAKE ./build_windows.sh
+GIT_REPO=$GIT_REPO GIT_REF=$GIT_REF CMAKE=$CMAKE ./build_windows.sh
 if [ $CMAKE = "mingw64-cmake" ]; then
     cd build_win64
 else

--- a/docker/fdv_win_fedora/entrypoint.sh
+++ b/docker/fdv_win_fedora/entrypoint.sh
@@ -6,26 +6,31 @@ cd $BUILDROOT
 
 # variables that can be passed in to Docker process ------------------
 
-# note this is just teh freedv-gui repo, codec2 and LPCNet repos are hard coded in build_windows.sh
+# note this is just the freedv-gui repo, codec2 and LPCNet repos are hard coded in build_windows.sh
 GIT_REPO=${FDV_GIT_REPO:-http://github.com/drowe67/freedv-gui.git}
-GIT_REF=${FDV_GIT_REF:-master}
+GIT_BRANCH=${FDV_GIT_BRANCH:-master}
 
 # if FDV_CLEAN -eq "1" rm's all previous cmake config and binaries (i.e. a complete rebuild from scratch)
 # if FDV_CLEAN -eq "0" just runs make which gives a faster build if only minor changes
-CLEAN=$(FDV_CLEAN:1}
+CLEAN=${FDV_CLEAN:-1}
 
 # override with "mingw32-cmake" for a 32 bit build
-CMAKE=$(FDV_CMAKE:mingw64-cmake}
+CMAKE=${FDV_CMAKE:-mingw64-cmake}
 
 echo "FDV_GIT_REPO=$GIT_REPO"
-echo "FDV_GIT_REF=$GIT_REF"
+echo "FDV_GIT_BRANCH=$GIT_BRANCH"
 echo "FDV_CLEAN=$CLEAN"
 echo "FDV_CMAKE=$CMAKE"
 
 # OK lets get started -----------------------------------------------
 
 if [ ! -d freedv-gui ] ; then git clone --depth=1 $GIT_REPO ; fi
-cd freedv-gui && git checkout $GIT_REF && git pull
+cd freedv-gui && git checkout $GIT_BRANCH && git pull
 echo "--------------------- starting build_windows.sh ---------------------"
 GIT_REPO=$GIT_REPO GIT_REF=$GIT_REF CLEAN=$CLEAN CMAKE=$CMAKE ./build_windows.sh
-cd build_win64 && make package
+if [ $CMAKE = "mingw64-cmake" ]; then
+    cd build_win64
+else
+    cd build_win32
+fi
+make package

--- a/docker/freedv_build_upload_windows.sh
+++ b/docker/freedv_build_upload_windows.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -x
+
+# Automation to cross compile freedv-gui for Windows using Docker on a
+# remote machine, then extract it from Docker and upload to a web
+# server
+#
+# usage:
+# $ BUILD_MACHINE=machine_name UPLOAD_PORT=1234 UPLOAD_USER_PATH=user@mywebserver:downloads \
+#   freedv_build_upload_windows.sh 32|64
+
+[ -z $BUILD_MACHINE ] && { echo "set BUILD_MACHINE"; exit 1; }
+[ -z $UPLOAD_PORT ] && { echo "set UPLOAD_PORT"; exit 1; }
+[ -z $UPLOAD_USER_PATH ] && { echo "set UPLOAD_USER_PATH"; exit 1; }
+[ -z $UPLOAD_USER_PATH ] && { echo "set UPLOAD_USER_PATH"; exit 1; }
+[ -z $FDV_GIT_BRANCH ] && FDV_GIT_BRANCH=master
+
+FDV_CMAKE=mingw64-cmake
+if [ $# -eq 1 ]; then
+    if [ $1 -eq 32 ]; then
+        FDV_CMAKE=mingw32-cmake
+    fi
+fi
+
+log=build_log.txt
+ssh $BUILD_MACHINE "cd freedv-gui/docker; FDV_CMAKE=$FDV_CMAKE FDV_GIT_BRANCH=$FDV_GIT_BRANCH docker-compose -f docker-compose-win.yml up" > $log
+package_docker_path=$(cat $log | sed  -n "s/.*package: \(.*exe\) .*/\1/p")
+echo $package_docker_path
+ssh $BUILD_MACHINE "docker cp fdv_win_fed28_c:$package_docker_path freedv-gui/docker"
+package_file=$(basename $package_docker_path)
+scp $BUILD_MACHINE:freedv-gui/docker/$package_file .
+scp -P $UPLOAD_PORT $package_file $UPLOAD_USER_PATH

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -3171,7 +3171,7 @@ void MainFrame::startRxStream()
         assert(g_rxUserdata->insrcsf != NULL);
 
         // create FIFOs used to interface between Port Audio and txRx
-        // prcoessing loop, which iterates about once every 20ms.
+        // processing loop, which iterates about once every 20ms.
         // Sample rate conversion, stats for spectral plots, and
         // transmit processng are all performed in the txRxProcessing
         // loop.
@@ -3205,25 +3205,28 @@ void MainFrame::startRxStream()
         // TODO: might be able to tune these on a per waveform basis, or refactor
         // to a neater design with less layers of FIFOs
 
-        int modem_samplerate, rxFifoSizeSamples;
+        int modem_samplerate, rxInFifoSizeSamples, rxOutFifoSizeSamples;
         if (g_mode == -1) {
             modem_samplerate = horus_get_Fs(g_horus);
-            rxFifoSizeSamples = horus_get_max_demod_in(g_horus);
+            rxInFifoSizeSamples = horus_get_max_demod_in(g_horus);
+            rxOutFifoSizeSamples = rxInFifoSizeSamples;
         }
         else {
             modem_samplerate = freedv_get_modem_sample_rate(g_pfreedv);
-            rxFifoSizeSamples = freedv_get_n_max_modem_samples(g_pfreedv);
+            rxInFifoSizeSamples = freedv_get_n_max_modem_samples(g_pfreedv);
+            rxOutFifoSizeSamples = freedv_get_n_speech_samples(g_pfreedv);
         }
 
         // add an extra 40ms to give a bit of headroom for processing loop adding samples
         // which operates on 20ms buffers
 
-        rxFifoSizeSamples += 0.04*modem_samplerate;
+        rxInFifoSizeSamples += 0.04*modem_samplerate;
+        rxOutFifoSizeSamples += 0.04*modem_samplerate;
 
-        g_rxUserdata->rxinfifo = codec2_fifo_create(rxFifoSizeSamples);
-        g_rxUserdata->rxoutfifo = codec2_fifo_create(rxFifoSizeSamples);
+        g_rxUserdata->rxinfifo = codec2_fifo_create(rxInFifoSizeSamples);
+        g_rxUserdata->rxoutfifo = codec2_fifo_create(rxOutFifoSizeSamples);
 
-        fprintf(stderr, "rxFifoSizeSamples: %d\n",  rxFifoSizeSamples);
+        fprintf(stderr, "rxInFifoSizeSamples: %d rxOutFifoSizeSamples: %d\n", rxInFifoSizeSamples, rxOutFifoSizeSamples);
         
         // Init Equaliser Filters ------------------------------------------------------
 


### PR DESCRIPTION
1. Using Danilo's fine work to allow us to build freedv-gui for windows using Docker.  This is another step in automating the build process, and allows us to use Docker containers rather than a Fedora machine.  

   Thanks Danilo for showing how this can be done :+1: 

2. Now building working Windows installers, people have tested the EXEs with good results. 

3. Fixed a FIFO size bug that had broken 2020 Rx.

4. Automation script to build freedv-gui on a remote machine and upload 32 and 64 bit Windows installers to a web site in a single step.