### PR TITLE
OSX Catalina build updates

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -6,7 +6,7 @@ For the following instructions, I'm assuming you will be placing everything in:
 1/ DEPENDENCIES
 Using Macports, most of the appropriate dependencies can be installed by:
 
-$ sudo port install subversion git libtool libsamplerate sox portaudio dylibbundler cmake
+$ sudo port install subversion git libtool libsamplerate sox portaudio cmake
 
 It should be fairly similar using HomeBrew, but you will need to replace all the /opt/ paths in the following instructions.
 

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -15,6 +15,7 @@ cd macdylibbundler && git checkout master && git pull
 make
 
 # Prerequisite: build hamlib
+cd $FREEDVGUIDIR
 git clone git://git.code.sf.net/p/hamlib/code hamlib-code
 cd hamlib-code && git checkout master && git pull
 ./bootstrap

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -10,7 +10,6 @@ export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 export HAMLIBDIR=$FREEDVGUIDIR/hamlib
 
 # Prerequisite: build hamlib
-cd $FREEDVGUIDIR
 git clone git://git.code.sf.net/p/hamlib/code hamlib-code
 cd hamlib-code && git checkout master && git pull
 ./bootstrap
@@ -20,7 +19,7 @@ make install
 
 # First build and install vanilla codec2 as we need -lcodec2 to build LPCNet
 cd $FREEDVGUIDIR
-git clone https://github.com/tmiw/codec2.git
+git clone https://github.com/drowe67/codec2.git
 cd codec2 && git checkout master && git pull
 mkdir -p build_osx && cd build_osx && rm -Rf * && cmake .. && make
 

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -10,6 +10,7 @@ export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 export HAMLIBDIR=$FREEDVGUIDIR/hamlib
 
 # Prerequisite: build hamlib
+cd $FREEDVGUIDIR
 git clone git://git.code.sf.net/p/hamlib/code hamlib-code
 cd hamlib-code && git checkout master && git pull
 ./bootstrap
@@ -19,7 +20,7 @@ make install
 
 # First build and install vanilla codec2 as we need -lcodec2 to build LPCNet
 cd $FREEDVGUIDIR
-git clone https://github.com/drowe67/codec2.git
+git clone https://github.com/tmiw/codec2.git
 cd codec2 && git checkout master && git pull
 mkdir -p build_osx && cd build_osx && rm -Rf * && cmake .. && make
 

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -9,6 +9,11 @@ export CODEC2DIR=$FREEDVGUIDIR/codec2
 export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 export HAMLIBDIR=$FREEDVGUIDIR/hamlib
 
+# Prerequisite: build dylibbundler
+git clone https://github.com/auriamg/macdylibbundler.git
+cd macdylibbundler && git checkout master && git pull
+make
+
 # Prerequisite: build hamlib
 git clone git://git.code.sf.net/p/hamlib/code hamlib-code
 cd hamlib-code && git checkout master && git pull

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ if(APPLE)
         COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @executable_path/../libs/
         COMMAND mkdir dist_tmp
         COMMAND cp -r FreeDV.app dist_tmp
-        COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO ./FreeDV.dmg
+        COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO -fs HFS+ ./FreeDV.dmg
         COMMAND rm -rf dist_tmp
     )
 endif(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ if(APPLE)
         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
         COMMAND echo ARGS -n "APPL????" > FreeDV.app/Contents/PkgInfo
         COMMAND cp ARGS freedv FreeDV.app/Contents/MacOS/FreeDV
-        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @executable_path/../libs/
+        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/
         COMMAND mkdir dist_tmp
         COMMAND cp -r FreeDV.app dist_tmp
         COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO -fs HFS+ ./FreeDV.dmg


### PR DESCRIPTION
Some updates to the build script to ensure that binaries built on OS X Catalina (10.15) can still be run on older versions:

1. Add building of dylibbundler to build_osx.sh script (newer version has updates to set rpath correctly) and update call to it in CMakeLists.txt.
2. Build DMG using older HFS+ file system (instead of APFS).