### PR TITLE
Prompt the user to grant permission to FreeDV for microphone access

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,24 @@ set(FREEDV_SOURCES
     sox/xmalloc.c
     topFrame.h
     version.h
+    osx_interface.h
+)
+
+set(FREEDV_SOURCES_OSX
+    osx_interface.mm
+)
+
+set(FREEDV_LINK_LIBS_OSX
+    "-framework AVFoundation"
 )
 
 # WIN32 is needed for Windows GUI apps and is ignored for UNIX like systems.
-add_executable(freedv WIN32 ${FREEDV_SOURCES} ${RES_FILES})
+# In addition, there are some required OSX-specific code files for platform specific handling.
+if(APPLE)
+    add_executable(freedv WIN32 ${FREEDV_SOURCES} ${RES_FILES} ${FREEDV_SOURCES_OSX})
+else()
+    add_executable(freedv WIN32 ${FREEDV_SOURCES} ${RES_FILES})
+endif(APPLE)
 
 # Link imported or build tree targets.
 target_link_libraries(freedv codec2 lpcnetfreedv)
@@ -66,7 +80,11 @@ if(FREEDV_STATIC_DEPS)
 endif(FREEDV_STATIC_DEPS)
 
 # Link other dependencies
+if(APPLE)
+target_link_libraries(freedv ${FREEDV_LINK_LIBS} ${FREEDV_LINK_LIBS_OSX})
+else()
 target_link_libraries(freedv ${FREEDV_LINK_LIBS})
+endif(APPLE)
 
 # Insert source and generated header directories before other search directories.
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -21,6 +21,7 @@
 //==========================================================================
 
 #include "fdmdv2_main.h"
+#include "osx_interface.h"
 
 #define wxUSE_FILEDLG   1
 #define wxUSE_LIBPNG    1
@@ -2828,8 +2829,14 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         }
 
         // attempt to start sound cards and tx/rx processing
-
-        startRxStream();
+        if (VerifyMicrophonePermissions())
+        {
+            startRxStream();
+        }
+        else
+        {
+            wxMessageBox(wxString("Microphone permissions must be granted to FreeDV for it to function properly."), wxT("Error"), wxOK | wxICON_ERROR, this);
+        }
 
         if (m_RxRunning)
         {

--- a/src/info.plist
+++ b/src/info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Required to transmit your voice to the other party.</string>
 	<key>CFBundleExecutable</key>
 	<string>freedv</string>
 	<key>CFBundleIconFile</key>
@@ -40,6 +42,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Required to transmit your voice to the other party.</string>
 	<key>CFBundleExecutable</key>
 	<string>freedv</string>
 	<key>CFBundleIconFile</key>
@@ -74,6 +78,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Required to transmit your voice to the other party.</string>
 	<key>CFBundleExecutable</key>
 	<string>freedv</string>
 	<key>CFBundleIconFile</key>

--- a/src/osx_interface.h
+++ b/src/osx_interface.h
@@ -1,0 +1,35 @@
+//==========================================================================
+// Name:            osx_interface.h
+//
+// Purpose:         Provides C wrapper to needed Objective-C calls.
+// Created:         Nov. 23, 2019
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+#ifndef __OSX_INTERFACE__
+#define __OSX_INTERFACE__
+
+// Checks whether FreeDV has permissions to access the microphone on OSX Catalina
+// and above. If the user doesn't grant permissions (returns FALSE), the GUI 
+// should be able to properly handle the situation.
+#ifdef __APPLE__
+extern "C" bool VerifyMicrophonePermissions();
+#else
+// Stub for non-Apple platforms
+extern "C" bool VerifyMicrophonePermissions() { return true; }
+#endif // __APPLE__
+
+#endif // __OSX_INTERFACE__

--- a/src/osx_interface.mm
+++ b/src/osx_interface.mm
@@ -1,0 +1,79 @@
+//==========================================================================
+// Name:            osx_interface.mm
+//
+// Purpose:         Provides C wrapper to needed Objective-C calls.
+// Created:         Nov. 23, 2019
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#import <AVFoundation/AVFoundation.h>
+#include <mutex>
+#include <condition_variable>
+#include "osx_interface.h"
+
+static std::mutex osx_permissions_mutex;
+static std::condition_variable osx_permissions_condvar;
+static bool globalHasAccess = false;
+
+bool VerifyMicrophonePermissions()
+{
+    bool hasAccess = true;
+    if (@available(macOS 10.14, *)) {
+        // OSX >= 10.14: Request permission to access the camera and microphone.
+        switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio])
+        {
+            case AVAuthorizationStatusAuthorized:
+            {
+                // The user has previously granted access to the camera.
+                break;
+            }
+            case AVAuthorizationStatusNotDetermined:
+            {
+                // The app hasn't yet asked the user for camera access.
+                // Note that this call is asynchronous but we need to wait for a response before
+                // proceeding. TBD for improvement.
+                [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
+                    std::unique_lock<std::mutex> lk(osx_permissions_mutex);
+                    globalHasAccess = granted;
+                    osx_permissions_condvar.notify_one();
+                }];
+
+                {
+                    std::unique_lock<std::mutex> lk(osx_permissions_mutex);
+                    osx_permissions_condvar.wait(lk);
+                    hasAccess = globalHasAccess;
+                }
+                break;
+            }
+            case AVAuthorizationStatusDenied:
+            case AVAuthorizationStatusRestricted:
+            {
+                // The user has previously denied access or otherwise can't grant permissions.
+                hasAccess = false;
+                break;
+            }
+            default:
+            {
+                // Other result not previously handled.
+                assert(0);
+            }
+        }
+    }
+
+    return hasAccess;
+}
+


### PR DESCRIPTION
Adds OSX-specific code and build logic to enable the Apple-mandated permissions prompt for microphone access. Otherwise, PortAudio can't open the microphone and thus FreeDV will be unable to function.