### PR TITLE
Issues causing FreeDV 1.4 release candidate to crash

### DIFF
--- a/docker/README_docker.md
+++ b/docker/README_docker.md
@@ -19,17 +19,23 @@ Building is only required once
 ```
 docker-compose -f docker-compose-win.yml build
 ```
+
 ## Running the image(s)
 ```
 docker-compose -f docker-compose-win.yml up 
 ```
 
-You can optionally control via the environment variables GIT_REPO and GIT_REF which branch/commit from which repo is being built. The if these are not defined default is the `master` branch  of (https://github.com/drowe67/freedv-gui.git) and does not have to be specified explicitly.
+You can optionally control via the environment variables FDV_GIT_REPO, FDV_GIT_BRANCH, FDV_CMAKE, FDV_CLEAN, for example:
 
+Build from freedv-gui branch =my-super-branch:
 ```bash
-export GIT_REF=my-super-branch
-export GIT_REPO=http://github.com/dummy/freedv-gui.git
-docker-compose -f docker-compose-win.yml up 
+FDV_GIT_BRANCH=my-super-branch docker-compose -f docker-compose-win.yml up 
+
+```
+
+Build a 32 bit image (default is 64 bit):
+```bash
+FDV_CMAKE=mingw32-cmake docker-compose -f docker-compose-win.yml up 
 
 ```
 ## Accessing created output

--- a/docker/fdv_win_fedora/entrypoint.sh
+++ b/docker/fdv_win_fedora/entrypoint.sh
@@ -7,7 +7,7 @@ cd $BUILDROOT
 # variables that can be passed in to Docker process ------------------
 
 # note this is just the freedv-gui repo, codec2 and LPCNet repos are hard coded in build_windows.sh
-GIT_REPO=${FDV_GIT_REPO:-http://github.com/drowe67/freedv-gui.git}
+GIT_REPO=${FDV_GIT_REPO:-https://github.com/drowe67/freedv-gui.git}
 GIT_BRANCH=${FDV_GIT_BRANCH:-master}
 
 # override with "mingw32-cmake" for a 32 bit build
@@ -20,8 +20,11 @@ echo "FDV_CMAKE=$CMAKE"
 
 # OK lets get started -----------------------------------------------
 
-if [ ! -d freedv-gui ] ; then git clone --depth=1 $GIT_REPO ; fi
-cd freedv-gui && git pull && git checkout $GIT_BRANCH
+if [ ! -d freedv-gui ] ; then git clone $GIT_REPO ; fi
+cd freedv-gui
+git pull -v
+git branch
+git checkout $GIT_BRANCH
 echo "--------------------- starting build_windows.sh ---------------------"
 GIT_REPO=$GIT_REPO GIT_REF=$GIT_REF CMAKE=$CMAKE ./build_windows.sh
 if [ $CMAKE = "mingw64-cmake" ]; then

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -4094,8 +4094,6 @@ void txRxProcessing()
                 fprintf(stderr, "  nout: %d\n", nout);
             }
             ret = codec2_fifo_write(cbData->outfifo1, outsound_card, nout);
-            // should never fire as we check there is enough room before entering while loop
-            assert(ret != -1);
         }
     }
    


### PR DESCRIPTION
Some issues causing freedv-gui to crash, that were found by the UK team.  Anything that causes crashes should be fixed for the FreeDV 1.4 release:

1. assert() that is firing on Windows machines, was pretty benign, just testing an assumption about a FIFO having space that can tracked down later.
1. When USB sound devices are changes, and Start is pressed without re running Tools/Audio Config, freedv-gui crashes.  OK have reproduced this one on Linux, but no quick fix, so have posted as Issue https://github.com/drowe67/freedv-gui/issues/35
