### PR TITLE
Improved USB sound device support

### DIFF
--- a/src/dlg_audiooptions.cpp
+++ b/src/dlg_audiooptions.cpp
@@ -917,10 +917,6 @@ void AudioOptsDialog::populateParams(AudioInfoDisplay ai)
         {
             wxString devName = deviceInfo->name;
             wxString apiName = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
-            // Don't display Windows Direct Sound devices, as it clutters up the list of
-            // available devices.
-//            if (apiName.Contains(wxT("Direct")))
-//                continue;
 
             // Don't display spdif devices or surround
             if(devName.Contains(wxT("spdif")) || devName.Contains(wxT("surround")))

--- a/src/dlg_audiooptions.cpp
+++ b/src/dlg_audiooptions.cpp
@@ -33,9 +33,15 @@
 #define TEST_DT                 0.1      // time between plot updates in seconds
 #define TEST_WAVEFORM_PLOT_BUF  ((int)(DT*400))
 
+int AudioOptsDialog::displayConfigErrorCount = 0;
+
 void AudioOptsDialog::Pa_Init(void)
 {
     m_isPaInitialized = false;
+
+    // The ALSA lib spits out a bunch of messages that are of no help to the average user
+    // Temporarily turn them off
+    freopen("/dev/null", "w", stderr);
 
     if((pa_err = Pa_Initialize()) == paNoError)
     {
@@ -46,6 +52,7 @@ void AudioOptsDialog::Pa_Init(void)
         wxMessageBox(wxT("Port Audio failed to initialize"), wxT("Pa_Initialize"), wxOK);
         return;
     }
+    freopen("/dev/tty", "w", stderr);
 }
 
 
@@ -394,35 +401,110 @@ void AudioOptsDialog::OnInitDialog( wxInitDialogEvent& event )
 }
 
 //-------------------------------------------------------------------------
-// OnInitDialog()
+// setTextCtrlIfDevNameValid()
 //
 // helper function to look up name of devNum, and if it exists write
 // name to textCtrl.  Used to trap dissapearing devices.
 //-------------------------------------------------------------------------
