### PR TITLE
Resolve compile error on older Xcode due to the use of @available.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,13 @@ else()
 target_link_libraries(freedv ${FREEDV_LINK_LIBS})
 endif(APPLE)
 
+# For older Xcode (< 9.0), bypass usage of @available.
+if(APPLE)
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0.0.900037)
+add_definitions(-DAPPLE_OLD_XCODE)
+endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0.0.900037)
+endif(APPLE)
+
 # Insert source and generated header directories before other search directories.
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/osx_interface.mm
+++ b/src/osx_interface.mm
@@ -32,6 +32,7 @@ static bool globalHasAccess = false;
 bool VerifyMicrophonePermissions()
 {
     bool hasAccess = true;
+#ifndef APPLE_OLD_XCODE
     if (@available(macOS 10.14, *)) {
         // OSX >= 10.14: Request permission to access the camera and microphone.
         switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio])
@@ -73,6 +74,7 @@ bool VerifyMicrophonePermissions()
             }
         }
     }
+#endif // !APPLE_OLD_XCODE
 
     return hasAccess;
 }


### PR DESCRIPTION
Turns out that the previous PR I submitted to allow for FreeDV to continue working correctly on Catalina broke building it with anything older than Xcode 9. This PR should fix the issue but I'm waiting for @darksidelemm's feedback to confirm. 