### PR TITLE
Added sideband detection to FreeDV's Hamlib support.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -178,7 +178,9 @@ unplugged/plugged.
 
 ### USB or LSB?
 
-On bands beneath 10 MHz, LSB is used for FreeDV.  On 10MHz and above, USB is used. After much debate, the FreeDV community has adopted the same conventions as SSB, based on the reasoning that FreeDV is a voice mode.  
+On bands beneath 10 MHz, LSB is used for FreeDV.  On 10MHz and above, USB is used. After much debate, the FreeDV community has adopted the same conventions as SSB, based on the reasoning that FreeDV is a voice mode. 
+
+As an aid to the above, FreeDV will show the current mode on the bottom of the window upon pressing the Start button if Hamlib is enabled and your radio supports retrieving frequency and mode information over CAT. If your radio is using an unexpected mode (e.g. LSB on 20 meters), it will display that mode on the bottom of the window next to the Clear button in red letters. When a session is not active, Hamlib isn't enabled or if your radio doesn't support retrieving frequency and mode over CAT, it will remain grayed out with "unk" displaying instead of the mode (for "unknown").
 
 ## Common Problems
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ if(APPLE)
     add_custom_command(
         TARGET freedv
         POST_BUILD
+        COMMAND rm -rf FreeDV.* dist_tmp
         COMMAND mkdir ARGS -p FreeDV.app/Contents/MacOS
         COMMAND mkdir ARGS -p FreeDV.app/Contents/Resources/English.lproj
         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/info.plist FreeDV.app/Contents

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ if(APPLE)
     add_custom_command(
         TARGET freedv
         POST_BUILD
-        COMMAND rm -rf FreeDV.* dist_tmp
+        COMMAND rm ARGS -rf FreeDV.* dist_tmp
         COMMAND mkdir ARGS -p FreeDV.app/Contents/MacOS
         COMMAND mkdir ARGS -p FreeDV.app/Contents/Resources/English.lproj
         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/info.plist FreeDV.app/Contents

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2825,14 +2825,6 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         //printf("m_textEncoding = %d\n", wxGetApp().m_textEncoding);
         //printf("g_stats.snr: %f\n", g_stats.snr_est);
 
-        // attempt to start PTT ......
-        
-        if (wxGetApp().m_boolHamlibUseForPTT)
-            OpenHamlibRig();
-        if (wxGetApp().m_boolUseSerialPTT) {
-            OpenSerialPort();
-        }
-
         // attempt to start sound cards and tx/rx processing
         if (VerifyMicrophonePermissions())
         {
@@ -2841,6 +2833,14 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         else
         {
             wxMessageBox(wxString("Microphone permissions must be granted to FreeDV for it to function properly."), wxT("Error"), wxOK | wxICON_ERROR, this);
+        }
+
+        // attempt to start PTT ......
+        
+        if (wxGetApp().m_boolHamlibUseForPTT)
+            OpenHamlibRig();
+        if (wxGetApp().m_boolUseSerialPTT) {
+            OpenSerialPort();
         }
 
         if (m_RxRunning)

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -734,6 +734,7 @@ MainFrame::~MainFrame()
 
     if (wxGetApp().m_hamlib)
     {
+        wxGetApp().m_hamlib->disable_sideband_detection();
         wxGetApp().m_hamlib->close();
         delete wxGetApp().m_hamlib;
     }
@@ -2614,14 +2615,7 @@ bool MainFrame::OpenHamlibRig() {
         wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
     else
     {
-        // Validate current sideband configuration of radio. FreeDV by convention uses the same sidebands
-        // as SSB voice.
-        wxString error;
-        status = wxGetApp().m_hamlib->is_correct_sideband(error);
-        if (!status)
-        {
-            wxMessageBox(error, wxT("Warning"), wxOK | wxICON_WARNING, this);
-        }
+        wxGetApp().m_hamlib->enable_sideband_detection(m_BtnSSBStatus);
     }
 
     return status;
@@ -2885,6 +2879,7 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
                 if (hamlib->ptt(false, hamlibError) == false) {
                     wxMessageBox(wxString("Hamlib PTT Error: ") + hamlibError, wxT("Error"), wxOK | wxICON_ERROR, this);
                 }
+                hamlib->disable_sideband_detection();
                 hamlib->close();
             }
         }

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -282,13 +282,6 @@ bool MainApp::OnInit()
 //-------------------------------------------------------------------------
 int MainApp::OnExit()
 {
-    // Note: sideband detection needs to be disabled here instead
-    // of in the destructor due to its need to touch the UI.
-    if (wxGetApp().m_hamlib)
-    {
-        wxGetApp().m_hamlib->disable_sideband_detection();
-    }
-
     //fprintf(stderr, "MainApp::OnExit\n");
     if (m_plugIn) {
         #ifdef __WXMSW__
@@ -2432,6 +2425,13 @@ void MainFrame::OnRecFileFromModulator(wxCommandEvent& event)
 //-------------------------------------------------------------------------
 void MainFrame::OnExit(wxCommandEvent& event)
 {
+    // Note: sideband detection needs to be disabled here instead
+    // of in the destructor due to its need to touch the UI.
+    if (wxGetApp().m_hamlib)
+    {
+        wxGetApp().m_hamlib->disable_sideband_detection();
+    }
+
     //fprintf(stderr, "MainFrame::OnExit\n");
     wxUnusedVar(event);
 #ifdef _USE_TIMER

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2612,7 +2612,18 @@ bool MainFrame::OpenHamlibRig() {
     bool status = wxGetApp().m_hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate);
     if (status == false)
         wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
- 
+    else
+    {
+        // Validate current sideband configuration of radio. FreeDV by convention uses the same sidebands
+        // as SSB voice.
+        wxString error;
+        status = wxGetApp().m_hamlib->is_correct_sideband(error);
+        if (!status)
+        {
+            wxMessageBox(error, wxT("Warning"), wxOK | wxICON_WARNING, this);
+        }
+    }
+
     return status;
 } 
 

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2616,7 +2616,7 @@ bool MainFrame::OpenHamlibRig() {
         wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
     else
     {
-        wxGetApp().m_hamlib->enable_sideband_detection(m_BtnSSBStatus);
+        wxGetApp().m_hamlib->enable_sideband_detection(m_txtSSBStatus);
     }
 
     return status;

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -282,6 +282,13 @@ bool MainApp::OnInit()
 //-------------------------------------------------------------------------
 int MainApp::OnExit()
 {
+    // Note: sideband detection needs to be disabled here instead
+    // of in the destructor due to its need to touch the UI.
+    if (wxGetApp().m_hamlib)
+    {
+        wxGetApp().m_hamlib->disable_sideband_detection();
+    }
+
     //fprintf(stderr, "MainApp::OnExit\n");
     if (m_plugIn) {
         #ifdef __WXMSW__
@@ -731,13 +738,6 @@ MainFrame::~MainFrame()
 #ifdef __EXPERIMENTAL_UDP__
     stopUDPThread();
 #endif
-
-    if (wxGetApp().m_hamlib)
-    {
-        wxGetApp().m_hamlib->disable_sideband_detection();
-        wxGetApp().m_hamlib->close();
-        delete wxGetApp().m_hamlib;
-    }
 
     if (wxGetApp().m_serialport)
     {
@@ -2457,6 +2457,7 @@ void MainFrame::OnExit(wxCommandEvent& event)
     m_togBtnAnalog->Disable();
     //m_togBtnALC->Disable();
     //m_btnTogPTT->Disable();
+
     Pa_Terminate();
     Destroy();
 }

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -223,7 +223,7 @@ void Hamlib::disable_sideband_detection()
     rig_set_mode_callback(m_rig, NULL, NULL);
 
     // Disable control.
-    m_sidebandBox->Enable(false);
+    if (m_sidebandBox != NULL) m_sidebandBox->Enable(false);
 }
 
 void Hamlib::update_sideband_status()

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -31,7 +31,11 @@ typedef std::vector<const struct rig_caps *> riglist_t;
 static bool rig_cmp(const struct rig_caps *rig1, const struct rig_caps *rig2);
 static int build_list(const struct rig_caps *rig, rig_ptr_t);
 
-Hamlib::Hamlib() : m_rig(NULL) {
+Hamlib::Hamlib() : 
+    m_rig(NULL),
+    m_sidebandBox(NULL),
+    m_currFreq(0),
+    m_currMode(0)  {
     /* Stop hamlib from spewing info to stderr. */
     rig_set_debug(RIG_DEBUG_NONE);
 

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -213,18 +213,28 @@ void Hamlib::enable_sideband_detection(wxStaticText* statusBox)
         }
     }
 
+    // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
+    // disabled. When/if that changes, re-enabling is a simple matter of removing
+    // the #if/#endif below.
+#if 0
     // Enable rig callbacks.
     rig_set_freq_callback(m_rig, &hamlib_freq_cb, this);
     rig_set_mode_callback(m_rig, &hamlib_mode_cb, this);
     rig_set_trn(m_rig, RIG_TRN_POLL);
+#endif
 }
 
 void Hamlib::disable_sideband_detection()
 {
+    // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
+    // disabled. When/if that changes, re-enabling is a simple matter of removing
+    // the #if/#endif below.
+#if 0
     // Disable callbacks.
     rig_set_trn(m_rig, RIG_TRN_OFF);
     rig_set_freq_callback(m_rig, NULL, NULL);
     rig_set_mode_callback(m_rig, NULL, NULL);
+#endif
 
     // Disable control.
     if (m_sidebandBox != NULL) 

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -227,7 +227,11 @@ void Hamlib::disable_sideband_detection()
     rig_set_mode_callback(m_rig, NULL, NULL);
 
     // Disable control.
-    if (m_sidebandBox != NULL) m_sidebandBox->Enable(false);
+    if (m_sidebandBox != NULL) 
+    {
+        m_sidebandBox = NULL;
+        m_sidebandBox->Enable(false);
+    }
 }
 
 void Hamlib::update_sideband_status()

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -229,8 +229,8 @@ void Hamlib::disable_sideband_detection()
     // Disable control.
     if (m_sidebandBox != NULL) 
     {
-        m_sidebandBox = NULL;
         m_sidebandBox->Enable(false);
+        m_sidebandBox = NULL;
     }
 }
 

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -213,32 +213,43 @@ void Hamlib::enable_sideband_detection(wxStaticText* statusBox)
         }
     }
 
-    // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
-    // disabled. When/if that changes, re-enabling is a simple matter of removing
-    // the #if/#endif below.
+    // If we couldn't get current mode/frequency for any reason, disable the UI for it.
+    if (result != RIG_OK)
+    {
+        m_sidebandBox->SetLabel(wxT("unk"));
+        m_sidebandBox->Enable(false);
+        m_sidebandBox = NULL;
+    }
+    else
+    {
+        // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
+        // disabled. When/if that changes, re-enabling is a simple matter of removing
+        // the #if/#endif below.
 #if 0
-    // Enable rig callbacks.
-    rig_set_freq_callback(m_rig, &hamlib_freq_cb, this);
-    rig_set_mode_callback(m_rig, &hamlib_mode_cb, this);
-    rig_set_trn(m_rig, RIG_TRN_POLL);
+        // Enable rig callbacks.
+        rig_set_freq_callback(m_rig, &hamlib_freq_cb, this);
+        rig_set_mode_callback(m_rig, &hamlib_mode_cb, this);
+        rig_set_trn(m_rig, RIG_TRN_POLL);
 #endif
+    }
 }
 
 void Hamlib::disable_sideband_detection()
 {
-    // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
-    // disabled. When/if that changes, re-enabling is a simple matter of removing
-    // the #if/#endif below.
-#if 0
-    // Disable callbacks.
-    rig_set_trn(m_rig, RIG_TRN_OFF);
-    rig_set_freq_callback(m_rig, NULL, NULL);
-    rig_set_mode_callback(m_rig, NULL, NULL);
-#endif
-
-    // Disable control.
     if (m_sidebandBox != NULL) 
     {
+        // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
+        // disabled. When/if that changes, re-enabling is a simple matter of removing
+        // the #if/#endif below.
+#if 0
+        // Disable callbacks.
+        rig_set_trn(m_rig, RIG_TRN_OFF);
+        rig_set_freq_callback(m_rig, NULL, NULL);
+        rig_set_mode_callback(m_rig, NULL, NULL);
+#endif
+    
+        // Disable control.
+        m_sidebandBox->SetLabel(wxT("unk"));
         m_sidebandBox->Enable(false);
         m_sidebandBox = NULL;
     }

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -233,6 +233,8 @@ void Hamlib::update_sideband_status()
         m_sidebandBox->SetLabel(wxT("USB"));
     else if (m_currMode == RIG_MODE_LSB || m_currMode == RIG_MODE_PKTLSB)
         m_sidebandBox->SetLabel(wxT("LSB"));
+    else
+        m_sidebandBox->SetLabel(rig_strrmode(m_currMode));
 
     // Update color
     bool isMatchingSideband = 

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -174,7 +174,7 @@ bool Hamlib::is_correct_sideband(wxString &hamlibError) {
 
     rmode_t mode = RIG_MODE_NONE;
     pbwidth_t passband = 0;
-    auto result = rig_get_mode(m_rig, RIG_VFO_CURR, &mode, &passband);
+    int result = rig_get_mode(m_rig, RIG_VFO_CURR, &mode, &passband);
     if (result != RIG_OK)
     {
         fprintf(stderr, "rig_get_mode: error = %s \n", rigerror(result));

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -35,7 +35,7 @@ Hamlib::Hamlib() :
     m_rig(NULL),
     m_sidebandBox(NULL),
     m_currFreq(0),
-    m_currMode(0)  {
+    m_currMode(RIG_MODE_USB)  {
     /* Stop hamlib from spewing info to stderr. */
     rig_set_debug(RIG_DEBUG_NONE);
 

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -5,6 +5,7 @@ extern "C" {
 #include <hamlib/rig.h>
 }
 #include <wx/combobox.h>
+#include <wx/stattext.h>
 #include <vector>
 
 class Hamlib {
@@ -15,7 +16,8 @@ class Hamlib {
         void populateComboBox(wxComboBox *cb);
         bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate);
         bool ptt(bool press, wxString &hamlibError);
-        bool is_correct_sideband(wxString &hamlibError);
+        void enable_sideband_detection(wxStaticText* statusBox);
+        void disable_sideband_detection();
         void close(void);
         int get_serial_rate(void);
         int get_data_bits(void);
@@ -24,9 +26,19 @@ class Hamlib {
         typedef std::vector<const struct rig_caps *> riglist_t;
 
     private:
+        static int hamlib_freq_cb(RIG* rig, vfo_t currVFO, freq_t currFreq, void* ptr);
+        static int hamlib_mode_cb(RIG* rig, vfo_t currVFO, rmode_t currMode, pbwidth_t passband, void* ptr);
+
+        void update_sideband_status();
+
         RIG *m_rig;
         /* Sorted list of rigs. */
         riglist_t m_rigList;
+
+        /* Sideband detection status box and state. */
+        wxStaticText* m_sidebandBox;
+        freq_t m_currFreq;
+        rmode_t m_currMode;
 };
 
 #endif /*HAMLIB_H*/

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -15,6 +15,7 @@ class Hamlib {
         void populateComboBox(wxComboBox *cb);
         bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate);
         bool ptt(bool press, wxString &hamlibError);
+        bool is_correct_sideband(wxString &hamlibError);
         void close(void);
         int get_serial_rate(void);
         int get_data_bits(void);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -238,10 +238,10 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
 
     wxBoxSizer* ssbStatusSizer;
     ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
-    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
-    m_BtnSSBStatus->Enable(false); // enabled only if Hamlib is turned on
-    m_BtnSSBStatus->SetMinSize(wxSize(40,-1));
-    ssbStatusSizer->Add(m_BtnSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
+    m_txtSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_txtSSBStatus->Enable(false); // enabled only if Hamlib is turned on
+    m_txtSSBStatus->SetMinSize(wxSize(40,-1));
+    ssbStatusSizer->Add(m_txtSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
     lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 1);
 
     m_BtnCallSignReset = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxDefaultSize, 0);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -238,10 +238,11 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
 
     wxBoxSizer* ssbStatusSizer;
     ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
-    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxSize(60, -1), wxALIGN_CENTRE);
+    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
     m_BtnSSBStatus->Enable(false); // enabled only if Hamlib is turned on
+    m_BtnSSBStatus->SetMinSize(wxSize(40,-1));
     ssbStatusSizer->Add(m_BtnSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
-    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL, 1);
+    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 1);
 
     m_BtnCallSignReset = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxDefaultSize, 0);
     lowerSizer->Add(m_BtnCallSignReset, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 1);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -236,6 +236,13 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     wxBoxSizer* lowerSizer;
     lowerSizer = new wxBoxSizer(wxHORIZONTAL);
 
+    wxBoxSizer* ssbStatusSizer;
+    ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
+    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxSize(60, -1), wxALIGN_CENTRE);
+    m_BtnSSBStatus->Enable(false); // enabled only if Hamlib is turned on
+    ssbStatusSizer->Add(m_BtnSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
+    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL, 1);
+
     m_BtnCallSignReset = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxDefaultSize, 0);
     lowerSizer->Add(m_BtnCallSignReset, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 1);
 
@@ -245,13 +252,6 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     m_txtCtrlCallSign->SetToolTip(_("Call Sign of transmitting station will appear here"));
     bSizer15->Add(m_txtCtrlCallSign, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
     lowerSizer->Add(bSizer15, 1, wxEXPAND, 5);
-
-    wxBoxSizer* ssbStatusSizer;
-    ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
-    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxSize(60, -1), wxALIGN_CENTRE);
-    m_BtnSSBStatus->Enable(false); // enabled only if Hamlib is turned on
-    ssbStatusSizer->Add(m_BtnSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
-    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL, 1);
 
 #ifdef __EXPERIMENTAL_UDP__
     wxStaticBoxSizer* sbSizer_Checksum = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Checksums")), wxHORIZONTAL);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -238,7 +238,7 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
 
     wxBoxSizer* ssbStatusSizer;
     ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
-    m_txtSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_txtSSBStatus = new wxStaticText(this, wxID_ANY, wxT("unk"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
     m_txtSSBStatus->Enable(false); // enabled only if Hamlib is turned on
     m_txtSSBStatus->SetMinSize(wxSize(40,-1));
     ssbStatusSizer->Add(m_txtSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -246,6 +246,13 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     bSizer15->Add(m_txtCtrlCallSign, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 5);
     lowerSizer->Add(bSizer15, 1, wxEXPAND, 5);
 
+    wxBoxSizer* ssbStatusSizer;
+    ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
+    m_BtnSSBStatus = new wxStaticText(this, wxID_ANY, wxT("USB"), wxDefaultPosition, wxSize(60, -1), wxALIGN_CENTRE);
+    m_BtnSSBStatus->Enable(false); // enabled only if Hamlib is turned on
+    ssbStatusSizer->Add(m_BtnSSBStatus, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL|wxEXPAND, 1);
+    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL, 1);
+
 #ifdef __EXPERIMENTAL_UDP__
     wxStaticBoxSizer* sbSizer_Checksum = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Checksums")), wxHORIZONTAL);
 

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -90,6 +90,7 @@ class TopFrame : public wxFrame
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;
+        wxStaticText* m_BtnSSBStatus;
         wxStaticText* m_txtChecksumGood;
         wxStaticText* m_txtChecksumBad;
 

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -90,7 +90,7 @@ class TopFrame : public wxFrame
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;
-        wxStaticText* m_BtnSSBStatus;
+        wxStaticText* m_txtSSBStatus;
         wxStaticText* m_txtChecksumGood;
         wxStaticText* m_txtChecksumBad;
 


### PR DESCRIPTION
Per agreed convention, FreeDV uses LSB for bands under 10MHz and USB for bands above it. This differs from the usual "data mode" convention of USB regardless of band, This commit adds the ability for FreeDV to detect the sideband currently being used by the radio and emit a warning dialog if it differs from the expected convention.

Limitations:

1. Hamlib support must be enabled in FreeDV's settings.
2. Detection is only done when the user pushes Start. If the sideband changes during the session, FreeDV will not detect the change.
3. FreeDV/Codec2 will not attempt to mitigate incorrect sideband settings during the decode process.

## Test Plan
David, 21 Feb 2020
| Test | Description | OS | Radio | Who | Status |
| --- | --- |  --- | --- | --- | --- |
| 1 | Detects USB/LSB From Hamlib enabled radio | OSX | KX3 | Mooneer | **Pass** |
| 2 | Detects USB/LSB From Hamlib enabled radio  | Ubuntu 18  | IC-7200 | David | **Pass** |
| 3 | Detects USB/LSB From Hamlib enabled radio  | Windows 32 or 64  | Flex/IC-7000  | K5WH VK5APR  | **Pass**  |
| 4 | Hamlib PTT still works  | Any  | KX3 | Mooneer  | **Pass** |
| 5 | Serial PTT still works  | Any  | IC-7000  | Peter, VK5APR  | **Pass**  |

