### PR TITLE
Add minimum size for SNR text field to avoid it being chopped off in OSX and possibly other platforms.

### DIFF
--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -133,6 +133,7 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     // Box for S/N ratio (Numeric)
     //------------------------------
     m_textSNR = new wxStaticText(this, wxID_ANY, wxT(" 0.0"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
+    m_textSNR->SetMinSize(wxSize(40,-1));
     snrSizer->Add(m_textSNR, 0, wxALIGN_CENTER_HORIZONTAL, 1);
 
     //------------------------------


### PR DESCRIPTION
@drowe67, found some weirdness with the SNR text field on OSX while testing 1.4.1. As the title states, I added a minimum size to that field to avoid the text being chopped off if the SNR is two digits or greater.

(Note: I think this has been around for a bit. I don't think this is related to the 1.4.1 changes.)