### PR TITLE
Use freedv_tx() instead of freedv_comptx() for 2400B.

### DIFF
--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -4097,7 +4097,7 @@ void txRxProcessing()
                 COMP tx_fdm_offset[nfreedv];
                 int  i;
 
-                if (g_mode == FREEDV_MODE_800XA) {
+                if (g_mode == FREEDV_MODE_800XA || g_mode == FREEDV_MODE_2400B) {
                     /* 800XA doesn't support complex output just yet */
                     freedv_tx(g_pfreedv, outfreedv, infreedv);
                 }


### PR DESCRIPTION
Walter (K5WH) noticed that TX using 2400B stopped working at some point. From what I could tell, TX was fine when Analog was enabled but not using DV (and the current Codec2 UT for 2400B still seem to pass as well). I did notice in the Codec2 UT that it always uses freedv_tx() instead of freedv_comptx() inside the freedv_tx UT utility; when I did the change in this PR, I seemed to be hearing modulated data being transmitted as soon as I pushed TX (vs. no audio as before). Additionally, a second machine/radio seemed to decode the audio being transmitted with no problems.

Anyway, @drowe67, I'm not sure this is the correct way to fix it. Should 2400B actually be using freedv_comptx()? I admittedly don't know much about the lower level Codec2 stuff so it's possible I'm totally missing something.