-int AudioOptsDialog::setTextCtrlIfDevNumValid(wxTextCtrl *textCtrl, wxListCtrl *listCtrl, int devNum)
+std::string AudioOptsDialog::setTextCtrlIfDevNameValid(wxTextCtrl *textCtrl, wxListCtrl *listCtrl, std::string &audioDevName)
 {
-    int i, aDevNum, found_devNum;
+    int i;
+    std::string devName = "";
+    int found_devNum = -1;
+    std::string foundDevName;
 
     // ignore last list entry as it is the "none" entry
-
-    found_devNum = 0;
     for(i=0; i<listCtrl->GetItemCount()-1; i++) {
-        aDevNum = wxAtoi(listCtrl->GetItemText(i, 1));
-        //printf("aDevNum: %d devNum: %d\n", aDevNum, devNum);
-        if (aDevNum == devNum) {
-            found_devNum = 1;
-            textCtrl->SetValue(listCtrl->GetItemText(i, 0) + " (" + wxString::Format(wxT("%i"),devNum) + ")");
-            printf("setting focus of %d\n", i);
-            listCtrl->SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+        devName = listCtrl->GetItemText(i, 0);
+        //wxPrintf("setTextCtrlIfDevNameValid first pass, audioDevName: %s devName: %s\n", audioDevName, devName);
+        if (devName == audioDevName) {
+            found_devNum = i;
+            foundDevName = devName;
+            //wxPrintf("setTextCtrlIfDevNameValid, found complete name\n");
+            break;  // weird, this break doesn't pop us out of 'for' loop
         }
     }
 
-    if (found_devNum) 
-        return devNum;
-    else {
-        textCtrl->SetValue("none");
-        return -1;
+    if (found_devNum == -1) {
+        // It could be that the user swapped out audio devices prior to last saving configuration,
+        // in which case, the (hw:n,m) string could be different.  If a substring with the name excluding
+        // (hw:n,m) is found, then use it.  The generic "USB Audio Codec" is often assigned to more than
+        // one device, in which case, it can't be used.
+        int numberOfCodecDevices = CountNumberOfCodecDevices(listCtrl);
+
+        for (i = 0; i < listCtrl->GetItemCount()-1; i++) {
+            devName = listCtrl->GetItemText(i, 0);
+
+            // Get the names up to, but not including the "hw(..." string
+            // Also exclude Window's "n - " that can occur at beginning
+            std::string audioDevNameSubstr = stripAudioDevName(audioDevName);
+            std::string devNameSubstr = stripAudioDevName(devName);
+
+            if(audioDevNameSubstr == devNameSubstr) {
+                if((audioDevName.find("USB Audio Codec") == std::string::npos)
+                        || ( numberOfCodecDevices == 1)) {
+                    found_devNum = i;
+                    foundDevName = devName;
+                }
+            }
+        }
     }
+
+    if (found_devNum != -1) {
+        textCtrl->SetValue(foundDevName);
+        listCtrl->SetItemState(found_devNum, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+    } else {
+        textCtrl->SetValue("none");
+        foundDevName = "";
+    }
+
+    return foundDevName;
+}
+
+//-------------------------------------------------------------------------
+// stripAudioDevName()
+//-------------------------------------------------------------------------
+std::string AudioOptsDialog::stripAudioDevName(std::string & devName)
+{
+    // Get the names up to, but not including the "hw(..." string
+    // Also exclude Window's "n - " that can occur at beginning
+
+    // Drop everything after "- (hw" that is, stuff like "- (hw:1,0)
+    size_t posEnd = devName.find("(hw");
+    std::string strippedDevName = devName.substr(0, posEnd);
+
+    // for Windows, get rid of"n-", example, "microphone (5- USB..." becomes "microphone (USB
+    // If you find a dash, then get rid of the dash and the char/number
+    size_t posStart = strippedDevName.find("-");
+    if (posStart != std::string::npos)
+    {
+        strippedDevName.erase(posStart -1, 3 );
+    }
+
+    // Windows returns variable length names when same usb dev plugged into different
+    // usb ports!!!
+    strippedDevName.resize(27);
+
+    return strippedDevName;
+}
+
+//-------------------------------------------------------------------------
+// CountNumberOfCodecDevices()
+//-------------------------------------------------------------------------
+int AudioOptsDialog::CountNumberOfCodecDevices(wxListCtrl *listCtrl)
+{
+    int numberOfCodecDevices = 0;
+    std::string devName;
+    int i;
+
+    for(i=0; i<listCtrl->GetItemCount()-1; i++) {
+        devName = listCtrl->GetItemText(i, 0);
+
+        if(devName.find("USB Audio CODEC") != std::string::npos)
+            ++numberOfCodecDevices;
+    }
+
+    return numberOfCodecDevices;
 }
 
 //-------------------------------------------------------------------------
@@ -435,70 +517,107 @@ int AudioOptsDialog::ExchangeData(int inout)
         // Map sound card device numbers to tx/rx device numbers depending
         // on number of sound cards in use
 
-        printf("EXCHANGE_DATA_IN:\n");
-        printf("  g_nSoundCards: %d\n", g_nSoundCards);
-        printf("  g_soundCard1InDeviceNum: %d\n", g_soundCard1InDeviceNum);
-        printf("  g_soundCard1OutDeviceNum: %d\n", g_soundCard1OutDeviceNum);
-        printf("  g_soundCard1SampleRate: %d\n", g_soundCard1SampleRate);
-        printf("  g_soundCard2InDeviceNum: %d\n", g_soundCard2InDeviceNum);
-        printf("  g_soundCard2OutDeviceNum: %d\n", g_soundCard2OutDeviceNum);
-        printf("  g_soundCard2SampleRate: %d\n", g_soundCard2SampleRate);
+        wxPrintf("EXCHANGE_DATA_IN:\n");
+        wxPrintf("  g_nSoundCards: %d\n", g_nSoundCards);
+        wxPrintf("  g_soundCard1InDeviceName: %s\n", g_soundCard1InDeviceName);
+        wxPrintf("  g_soundCard1OutDeviceName: %s\n", g_soundCard1OutDeviceName);
+        wxPrintf("  g_soundCard1SampleRate: %d\n", g_soundCard1SampleRate);
+        wxPrintf("  g_soundCard2InDeviceName: %s\n", g_soundCard2InDeviceName);
+        wxPrintf("  g_soundCard2OutDeviceName: %s\n", g_soundCard2OutDeviceName);
+        wxPrintf("  g_soundCard2SampleRate: %d\n", g_soundCard2SampleRate);
 
         if (g_nSoundCards == 0) {
-            m_textCtrlRxIn ->SetValue("none"); rxInAudioDeviceNum  = -1;
-            m_textCtrlRxOut->SetValue("none"); rxOutAudioDeviceNum = -1;
-            m_textCtrlTxIn ->SetValue("none"); txInAudioDeviceNum  = -1;
-            m_textCtrlTxOut->SetValue("none"); txOutAudioDeviceNum = -1;           
+            m_textCtrlRxIn ->SetValue("none"); rxInAudioDeviceName  =  "";
+            m_textCtrlRxOut->SetValue("none"); rxOutAudioDeviceName =  "";
+            m_textCtrlTxIn ->SetValue("none"); txInAudioDeviceName  =  "";
+            m_textCtrlTxOut->SetValue("none"); txOutAudioDeviceName =  "";
         }
 
         if (g_nSoundCards == 1) {
-            rxInAudioDeviceNum  = setTextCtrlIfDevNumValid(m_textCtrlRxIn, 
-                                                           m_listCtrlRxInDevices, 
-                                                           g_soundCard1InDeviceNum);
+            rxInAudioDeviceName  = setTextCtrlIfDevNameValid(m_textCtrlRxIn,
+                                                           m_listCtrlRxInDevices,
+                                                           g_soundCard1InDeviceName);
 
-            rxOutAudioDeviceNum = setTextCtrlIfDevNumValid(m_textCtrlRxOut, 
+            rxOutAudioDeviceName = setTextCtrlIfDevNameValid(m_textCtrlRxOut,
                                                            m_listCtrlRxOutDevices, 
-                                                           g_soundCard1OutDeviceNum);
+                                                           g_soundCard1OutDeviceName);
 
-            if ((rxInAudioDeviceNum != -1) && (rxInAudioDeviceNum != -1)) {
+            if ((rxInAudioDeviceName != "") && (rxOutAudioDeviceName != "")) {
                 m_cbSampleRateRxIn->SetValue(wxString::Format(wxT("%i"),g_soundCard1SampleRate));
                 m_cbSampleRateRxOut->SetValue(wxString::Format(wxT("%i"),g_soundCard1SampleRate));
             }
+            else
+            {
+                m_cbSampleRateRxIn->SetValue(wxT("None"));
+                m_cbSampleRateRxOut->SetValue(wxT("None"));
+                wxMessageBox(wxT("Unable to match previously configured audio input/output devices with "
+                                 "current hardware configuration."), wxT("Audio Config Issue"), wxOK);
+            }
 
-            m_textCtrlTxIn ->SetValue("none"); txInAudioDeviceNum  = -1;
-            m_textCtrlTxOut->SetValue("none"); txOutAudioDeviceNum = -1;           
+            m_textCtrlTxIn ->SetValue("none"); txInAudioDeviceName  = "";
+            m_textCtrlTxOut->SetValue("none"); txOutAudioDeviceName = "";
         }
 
         if (g_nSoundCards == 2) {
- 
-            rxInAudioDeviceNum  = setTextCtrlIfDevNumValid(m_textCtrlRxIn, 
+            bool audioCardsOk = true;
+            rxInAudioDeviceName  = setTextCtrlIfDevNameValid(m_textCtrlRxIn,
                                                            m_listCtrlRxInDevices, 
-                                                           g_soundCard1InDeviceNum);
+                                                           g_soundCard1InDeviceName);
 
-            rxOutAudioDeviceNum = setTextCtrlIfDevNumValid(m_textCtrlRxOut, 
+            rxOutAudioDeviceName = setTextCtrlIfDevNameValid(m_textCtrlRxOut,
                                                            m_listCtrlRxOutDevices, 
-                                                           g_soundCard2OutDeviceNum);
+                                                           g_soundCard2OutDeviceName);
 
-            txInAudioDeviceNum  = setTextCtrlIfDevNumValid(m_textCtrlTxIn, 
+            txInAudioDeviceName  = setTextCtrlIfDevNameValid(m_textCtrlTxIn,
                                                            m_listCtrlTxInDevices, 
-                                                           g_soundCard2InDeviceNum);
+                                                           g_soundCard2InDeviceName);
 
-            txOutAudioDeviceNum = setTextCtrlIfDevNumValid(m_textCtrlTxOut, 
+            txOutAudioDeviceName = setTextCtrlIfDevNameValid(m_textCtrlTxOut,
                                                            m_listCtrlTxOutDevices, 
-                                                           g_soundCard1OutDeviceNum);
+                                                           g_soundCard1OutDeviceName);
 
-            if ((rxInAudioDeviceNum != -1) && (txOutAudioDeviceNum != -1)) {
+            if ((rxInAudioDeviceName != "") && (txOutAudioDeviceName != "")) {
+                // Reset the global devices names in case there was an acceptable name change
+                // e.g. (hw:0,0) becomes (hw:1,0)
+                g_soundCard1InDeviceName = rxInAudioDeviceName;
+                g_soundCard1OutDeviceName = txOutAudioDeviceName;
+
                 m_cbSampleRateRxIn->SetValue(wxString::Format(wxT("%i"),g_soundCard1SampleRate));
                 m_cbSampleRateTxOut->SetValue(wxString::Format(wxT("%i"),g_soundCard1SampleRate));
             }
+            else {
+                // While there *may* have been two sound cards, one could have been pulled out.
+                audioCardsOk = false;
+                m_cbSampleRateRxIn->SetValue(wxT("None"));
+                m_cbSampleRateTxOut->SetValue(wxT("None"));
+            }
 
-            if ((txInAudioDeviceNum != -1) && (rxOutAudioDeviceNum != -1)) {
+            if ((txInAudioDeviceName != "") && (rxOutAudioDeviceName != "")) {
+                // Reset the global devices names in case there was an acceptable name change
+                g_soundCard2InDeviceName = txInAudioDeviceName;
+                g_soundCard2OutDeviceName = rxOutAudioDeviceName;
+
                 m_cbSampleRateTxIn->SetValue(wxString::Format(wxT("%i"),g_soundCard2SampleRate));
                 m_cbSampleRateRxOut->SetValue(wxString::Format(wxT("%i"),g_soundCard2SampleRate));
             }
+            else {
+                // While there *may* have been two sound cards, one could have been pulled out.
+                audioCardsOk = false;
+                m_cbSampleRateTxIn->SetValue(wxT("None"));
+                m_cbSampleRateRxOut->SetValue(wxT("None"));
+            }
+
+            if(!audioCardsOk && displayConfigErrorCount < 1)
+            {
+                // This message should only be displayed once, and usually that occurs at startup if the
+                // user had inadverently removed hwd that was connected to FreeDV
+                wxMessageBox(wxT("Unable to match previously configured audio input/output devices with "
+                                 "current hardware configuration."), wxT("Audio Config Issue"), wxOK);
+                ++displayConfigErrorCount;
+            }
         }
-        printf("  rxInAudioDeviceNum: %d\n  rxOutAudioDeviceNum: %d\n  txInAudioDeviceNum: %d\n  txOutAudioDeviceNum: %d\n",
-               rxInAudioDeviceNum, rxOutAudioDeviceNum, txInAudioDeviceNum, txOutAudioDeviceNum);
+        wxPrintf("  rxInAudioDeviceName: %s\n  rxOutAudioDeviceName: %s\n  txInAudioDeviceName: %s\n  txOutAudioDeviceName: %s\n",
+               rxInAudioDeviceName, rxOutAudioDeviceName, txInAudioDeviceName, txOutAudioDeviceName);
     }
 
     if(inout == EXCHANGE_DATA_OUT)
@@ -508,8 +627,8 @@ int AudioOptsDialog::ExchangeData(int inout)
         wxString sampleRate1, sampleRate2;
 
         printf("EXCHANGE_DATA_OUT:\n");
-        printf("  rxInAudioDeviceNum: %d\n  rxOutAudioDeviceNum: %d\n  txInAudioDeviceNum: %d\n  txOutAudioDeviceNum: %d\n",
-               rxInAudioDeviceNum, rxOutAudioDeviceNum, txInAudioDeviceNum, txOutAudioDeviceNum);
+        wxPrintf("  rxInAudioDeviceName: %s\n  rxOutAudioDeviceName: %s\n  txInAudioDeviceName: %s\n  txOutAudioDeviceName: %s\n",
+               rxInAudioDeviceName, rxOutAudioDeviceName, txInAudioDeviceName, txOutAudioDeviceName);
 
         // ---------------------------------------------------------------
         // check we have a valid 1 or 2 sound card configuration
@@ -517,8 +636,8 @@ int AudioOptsDialog::ExchangeData(int inout)
 
         // one sound card config, tx device numbers should be set to -1 
 
-        if ((rxInAudioDeviceNum != -1) && (rxOutAudioDeviceNum != -1) &&
-            (txInAudioDeviceNum == -1) && (txOutAudioDeviceNum == -1)) {
+        if ((rxInAudioDeviceName != "") && (rxOutAudioDeviceName != "") &&
+            (txInAudioDeviceName == "") && (txOutAudioDeviceName == "")) {
  
             valid_one_card_config = 1; 
 
@@ -534,19 +653,19 @@ int AudioOptsDialog::ExchangeData(int inout)
 
         // two card configuration
 
-        if ((rxInAudioDeviceNum != -1) && (rxOutAudioDeviceNum != -1) &&
-            (txInAudioDeviceNum != -1) && (txOutAudioDeviceNum != -1)) {
+        if ((rxInAudioDeviceName != "") && (rxOutAudioDeviceName != "") &&
+            (txInAudioDeviceName != "") && (txOutAudioDeviceName != "")) {
 
             valid_two_card_config = 1; 
 
             // Check we haven't doubled up on sound devices
 
-            if (rxInAudioDeviceNum == txInAudioDeviceNum) {
+            if (rxInAudioDeviceName == txInAudioDeviceName) {
                 wxMessageBox(wxT("You must use different devices for From Radio and From Microphone"), wxT(""), wxOK);
                 return -1;
             }
 
-            if (rxOutAudioDeviceNum == txOutAudioDeviceNum) {
+            if (rxOutAudioDeviceName == txOutAudioDeviceName) {
                 wxMessageBox(wxT("You must use different devices for To Radio and To Speaker/Headphones"), wxT(""), wxOK);
                 return -1;
             }
@@ -587,43 +706,43 @@ int AudioOptsDialog::ExchangeData(int inout)
         // Tx/Rx oriented as in this dialog.
         // ---------------------------------------------------------------
         g_nSoundCards = 0;
-        g_soundCard1InDeviceNum = g_soundCard1OutDeviceNum = g_soundCard2InDeviceNum = g_soundCard2OutDeviceNum = -1;
+        g_soundCard1InDeviceName = g_soundCard1OutDeviceName = g_soundCard2InDeviceName = g_soundCard2OutDeviceName ="";
 
         if (valid_one_card_config) {
 
             // Only callback 1 used
 
             g_nSoundCards = 1;
-            g_soundCard1InDeviceNum  = rxInAudioDeviceNum;
-            g_soundCard1OutDeviceNum = rxOutAudioDeviceNum;
+            g_soundCard1InDeviceName  = rxInAudioDeviceName;
+            g_soundCard1OutDeviceName = rxOutAudioDeviceName;
             g_soundCard1SampleRate = wxAtoi(sampleRate1);
         }
 
         if (valid_two_card_config) {
             g_nSoundCards = 2;
-            g_soundCard1InDeviceNum  = rxInAudioDeviceNum;
-            g_soundCard1OutDeviceNum = txOutAudioDeviceNum;
+            g_soundCard1InDeviceName  = rxInAudioDeviceName;
+            g_soundCard1OutDeviceName = txOutAudioDeviceName;
             g_soundCard1SampleRate   = wxAtoi(sampleRate1);
-            g_soundCard2InDeviceNum  = txInAudioDeviceNum;
-            g_soundCard2OutDeviceNum = rxOutAudioDeviceNum;
+            g_soundCard2InDeviceName  = txInAudioDeviceName;
+            g_soundCard2OutDeviceName = rxOutAudioDeviceName;
             g_soundCard2SampleRate   = wxAtoi(sampleRate2);
         }
 
-        printf("  g_nSoundCards: %d\n", g_nSoundCards);
-        printf("  g_soundCard1InDeviceNum: %d\n", g_soundCard1InDeviceNum);
-        printf("  g_soundCard1OutDeviceNum: %d\n", g_soundCard1OutDeviceNum);
-        printf("  g_soundCard1SampleRate: %d\n", g_soundCard1SampleRate);
-        printf("  g_soundCard2InDeviceNum: %d\n", g_soundCard2InDeviceNum);
-        printf("  g_soundCard2OutDeviceNum: %d\n", g_soundCard2OutDeviceNum);
-        printf("  g_soundCard2SampleRate: %d\n", g_soundCard2SampleRate);
+        wxPrintf("  g_nSoundCards: %d\n", g_nSoundCards);
+        wxPrintf("  g_soundCard1InDeviceName: %s\n", g_soundCard1InDeviceName);
+        wxPrintf("  g_soundCard1OutDeviceName: %s\n", g_soundCard1OutDeviceName);
+        wxPrintf("  g_soundCard1SampleRate: %d\n", g_soundCard1SampleRate);
+        wxPrintf("  g_soundCard2InDeviceName: %s\n", g_soundCard2InDeviceName);
+        wxPrintf("  g_soundCard2OutDeviceName: %s\n", g_soundCard2OutDeviceName);
+        wxPrintf("  g_soundCard2SampleRate: %d\n", g_soundCard2SampleRate);
 
         wxConfigBase *pConfig = wxConfigBase::Get();
-        pConfig->Write(wxT("/Audio/soundCard1InDeviceNum"),       g_soundCard1InDeviceNum);
-        pConfig->Write(wxT("/Audio/soundCard1OutDeviceNum"),      g_soundCard1OutDeviceNum);
+        pConfig->Write(wxT("/Audio/soundCard1InDeviceName"),      wxString(g_soundCard1InDeviceName));
+        pConfig->Write(wxT("/Audio/soundCard1OutDeviceName"),     wxString(g_soundCard1OutDeviceName));
         pConfig->Write(wxT("/Audio/soundCard1SampleRate"),        g_soundCard1SampleRate );
 
-        pConfig->Write(wxT("/Audio/soundCard2InDeviceNum"),       g_soundCard2InDeviceNum);
-        pConfig->Write(wxT("/Audio/soundCard2OutDeviceNum"),      g_soundCard2OutDeviceNum);
+        pConfig->Write(wxT("/Audio/soundCard2InDeviceName"),      wxString(g_soundCard2InDeviceName));
+        pConfig->Write(wxT("/Audio/soundCard2OutDeviceName"),     wxString(g_soundCard2OutDeviceName));
         pConfig->Write(wxT("/Audio/soundCard2SampleRate"),        g_soundCard2SampleRate );
 
         pConfig->Flush();
@@ -690,7 +809,7 @@ int AudioOptsDialog:: buildListOfSupportedSampleRates(wxComboBox *cbSampleRate, 
         if( err == paFormatIsSupported ) {
             str.Printf("%i", (int)standardSampleRates[i]);
             cbSampleRate->AppendString(str);
-            printf("%i ", (int)standardSampleRates[i]);
+            wxPrintf("Supported rates: %i\n", (int)standardSampleRates[i]);
             numSampleRates++;
         }
     }
@@ -796,15 +915,27 @@ void AudioOptsDialog::populateParams(AudioInfoDisplay ai)
         if( ((in_out == AUDIO_IN) && (deviceInfo->maxInputChannels > 0)) ||
             ((in_out == AUDIO_OUT) && (deviceInfo->maxOutputChannels > 0)))
         {
+            wxString devName = deviceInfo->name;
+            wxString apiName = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
+            // Don't display Windows Direct Sound devices, as it clutters up the list of
+            // available devices.
+//            if (apiName.Contains(wxT("Direct")))
+//                continue;
+
+            // Don't display spdif devices or surround
+            if(devName.Contains(wxT("spdif")) || devName.Contains(wxT("surround")))
+                continue;
+
             col = 0;
-            buf.Printf(wxT("%s"), deviceInfo->name);
+            buf.Printf(wxT("%s"), devName);
             idx = ctrl->InsertItem(ctrl->GetItemCount(), buf);
             col++;
                 
             buf.Printf(wxT("%d"), devn);
             ctrl->SetItem(idx, col++, buf);
 
-            buf.Printf(wxT("%s"), Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
+
+            buf.Printf(wxT("%s"), apiName);
             ctrl->SetItem(idx, col++, buf);
 
             buf.Printf(wxT("%i"), (int)deviceInfo->defaultSampleRate);
@@ -840,22 +971,23 @@ void AudioOptsDialog::populateParams(AudioInfoDisplay ai)
 //-------------------------------------------------------------------------
 void AudioOptsDialog::OnDeviceSelect(wxComboBox *cbSampleRate, 
                                      wxTextCtrl *textCtrl, 
-                                     int        *devNum, 
+                                     std::string & audioDevName,
                                      wxListCtrl *listCtrlDevices, 
                                      int         index,
                                      int         in_out)
 {
-
+    int devNum;
     wxString devName = listCtrlDevices->GetItemText(index, 0);
      if (devName.IsSameAs("none")) {
-        *devNum = -1;
-        textCtrl->SetValue("none");
+        audioDevName = "";
+         textCtrl->SetValue("none");
     }
     else {
-        *devNum = wxAtoi(listCtrlDevices->GetItemText(index, 1));
-        textCtrl->SetValue(devName + " (" + wxString::Format(wxT("%i"),*devNum) + ")");
-
-        int numSampleRates = buildListOfSupportedSampleRates(cbSampleRate, *devNum, in_out);
+         // Report the selected name back to the caller
+        audioDevName = devName;
+        textCtrl->SetValue(devName);
+        devNum = wxAtoi(listCtrlDevices->GetItemText(index, 1));
+        int numSampleRates = buildListOfSupportedSampleRates(cbSampleRate, devNum, in_out);
         if (numSampleRates) {
             wxString defSampleRate = listCtrlDevices->GetItemText(index, 3);        
             cbSampleRate->SetValue(defSampleRate);
@@ -873,7 +1005,7 @@ void AudioOptsDialog::OnRxInDeviceSelect(wxListEvent& evt)
 {
     OnDeviceSelect(m_cbSampleRateRxIn, 
                    m_textCtrlRxIn, 
-                   &rxInAudioDeviceNum, 
+                   rxInAudioDeviceName,
                    m_listCtrlRxInDevices, 
                    evt.GetIndex(),
                    AUDIO_IN);
@@ -886,7 +1018,7 @@ void AudioOptsDialog::OnRxOutDeviceSelect(wxListEvent& evt)
 {
     OnDeviceSelect(m_cbSampleRateRxOut, 
                    m_textCtrlRxOut, 
-                   &rxOutAudioDeviceNum, 
+                   rxOutAudioDeviceName,
                    m_listCtrlRxOutDevices, 
                    evt.GetIndex(),
                    AUDIO_OUT);
@@ -899,7 +1031,7 @@ void AudioOptsDialog::OnTxInDeviceSelect(wxListEvent& evt)
 {
     OnDeviceSelect(m_cbSampleRateTxIn, 
                    m_textCtrlTxIn, 
-                   &txInAudioDeviceNum, 
+                   txInAudioDeviceName,
                    m_listCtrlTxInDevices, 
                    evt.GetIndex(),
                    AUDIO_IN);
@@ -912,7 +1044,7 @@ void AudioOptsDialog::OnTxOutDeviceSelect(wxListEvent& evt)
 {
     OnDeviceSelect(m_cbSampleRateTxOut, 
                    m_textCtrlTxOut, 
-                   &txOutAudioDeviceNum, 
+                   txOutAudioDeviceName,
                    m_listCtrlTxOutDevices, 
                    evt.GetIndex(),
                    AUDIO_OUT);
@@ -925,7 +1057,7 @@ void AudioOptsDialog::OnTxOutDeviceSelect(wxListEvent& evt)
 // synchronous portaudio functions, so the GUI will not respond until after test sample has been
 // taken
 //-------------------------------------------------------------------------
-void AudioOptsDialog::plotDeviceInputForAFewSecs(int devNum, PlotScalar *plotScalar) {
+void AudioOptsDialog::plotDeviceInputForAFewSecs(const std::string & soundCardName, PlotScalar *plotScalar) {
     PaStreamParameters  inputParameters;
     const PaDeviceInfo *deviceInfo = NULL;
     PaStream           *stream = NULL;
@@ -936,6 +1068,8 @@ void AudioOptsDialog::plotDeviceInputForAFewSecs(int devNum, PlotScalar *plotSca
     int                 numDevices, nBufs, j, src_error,inputChannels, sampleRate, sampleCount;
     SRC_STATE          *src;
     FIFO               *fifo;
+
+    PaDeviceIndex devNum = PortAudioWrap::getDeviceIndex(soundCardName);
 
     // a basic sanity check
     numDevices = Pa_GetDeviceCount();
@@ -1044,7 +1178,7 @@ void AudioOptsDialog::plotDeviceInputForAFewSecs(int devNum, PlotScalar *plotSca
 // synchronous portaudio functions, so the GUI will not respond until after test sample has been
 // taken.  Also plots a pretty picture like the record versions
 //-------------------------------------------------------------------------
-void AudioOptsDialog::plotDeviceOutputForAFewSecs(int devNum, PlotScalar *plotScalar) {
+void AudioOptsDialog::plotDeviceOutputForAFewSecs(const std::string &soundCardName, PlotScalar *plotScalar) {
     PaStreamParameters  outputParameters;
     const PaDeviceInfo *deviceInfo = NULL;
     PaStream           *stream = NULL;
@@ -1055,6 +1189,19 @@ void AudioOptsDialog::plotDeviceOutputForAFewSecs(int devNum, PlotScalar *plotSc
     int                 numDevices, j, src_error, n, outputChannels, sampleRate, sampleCount;
     SRC_STATE          *src;
     FIFO               *fifo;
+
+
+    // Clear the plot
+    short plotSamples[TEST_WAVEFORM_PLOT_BUF*2];
+    memset(plotSamples, 0, TEST_WAVEFORM_PLOT_BUF*2);
+    for(int i = 0; i < (TEST_WAVEFORM_PLOT_TIME * TEST_WAVEFORM_PLOT_FS); i += TEST_WAVEFORM_PLOT_BUF)
+        plotScalar->add_new_short_samples(0, plotSamples, TEST_WAVEFORM_PLOT_BUF, 32767);
+
+    plotScalar->Refresh();
+    plotScalar->Update();
+
+
+    PaDeviceIndex devNum = PortAudioWrap::getDeviceIndex(soundCardName);
 
     // a basic sanity check
     numDevices = Pa_GetDeviceCount();
@@ -1117,7 +1264,7 @@ void AudioOptsDialog::plotDeviceOutputForAFewSecs(int devNum, PlotScalar *plotSc
 
     while(sampleCount < (TEST_WAVEFORM_PLOT_TIME * TEST_WAVEFORM_PLOT_FS)) {
         for(j=0; j<TEST_BUF_SIZE; j++,n++) {
-            out48k_short[j] = 2000.0*cos(6.2832*(n++)*400.0/sampleRate);
+            out48k_short[j] = 6000.0*cos(6.2832*(n++)*400.0/sampleRate);
             if (outputChannels == 2) {
                 out48k_stereo_short[2*j] = out48k_short[j];   // left channel
                 out48k_stereo_short[2*j+1] = out48k_short[j]; // right channel
@@ -1162,7 +1309,7 @@ void AudioOptsDialog::plotDeviceOutputForAFewSecs(int devNum, PlotScalar *plotSc
 //-------------------------------------------------------------------------
 void AudioOptsDialog::OnRxInTest(wxCommandEvent& event)
 {
-    plotDeviceInputForAFewSecs(rxInAudioDeviceNum, m_plotScalarRxIn);
+    plotDeviceInputForAFewSecs(rxInAudioDeviceName, m_plotScalarRxIn);
 }
 
 //-------------------------------------------------------------------------
@@ -1170,7 +1317,7 @@ void AudioOptsDialog::OnRxInTest(wxCommandEvent& event)
 //-------------------------------------------------------------------------
 void AudioOptsDialog::OnRxOutTest(wxCommandEvent& event)
 {
-    plotDeviceOutputForAFewSecs(rxOutAudioDeviceNum, m_plotScalarRxOut);
+    plotDeviceOutputForAFewSecs(rxOutAudioDeviceName, m_plotScalarRxOut);
 }
 
 //-------------------------------------------------------------------------
@@ -1178,7 +1325,7 @@ void AudioOptsDialog::OnRxOutTest(wxCommandEvent& event)
 //-------------------------------------------------------------------------
 void AudioOptsDialog::OnTxInTest(wxCommandEvent& event)
 {
-    plotDeviceInputForAFewSecs(txInAudioDeviceNum, m_plotScalarTxIn);
+    plotDeviceInputForAFewSecs(txInAudioDeviceName, m_plotScalarTxIn);
 }
 
 //-------------------------------------------------------------------------
@@ -1186,7 +1333,7 @@ void AudioOptsDialog::OnTxInTest(wxCommandEvent& event)
 //-------------------------------------------------------------------------
 void AudioOptsDialog::OnTxOutTest(wxCommandEvent& event)
 {
-    plotDeviceOutputForAFewSecs(txOutAudioDeviceNum, m_plotScalarTxOut);
+    plotDeviceOutputForAFewSecs(txOutAudioDeviceName, m_plotScalarTxOut);
 }
 
 //-------------------------------------------------------------------------

--- a/src/dlg_audiooptions.h
+++ b/src/dlg_audiooptions.h
@@ -58,24 +58,26 @@ class AudioOptsDialog : public wxDialog
         PaError         pa_err;
         bool            m_isPaInitialized;
 
-        int             rxInAudioDeviceNum;
-        int             rxOutAudioDeviceNum;
-        int             txInAudioDeviceNum;
-        int             txOutAudioDeviceNum;
+        std::string        rxInAudioDeviceName;
+        std::string        rxOutAudioDeviceName;
+        std::string        txInAudioDeviceName;
+        std::string        txOutAudioDeviceName;
 
         void buildTestControls(PlotScalar **plotScalar, wxButton **btnTest, 
                                wxPanel *parentPanel, wxBoxSizer *bSizer, wxString buttonLabel);
-        void plotDeviceInputForAFewSecs(int devNum, PlotScalar *plotScalar);
-        void plotDeviceOutputForAFewSecs(int devNum, PlotScalar *plotScalar);
+        void plotDeviceInputForAFewSecs(const std::string &soundCardName, PlotScalar *plotScalar);
+        void plotDeviceOutputForAFewSecs(const std::string &soundCardName, PlotScalar *plotScalar);
 
         int buildListOfSupportedSampleRates(wxComboBox *cbSampleRate, int devNum, int in_out);
         void populateParams(AudioInfoDisplay);
         void showAPIInfo();
-        int setTextCtrlIfDevNumValid(wxTextCtrl *textCtrl, wxListCtrl *listCtrl, int devNum);
+        std::string setTextCtrlIfDevNameValid(wxTextCtrl *textCtrl, wxListCtrl *listCtrl, std::string &audioDevName);
+        std::string stripAudioDevName(std::string & devName);
+        int CountNumberOfCodecDevices(wxListCtrl *listCtrl);
         void Pa_Init(void);
         void OnDeviceSelect(wxComboBox *cbSampleRate, 
                             wxTextCtrl *textCtrl, 
-                            int        *devNum, 
+                            std::string & audioDevName,
                             wxListCtrl *listCtrlDevices, 
                             int         index,
                             int         in_out);
@@ -172,5 +174,7 @@ class AudioOptsDialog : public wxDialog
         AudioOptsDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Audio Config"), const wxPoint& pos = wxPoint(1,1), const wxSize& size = wxSize( 800, 650 ), long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER );
         ~AudioOptsDialog();
         int ExchangeData(int inout);
+        static int displayConfigErrorCount;
+
 };
 #endif //__AudioOptsDialog__

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -94,6 +94,11 @@ int                 g_soundCard2InDeviceNum;
 int                 g_soundCard2OutDeviceNum;
 int                 g_soundCard2SampleRate;
 
+std::string                 g_soundCard1InDeviceName;
+std::string                 g_soundCard1OutDeviceName;
+std::string                 g_soundCard2InDeviceName;
+std::string                 g_soundCard2OutDeviceName;
+
 // PortAudio over/underflow counters
 
 int                 g_infifo1_full;
@@ -273,6 +278,11 @@ bool MainApp::OnInit()
     frame->Show();
     g_parent =frame;
 
+    AudioOptsDialog *dlg = new AudioOptsDialog(NULL);
+    dlg->ExchangeData(EXCHANGE_DATA_IN);
+    delete dlg;
+
+
     return true;
 }
 
@@ -442,18 +452,51 @@ MainFrame::MainFrame(wxString plugInName, wxWindow *parent) : TopFrame(plugInNam
     wxGetApp().m_framesPerBuffer = pConfig->Read(wxT("/Audio/framesPerBuffer"), (int)PA_FPB);
     wxGetApp().m_fifoSize_ms = pConfig->Read(wxT("/Audio/fifoSize_ms"), (int)FIFO_SIZE);
 
-    g_soundCard1InDeviceNum  = pConfig->Read(wxT("/Audio/soundCard1InDeviceNum"),         -1);
-    g_soundCard1OutDeviceNum = pConfig->Read(wxT("/Audio/soundCard1OutDeviceNum"),        -1);
-    g_soundCard1SampleRate   = pConfig->Read(wxT("/Audio/soundCard1SampleRate"),          -1);
+    // Legacy FreeDV would use sound card device numbers in the config file, but these numbers
+    // are not static within the OS.  Newer FreeDV uses device names instead.
+    g_soundCard1InDeviceNum  = pConfig->Read(wxT("/Audio/soundCard1InDeviceNum"),  paNoDevice);
+    g_soundCard1OutDeviceNum = pConfig->Read(wxT("/Audio/soundCard1OutDeviceNum"), paNoDevice);
+    g_soundCard1SampleRate   = pConfig->Read(wxT("/Audio/soundCard1SampleRate"),           -1);
 
-    g_soundCard2InDeviceNum  = pConfig->Read(wxT("/Audio/soundCard2InDeviceNum"),         -1);
-    g_soundCard2OutDeviceNum = pConfig->Read(wxT("/Audio/soundCard2OutDeviceNum"),        -1);
-    g_soundCard2SampleRate   = pConfig->Read(wxT("/Audio/soundCard2SampleRate"),          -1);
+    g_soundCard2InDeviceNum  = pConfig->Read(wxT("/Audio/soundCard2InDeviceNum"),  paNoDevice);
+    g_soundCard2OutDeviceNum = pConfig->Read(wxT("/Audio/soundCard2OutDeviceNum"), paNoDevice);
+    g_soundCard2SampleRate   = pConfig->Read(wxT("/Audio/soundCard2SampleRate"),           -1);
+
+    g_soundCard1InDeviceName  = pConfig->Read(wxT("/Audio/soundCard1InDeviceName"),  wxT(""));
+    g_soundCard1OutDeviceName = pConfig->Read(wxT("/Audio/soundCard1OutDeviceName"), wxT(""));
+
+    g_soundCard2InDeviceName  = pConfig->Read(wxT("/Audio/soundCard2InDeviceName"),  wxT(""));
+    g_soundCard2OutDeviceName = pConfig->Read(wxT("/Audio/soundCard2OutDeviceName"), wxT(""));
+
+    // Temporarily initialize port audio so we can attempt to get device names based on
+    // previous device numbers.  Temp redirect stderr so ALSA lib doesn't clutter term output
+
+    freopen("/dev/null", "w", stderr);
+
+    if(Pa_Initialize())
+    {
+        wxMessageBox(wxT("Port Audio failed to initialize"), wxT("Pa_Initialize"), wxOK);
+    }
+    freopen("/dev/tty", "w", stderr);
+
+    // In the event the user's config file uses legacy device numbers and not strings, use
+    // device numbers if they, and not the strings, are available.  Save names instead later.
+    if ((g_soundCard1InDeviceNum != -1) && (g_soundCard1InDeviceName == ""))
+        g_soundCard1InDeviceName = PortAudioWrap::getDeviceNameStr(g_soundCard1InDeviceNum);
+
+    if ((g_soundCard1OutDeviceNum != -1) && (g_soundCard1OutDeviceName == ""))
+        g_soundCard1OutDeviceName = PortAudioWrap::getDeviceNameStr(g_soundCard1OutDeviceNum);
+
+    if ((g_soundCard2InDeviceNum != -1) && (g_soundCard2InDeviceName == ""))
+        g_soundCard2InDeviceName = PortAudioWrap::getDeviceNameStr(g_soundCard2InDeviceNum);
+
+    if ((g_soundCard2OutDeviceNum != -1) && (g_soundCard2OutDeviceName == ""))
+        g_soundCard2OutDeviceName = PortAudioWrap::getDeviceNameStr(g_soundCard2OutDeviceNum);
 
     g_nSoundCards = 0;
-    if ((g_soundCard1InDeviceNum > -1) && (g_soundCard1OutDeviceNum > -1)) {
+    if ((g_soundCard1InDeviceName != "") && (g_soundCard1OutDeviceName != "")) {
         g_nSoundCards = 1;
-        if ((g_soundCard2InDeviceNum > -1) && (g_soundCard2OutDeviceNum > -1))
+        if ((g_soundCard2InDeviceName != "") && (g_soundCard2OutDeviceName != ""))
             g_nSoundCards = 2;
     }
 
@@ -769,12 +812,12 @@ MainFrame::~MainFrame()
         pConfig->Write(wxT("/Audio/framesPerBuffer"),       wxGetApp().m_framesPerBuffer);
         pConfig->Write(wxT("/Audio/fifoSize_ms"),              wxGetApp().m_fifoSize_ms);
 
-        pConfig->Write(wxT("/Audio/soundCard1InDeviceNum"),   g_soundCard1InDeviceNum);
-        pConfig->Write(wxT("/Audio/soundCard1OutDeviceNum"),  g_soundCard1OutDeviceNum);
+        pConfig->Write(wxT("/Audio/soundCard1InDeviceName"),   wxString(g_soundCard1InDeviceName));
+        pConfig->Write(wxT("/Audio/soundCard1OutDeviceName"),  wxString(g_soundCard1OutDeviceName));
         pConfig->Write(wxT("/Audio/soundCard1SampleRate"),    g_soundCard1SampleRate );
 
-        pConfig->Write(wxT("/Audio/soundCard2InDeviceNum"),   g_soundCard2InDeviceNum);
-        pConfig->Write(wxT("/Audio/soundCard2OutDeviceNum"),  g_soundCard2OutDeviceNum);
+        pConfig->Write(wxT("/Audio/soundCard2InDeviceName"),   wxString(g_soundCard2InDeviceName));
+        pConfig->Write(wxT("/Audio/soundCard2OutDeviceName"),  wxString(g_soundCard2OutDeviceName));
         pConfig->Write(wxT("/Audio/soundCard2SampleRate"),    g_soundCard2SampleRate );
 
         pConfig->Write(wxT("/VoiceKeyer/WaveFilePath"), wxGetApp().m_txtVoiceKeyerWaveFilePath);
@@ -3033,9 +3076,10 @@ void MainFrame::startRxStream()
         }
 
         m_rxInPa = new PortAudioWrap();
-        if(g_soundCard1InDeviceNum != g_soundCard1OutDeviceNum)
+
+        if(g_soundCard1InDeviceName != g_soundCard1OutDeviceName)
             two_rx=true;
-        if(g_soundCard2InDeviceNum != g_soundCard2OutDeviceNum)
+        if(g_soundCard2InDeviceName != g_soundCard2OutDeviceName)
             two_tx=true;
         
         //fprintf(stderr, "two_rx: %d two_tx: %d\n", two_rx, two_tx);
@@ -3055,25 +3099,26 @@ void MainFrame::startRxStream()
 
         // Init Sound card 1 ----------------------------------------------
         // sanity check on sound card device numbers
-
-        if ((m_rxInPa->getDeviceCount() <= g_soundCard1InDeviceNum) ||
-            (m_rxOutPa->getDeviceCount() <= g_soundCard1OutDeviceNum)) {
+        if( !PortAudioWrap::isSoundCardNameValid(g_soundCard1InDeviceName)
+                || !PortAudioWrap::isSoundCardNameValid(g_soundCard1OutDeviceName)) {
             wxMessageBox(wxT("Sound Card 1 not present"), wxT("Error"), wxOK);
             delete m_rxInPa;
             if(two_rx)
-				delete m_rxOutPa;
+                delete m_rxOutPa;
             m_RxRunning = false;
             return;
+
         }
 
-        // work out how many input channels this device supports.
 
-        deviceInfo1 = Pa_GetDeviceInfo(g_soundCard1InDeviceNum);
+        // work out how many input channels this device supports.
+        PaDeviceIndex soundCard1InDeviceNum = PortAudioWrap::getDeviceIndex(g_soundCard1InDeviceName);
+        deviceInfo1 = Pa_GetDeviceInfo(soundCard1InDeviceNum);
         if (deviceInfo1 == NULL) {
             wxMessageBox(wxT("Couldn't get device info from Port Audio for Sound Card 1"), wxT("Error"), wxOK);
             delete m_rxInPa;
             if(two_rx)
-				delete m_rxOutPa;
+                delete m_rxOutPa;
             m_RxRunning = false;
             return;
         }
@@ -3082,14 +3127,17 @@ void MainFrame::startRxStream()
         else
             inputChannels1 = 2;
 
+        PaDeviceIndex soundCard1OutDeviceNum = PortAudioWrap::getDeviceIndex(g_soundCard1OutDeviceName);
+
         if(two_rx) {
-            initPortAudioDevice(m_rxInPa, g_soundCard1InDeviceNum, paNoDevice, 1,
+            initPortAudioDevice(m_rxInPa, soundCard1InDeviceNum, paNoDevice, 1,
                             g_soundCard1SampleRate, inputChannels1);
-            initPortAudioDevice(m_rxOutPa, paNoDevice, g_soundCard1OutDeviceNum, 1,
+
+            initPortAudioDevice(m_rxOutPa, paNoDevice, soundCard1OutDeviceNum, 1,
                             g_soundCard1SampleRate, inputChannels1);
 		}
         else
-            initPortAudioDevice(m_rxInPa, g_soundCard1InDeviceNum, g_soundCard1OutDeviceNum, 1,
+            initPortAudioDevice(m_rxInPa, soundCard1InDeviceNum, soundCard1OutDeviceNum, 1,
                             g_soundCard1SampleRate, inputChannels1);
 
         // Init Sound Card 2 ------------------------------------------------
@@ -3105,11 +3153,11 @@ void MainFrame::startRxStream()
             // sanity check on sound card device numbers
 
             //printf("m_txInPa->getDeviceCount(): %d\n", m_txInPa->getDeviceCount());
-            //printf("g_soundCard2InDeviceNum: %d\n", g_soundCard2InDeviceNum);
-            //printf("g_soundCard2OutDeviceNum: %d\n", g_soundCard2OutDeviceNum);
+            //wxPrintf("g_soundCard2InDeviceName: %s\n", g_soundCard2InDeviceName);
+            //wxPrintf("g_soundCard2OutDeviceName: %s\n", g_soundCard2OutDeviceName);
 
-            if ((m_txInPa->getDeviceCount() <= g_soundCard2InDeviceNum) ||
-                (m_txOutPa->getDeviceCount() <= g_soundCard2OutDeviceNum)) {
+            if( !PortAudioWrap::isSoundCardNameValid(g_soundCard2InDeviceName)
+                    || !PortAudioWrap::isSoundCardNameValid(g_soundCard2OutDeviceName)) {
                 wxMessageBox(wxT("Sound Card 2 not present"), wxT("Error"), wxOK);
                 delete m_rxInPa;
                 if(two_rx)
@@ -3121,15 +3169,16 @@ void MainFrame::startRxStream()
                 return;
             }
 
-            deviceInfo2 = Pa_GetDeviceInfo(g_soundCard2InDeviceNum);
+            PaDeviceIndex soundCard2InDeviceNum = PortAudioWrap::getDeviceIndex(g_soundCard2InDeviceName);
+            deviceInfo2 = Pa_GetDeviceInfo(soundCard2InDeviceNum);
             if (deviceInfo2 == NULL) {
                 wxMessageBox(wxT("Couldn't get device info from Port Audio for Sound Card 1"), wxT("Error"), wxOK);
                 delete m_rxInPa;
                 if(two_rx)
-					delete m_rxOutPa;
+                    delete m_rxOutPa;
                 delete m_txInPa;
                 if(two_tx)
-					delete m_txOutPa;
+                    delete m_txOutPa;
                 m_RxRunning = false;
                 return;
             }
@@ -3138,15 +3187,17 @@ void MainFrame::startRxStream()
             else
                 inputChannels2 = 2;
 
+            PaDeviceIndex soundCard2OutDeviceNum = PortAudioWrap::getDeviceIndex(g_soundCard2OutDeviceName);
+
             if(two_tx) {
-				initPortAudioDevice(m_txInPa, g_soundCard2InDeviceNum, paNoDevice, 2,
-                                g_soundCard2SampleRate, inputChannels2);
-				initPortAudioDevice(m_txOutPa, paNoDevice, g_soundCard2OutDeviceNum, 2,
-                                g_soundCard2SampleRate, inputChannels2);
-			}
-			else
-				initPortAudioDevice(m_txInPa, g_soundCard2InDeviceNum, g_soundCard2OutDeviceNum, 2,
-                                g_soundCard2SampleRate, inputChannels2);
+                initPortAudioDevice(m_txInPa, soundCard2InDeviceNum, paNoDevice, 2,
+                    g_soundCard2SampleRate, inputChannels2);
+                initPortAudioDevice(m_txOutPa, paNoDevice, soundCard2OutDeviceNum, 2,
+                    g_soundCard2SampleRate, inputChannels2);
+            }
+            else
+                initPortAudioDevice(m_txInPa, soundCard2InDeviceNum, soundCard2OutDeviceNum, 2,
+                    g_soundCard2SampleRate, inputChannels2);
         }
 
         // Init call back data structure ----------------------------------------------

--- a/src/fdmdv2_main.h
+++ b/src/fdmdv2_main.h
@@ -47,6 +47,7 @@
 #include <wx/textdlg.h>
 #include <wx/regex.h>
 #include <wx/socket.h>
+#include <wx/string.h>
 
 #include <samplerate.h>
 
@@ -119,7 +120,12 @@ extern int                 g_soundCard2InDeviceNum;
 extern int                 g_soundCard2OutDeviceNum;
 extern int                 g_soundCard2SampleRate;
 
-// Voice Keyer Constants 
+extern std::string            g_soundCard1InDeviceName;
+extern std::string            g_soundCard1OutDeviceName;
+extern std::string            g_soundCard2InDeviceName;
+extern std::string            g_soundCard2OutDeviceName;
+
+// Voice Keyer Constants
 
 #define VK_SYNC_WAIT_TIME 5.0
 

--- a/src/fdmdv2_pa_wrapper.cpp
+++ b/src/fdmdv2_pa_wrapper.cpp
@@ -338,3 +338,55 @@ PaError PortAudioWrap::setCallback(PaStreamCallback *callback)
     return paNoError;
 }
 
+//----------------------------------------------------------------
+// isSoundCardNameValid()
+//----------------------------------------------------------------
+bool PortAudioWrap::isSoundCardNameValid(const wxString & soundCardName)
+{
+    // If getDeviceIndex returns anything but paNoDevice, then the name is a
+    // valid sound card name
+    return (getDeviceIndex(soundCardName) != paNoDevice);
+}
+
+//----------------------------------------------------------------
+// getDeviceIndex()
+//----------------------------------------------------------------
+PaDeviceIndex PortAudioWrap::getDeviceIndex(const wxString & soundCardName)
+{
+    PaDeviceIndex index = paNoDevice;
+    const PaDeviceInfo * deviceInfo;
+
+    int numDevices = Pa_GetDeviceCount();
+
+    for (int devNum = 0; devNum < numDevices; devNum++) {
+        deviceInfo = Pa_GetDeviceInfo(devNum);
+        if (deviceInfo == NULL) {
+            //printf("PortAudioWrap::getDeviceIndex, call to Pa_GetDeviceInfo(%d) failed!\n", devNum);
+            continue;
+        }
+        else if (wxString::FromAscii(deviceInfo->name) == soundCardName) {
+            index = (PaDeviceIndex)devNum;
+            break;
+        }
+    }
+
+    return index;
+}
+
+//----------------------------------------------------------------
+// getDeviceNameStr()
+//----------------------------------------------------------------
+wxString PortAudioWrap::getDeviceNameStr(PaDeviceIndex devNum)
+{
+    const PaDeviceInfo * deviceInfo;
+    wxString devName = wxT("");
+
+    deviceInfo = Pa_GetDeviceInfo(devNum);
+    if (deviceInfo == NULL) {
+        wxPrintf("PortAudioWrap::getDeviceNameStr, call to Pa_GetDeviceInfo(%d) failed!\n", devNum);
+    }
+    else
+        devName = wxString::FromAscii(deviceInfo->name);
+
+    return devName;
+}

--- a/src/fdmdv2_pa_wrapper.h
+++ b/src/fdmdv2_pa_wrapper.h
@@ -66,6 +66,9 @@ class PortAudioWrap
 
         PaError             setStreamFlags(PaStreamFlags flags);
         PaError             setCallback(PaStreamCallback *m_pStreamCallback);
+        static bool         isSoundCardNameValid(const wxString & soundCardName);
+        static PaDeviceIndex getDeviceIndex(const wxString & soundCardName);
+        static wxString     getDeviceNameStr(PaDeviceIndex devNum);
         PaError             setStreamCallback(PaStream *stream, PaStreamCallback* callback) { m_pStreamCallback = callback; return 0;}
         PaError             setStreamFinishedCallback(PaStream *stream, PaStreamFinishedCallback* m_pStreamFinishedCallback);
 


### PR DESCRIPTION
Windows often lists the same sound device under two names.  This PR removes duplicates from the list, and can also detect re-ordering of USB sound devices.

This was prototyped a few months ago and works great except for a compatibility issue with Virtual Audio Cable (VAC) software.  This PR seeks to resolve the remaining issues.