### PR TITLE
Revert disabling of horus features, use horus_open_advanced

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -9,7 +9,7 @@ export CODEC2DIR=$FREEDVGUIDIR/codec2
 export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 
 # change this when working on combined codec2/freedv-gui changes
-CODEC2_BRANCH=master
+CODEC2_BRANCH=horus_api_fixes
 
 # First build and install vanilla codec2 as we need -lcodec2 to build LPCNet
 cd $FREEDVGUIDIR

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -4160,16 +4160,9 @@ void per_frame_rx_processing(
                 codec2_fifo_write(g_rxDataOutFifo, &ch, 1);
 
                 UDPSend(wxGetApp().m_udp_port, ascii_out, strlen(ascii_out));
-                horus_get_modem_extended_stats(g_horus, &g_stats);
-                if (g_freedv_verbose) {
-                    fprintf(stderr, "  fsk f_est: ");
-                    for(i=0; i<horus_get_mFSK(g_horus); i++) {
-                        fprintf(stderr, "%5.0f ", g_stats.f_est[i]);
-                    }
-                    fprintf(stderr, "\n");
-                }
             }
 
+            // Update modem stats even if we haven't got a packet, so the SNR display updates.
             horus_get_modem_extended_stats(g_horus, &g_stats);
             if (g_freedv_verbose) {
                 fprintf(stderr, "  fsk f_est: ");

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2689,7 +2689,7 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
             g_mode = -1;  /* TODO; a better way of handling (enumerating?) non-freedv modes */
 
             // Use advanced horus_open function, as we may be allowing some user-configurability here at some point.
-            g_horus = horus_open_advanced(HORUS_MODE_BINARY, HORUS_BINARY_DEFAULT_BAUD, HORUS_BINARY_DEFAULT_TONE_SPACING);
+            g_horus = horus_open_advanced(HORUS_MODE_BINARY_V1, HORUS_BINARY_V1_DEFAULT_BAUD, -1);
             horus_set_verbose(g_horus, g_freedv_verbose);
             
             /* init a sample rate converted for monitoring modem signal */

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -361,10 +361,8 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     sbSizer_mode->Add(m_rb1600, 0, wxALIGN_LEFT|wxALL, 1);
     m_rb2400b = new wxRadioButton( this, wxID_ANY, wxT("2400B"), wxDefaultPosition, wxDefaultSize, 0);
     sbSizer_mode->Add(m_rb2400b, 0, wxALIGN_LEFT|wxALL, 1);
-#ifdef __HORUS__
     m_rbHorusBinary = new wxRadioButton( this, wxID_ANY, wxT("HorusB"), wxDefaultPosition, wxDefaultSize, 0);
     sbSizer_mode->Add(m_rbHorusBinary, 0, wxALIGN_LEFT|wxALL, 1);
-#endif
     m_rb2020 = new wxRadioButton( this, wxID_ANY, wxT("2020"), wxDefaultPosition, wxDefaultSize,  0);
     sbSizer_mode->Add(m_rb2020, 0, wxALIGN_LEFT|wxALL, 1);
 

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -119,9 +119,7 @@ class TopFrame : public wxFrame
         wxRadioButton *m_rb1600;
         wxRadioButton *m_rb2400a;
         wxRadioButton *m_rb2400b;
-#ifdef __HORUS__
         wxRadioButton *m_rbHorusBinary;
-#endif
         wxRadioButton *m_rb2020;
         wxRadioButton *m_rbPlugIn;
 


### PR DESCRIPTION
I've also made the modem stats (e.g. SNR display) update on every frame of samples, not just on every received packet, for a more fluid SNR display.