### PR TITLE
Add support for changing CI-V address for Icom radios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ if(WXRC)
 endif(WXRC)
 set(WX_VERSION_MIN 3.0.0)
 set(WX_31_VERSION_MIN 3.1.3)
-find_package(wxWidgets REQUIRED core base aui html net adv)
+find_package(wxWidgets REQUIRED core base aui html net adv propgrid)
 execute_process(COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --version
     OUTPUT_VARIABLE WX_VERSION)
 string(STRIP ${WX_VERSION} WX_VERSION)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -168,6 +168,12 @@ Hamlib comes with a default serial rate for each radio.  If your radio
 has a different serial rate change the Serial Rate drop down box to
 match your radio.
 
+If using an Icom radio, Hamlib will use the radio's default CI-V address
+when connecting. If this has been changed, you can specify the correct
+address in the "Radio Address" field (valid values are 00 through FF
+in hexadecimal). Note that "00" is the "wildcard" CI-V address and will 
+also work if there are no other Icom/CI-V capable devices in the chain.
+
 When **Test** is pressed, the "Serial Params" field is populated and
 displayed.  This will help track down any mismatches between Hamlib
 and your radio.

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -82,7 +82,8 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     gridSizerhl->Add(m_cbSerialPort, 0, wxALIGN_CENTER_VERTICAL, 0);
 
     /* Hamlib Icom CI-V address text box. */
-    gridSizerhl->Add(new wxStaticText(this, wxID_ANY, _("Radio Address:"), wxDefaultPosition, wxDefaultSize, 0), 
+    m_stIcomCIVHex = new wxStaticText(this, wxID_ANY, _("Radio Address:"), wxDefaultPosition, wxDefaultSize, 0);
+    gridSizerhl->Add(m_stIcomCIVHex, 
                       0, wxALIGN_CENTER_VERTICAL |  wxALIGN_RIGHT, 20);
     m_pvIcomCIVHex = new wxNumericPropertyValidator(wxNumericPropertyValidator::Unsigned, 16);
     m_tcIcomCIVHex = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(35, -1), 0, *m_pvIcomCIVHex);
@@ -201,6 +202,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     this->Connect(wxEVT_INIT_DIALOG, wxInitDialogEventHandler(ComPortsDlg::OnInitDialog), NULL, this);
     m_ckUseHamlibPTT->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(ComPortsDlg::PTTUseHamLibClicked), NULL, this);
     m_ckUseSerialPTT->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(ComPortsDlg::PTTUseSerialClicked), NULL, this);
+    m_cbRigName->Connect(wxEVT_COMBOBOX, wxCommandEventHandler(ComPortsDlg::HamlibRigNameChanged), NULL, this);
     m_buttonOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnOK), NULL, this);
     m_buttonCancel->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnCancel), NULL, this);
     m_buttonApply->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnApply), NULL, this);
@@ -216,6 +218,7 @@ ComPortsDlg::~ComPortsDlg()
     this->Disconnect(wxEVT_INIT_DIALOG, wxInitDialogEventHandler(ComPortsDlg::OnInitDialog), NULL, this);
     m_ckUseHamlibPTT->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(ComPortsDlg::PTTUseHamLibClicked), NULL, this);
     m_ckUseSerialPTT->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(ComPortsDlg::PTTUseSerialClicked), NULL, this);
+    m_cbRigName->Disconnect(wxEVT_COMBOBOX, wxCommandEventHandler(ComPortsDlg::HamlibRigNameChanged), NULL, this);
     m_buttonOK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnOK), NULL, this);
     m_buttonCancel->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnCancel), NULL, this);
     m_buttonApply->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnApply), NULL, this);
@@ -355,6 +358,7 @@ void ComPortsDlg::ExchangeData(int inout)
 
         m_ckUseHamlibPTT->SetValue(wxGetApp().m_boolHamlibUseForPTT);
         m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
+        resetIcomCIVStatus();
         m_cbSerialPort->SetValue(wxGetApp().m_strHamlibSerialPort);
 
         if (wxGetApp().m_intHamlibSerialRate == 0) {
@@ -564,6 +568,31 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
 void ComPortsDlg::PTTUseSerialClicked(wxCommandEvent& event)
 {
     m_ckUseHamlibPTT->SetValue(false);
+}
+
+//-------------------------------------------------------------------------
+// ComPortsDlg::HamlibRigNameChanged(): hide/show Icom CI-V hex control
+// depending on the selected radio.
+//-------------------------------------------------------------------------
+void ComPortsDlg::HamlibRigNameChanged(wxCommandEvent& event)
+{
+    resetIcomCIVStatus();
+}
+
+void ComPortsDlg::resetIcomCIVStatus()
+{
+    std::string rigName = m_cbRigName->GetString(m_cbRigName->GetCurrentSelection()).ToStdString();
+    if (rigName.find("Icom") == 0)
+    {
+        m_stIcomCIVHex->Show();
+        m_tcIcomCIVHex->Show();
+    }
+    else
+    {
+        m_stIcomCIVHex->Hide();
+        m_tcIcomCIVHex->Hide();
+    }
+    Layout();
 }
 
 //-------------------------------------------------------------------------

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -55,7 +55,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     //----------------------------------------------------------------------
 
     wxStaticBoxSizer* staticBoxSizer18 = new wxStaticBoxSizer( new wxStaticBox(this, wxID_ANY, _("Hamlib Settings")), wxHORIZONTAL);
-    wxGridSizer* gridSizerhl = new wxGridSizer(5, 2, 0, 0);
+    wxGridSizer* gridSizerhl = new wxGridSizer(6, 2, 0, 0);
     staticBoxSizer18->Add(gridSizerhl, 1, wxEXPAND|wxALIGN_LEFT, 5);
 
     /* Use Hamlib for PTT checkbox. */
@@ -81,6 +81,13 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbSerialPort = new wxComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(140, -1), 0, NULL, wxCB_DROPDOWN);
     gridSizerhl->Add(m_cbSerialPort, 0, wxALIGN_CENTER_VERTICAL, 0);
 
+    /* Hamlib Icom CI-V address text box. */
+    gridSizerhl->Add(new wxStaticText(this, wxID_ANY, _("Radio Address:"), wxDefaultPosition, wxDefaultSize, 0), 
+                      0, wxALIGN_CENTER_VERTICAL |  wxALIGN_RIGHT, 20);
+    m_pvIcomCIVHex = new wxNumericPropertyValidator(wxNumericPropertyValidator::Unsigned, 16);
+    m_tcIcomCIVHex = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(35, -1), 0, *m_pvIcomCIVHex);
+    gridSizerhl->Add(m_tcIcomCIVHex, 0, wxALIGN_CENTER_VERTICAL, 0);
+    
     /* Hamlib Serial Rate combobox. */
 
     gridSizerhl->Add(new wxStaticText(this, wxID_ANY, _("Serial Rate:"), wxDefaultPosition, wxDefaultSize, 0), 
@@ -356,6 +363,8 @@ void ComPortsDlg::ExchangeData(int inout)
             m_cbSerialRate->SetValue(wxString::Format(wxT("%i"), wxGetApp().m_intHamlibSerialRate));
         }
 
+        m_tcIcomCIVHex->SetValue(wxString::Format(wxT("%02x"), wxGetApp().m_intHamlibIcomCIVHex));
+        
         /* Serial PTT */
 
         m_ckUseSerialPTT->SetValue(wxGetApp().m_boolUseSerialPTT);
@@ -381,8 +390,13 @@ void ComPortsDlg::ExchangeData(int inout)
         wxGetApp().m_boolHamlibUseForPTT = m_ckUseHamlibPTT->GetValue();
         wxGetApp().m_intHamlibRig = m_cbRigName->GetSelection();
         wxGetApp().m_strHamlibSerialPort = m_cbSerialPort->GetValue();
-
-        wxString s = m_cbSerialRate->GetValue();
+        
+        wxString s = m_tcIcomCIVHex->GetValue();
+        long hexAddress = 0;
+        m_tcIcomCIVHex->GetValue().ToLong(&hexAddress, 16);
+        wxGetApp().m_intHamlibIcomCIVHex = hexAddress;
+        
+        s = m_cbSerialRate->GetValue();
         if (s == "default") {
             wxGetApp().m_intHamlibSerialRate = 0;
         } else {

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #include <sstream>
-
+        
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 // Class ComPortsDlg
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
@@ -85,8 +85,8 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_stIcomCIVHex = new wxStaticText(this, wxID_ANY, _("Radio Address:"), wxDefaultPosition, wxDefaultSize, 0);
     gridSizerhl->Add(m_stIcomCIVHex, 
                       0, wxALIGN_CENTER_VERTICAL |  wxALIGN_RIGHT, 20);
-    m_pvIcomCIVHex = new wxNumericPropertyValidator(wxNumericPropertyValidator::Unsigned, 16);
-    m_tcIcomCIVHex = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(35, -1), 0, *m_pvIcomCIVHex);
+    m_tcIcomCIVHex = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(35, -1), 0, wxNumericPropertyValidator(wxNumericPropertyValidator::Unsigned, 16));
+    m_tcIcomCIVHex->SetMaxLength(2);
     gridSizerhl->Add(m_tcIcomCIVHex, 0, wxALIGN_CENTER_VERTICAL, 0);
     
     /* Hamlib Serial Rate combobox. */
@@ -367,7 +367,7 @@ void ComPortsDlg::ExchangeData(int inout)
             m_cbSerialRate->SetValue(wxString::Format(wxT("%i"), wxGetApp().m_intHamlibSerialRate));
         }
 
-        m_tcIcomCIVHex->SetValue(wxString::Format(wxT("%02x"), wxGetApp().m_intHamlibIcomCIVHex));
+        m_tcIcomCIVHex->SetValue(wxString::Format(wxT("%02X"), wxGetApp().m_intHamlibIcomCIVHex));
         
         /* Serial PTT */
 

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -479,6 +479,10 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
             serial_rate = tmp;
         }
 
+        s = m_tcIcomCIVHex->GetValue();
+        long hexAddress = 0;
+        m_tcIcomCIVHex->GetValue().ToLong(&hexAddress, 16);
+        
         // display serial params
 
         fprintf(stderr, "serial rate: %d\n", serial_rate);
@@ -486,7 +490,7 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
         // try to open rig
 
         Hamlib *hamlib = wxGetApp().m_hamlib; 
-        bool status = hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate);
+        bool status = hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate, hexAddress);
         if (status == false) {
             wxMessageBox("Couldn't connect to Radio with Hamlib.  Make sure the Hamlib serial Device, Rate, and Params match your radio", 
             wxT("Error"), wxOK | wxICON_ERROR, this);

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -60,7 +60,6 @@ class ComPortsDlg : public wxDialog
         wxStaticText  *m_cbSerialParams;
         wxStaticText *m_stIcomCIVHex;
         wxTextCtrl *m_tcIcomCIVHex;
-        wxNumericPropertyValidator *m_pvIcomCIVHex;
         Hamlib *m_hamlib;
 
         /* Serial Settings */

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -58,6 +58,7 @@ class ComPortsDlg : public wxDialog
         wxComboBox *m_cbSerialPort;
         wxComboBox *m_cbSerialRate;
         wxStaticText  *m_cbSerialParams;
+        wxStaticText *m_stIcomCIVHex;
         wxTextCtrl *m_tcIcomCIVHex;
         wxNumericPropertyValidator *m_pvIcomCIVHex;
         Hamlib *m_hamlib;
@@ -86,7 +87,9 @@ protected:
 
         void PTTUseHamLibClicked(wxCommandEvent& event);
         void PTTUseSerialClicked(wxCommandEvent& event);
-
+        void HamlibRigNameChanged(wxCommandEvent& event);
+        void resetIcomCIVStatus();
+        
         void OnTest(wxCommandEvent& event);
 
         void OnOK(wxCommandEvent& event);

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -35,6 +35,7 @@
 #include <wx/radiobut.h>
 #include <wx/button.h>
 #include <wx/spinctrl.h>
+#include <wx/propgrid/property.h>
 #include <wx/propgrid/props.h>
 
 

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -35,6 +35,8 @@
 #include <wx/radiobut.h>
 #include <wx/button.h>
 #include <wx/spinctrl.h>
+#include <wx/propgrid/props.h>
+
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 // Class ComPortsDlg
@@ -56,6 +58,8 @@ class ComPortsDlg : public wxDialog
         wxComboBox *m_cbSerialPort;
         wxComboBox *m_cbSerialRate;
         wxStaticText  *m_cbSerialParams;
+        wxTextCtrl *m_tcIcomCIVHex;
+        wxNumericPropertyValidator *m_pvIcomCIVHex;
         Hamlib *m_hamlib;
 
         /* Serial Settings */

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -478,6 +478,7 @@ MainFrame::MainFrame(wxString plugInName, wxWindow *parent) : TopFrame(plugInNam
     wxGetApp().m_intVoiceKeyerRepeats = pConfig->Read(wxT("/VoiceKeyer/Repeats"), 5);
  
     wxGetApp().m_boolHamlibUseForPTT = pConfig->ReadBool("/Hamlib/UseForPTT", false);
+    wxGetApp().m_intHamlibIcomCIVHex = pConfig->ReadLong("/Hamlib/IcomCIVHex", 0);
     wxGetApp().m_intHamlibRig = pConfig->ReadLong("/Hamlib/RigName", 0);
     wxGetApp().m_strHamlibSerialPort = pConfig->Read("/Hamlib/SerialPort", "");
     wxGetApp().m_intHamlibSerialRate = pConfig->ReadLong("/Hamlib/SerialRate", 0);
@@ -791,6 +792,7 @@ MainFrame::~MainFrame()
         pConfig->Write("/Hamlib/RigName", wxGetApp().m_intHamlibRig);
         pConfig->Write("/Hamlib/SerialPort", wxGetApp().m_strHamlibSerialPort);
         pConfig->Write("/Hamlib/SerialRate", wxGetApp().m_intHamlibSerialRate);
+        pConfig->Write("/Hamlib/IcomCIVHex", wxGetApp().m_intHamlibIcomCIVHex);
 
 
         pConfig->Write(wxT("/File/playFileToMicInPath"),    wxGetApp().m_playFileToMicInPath);

--- a/src/fdmdv2_main.h
+++ b/src/fdmdv2_main.h
@@ -194,6 +194,7 @@ class MainApp : public wxApp
         unsigned int        m_intHamlibRig;
         wxString            m_strHamlibSerialPort;
         unsigned int        m_intHamlibSerialRate;
+        unsigned int        m_intHamlibIcomCIVHex;
         Hamlib              *m_hamlib;
 
         bool                m_boolUseSerialPTT;

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -115,10 +115,17 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
     fprintf(stderr, "rig_init() OK ....\n");
 
     /* Set CI-V address if necessary. */
-    char civ_addr[5];
-    snprintf(civ_addr, 5, "0x%0X", civ_hex);
-    fprintf(stderr, "hamlib: setting CI-V address to: %s\n", civ_addr);
-    rig_set_conf(m_rig, rig_token_lookup(m_rig, "civaddr"), civ_addr);
+    if (!strncmp(m_rigList[rig_index]->mfg_name, "Icom", 4))
+    {
+        char civ_addr[5];
+        snprintf(civ_addr, 5, "0x%0X", civ_hex);
+        fprintf(stderr, "hamlib: setting CI-V address to: %s\n", civ_addr);
+        rig_set_conf(m_rig, rig_token_lookup(m_rig, "civaddr"), civ_addr);
+    }
+    else
+    {
+        fprintf(stderr, "hamlib: ignoring CI-V configuration due to non-Icom radio\r\n");
+    }
     
     strncpy(m_rig->state.rigport.pathname, serial_port, FILPATHLEN - 1);
     if (serial_rate) {

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -24,6 +24,8 @@
 #include <vector>
 #include <algorithm>
 
+#define TOK_CIVADDR TOKEN_BACKEND(1)
+
 using namespace std;
 
 typedef std::vector<const struct rig_caps *> riglist_t;
@@ -85,7 +87,7 @@ void Hamlib::populateComboBox(wxComboBox *cb) {
     }
 }
 
-bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int serial_rate) {
+bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex) {
 
     /* Look up model from index. */
 
@@ -112,8 +114,12 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
     }
     fprintf(stderr, "rig_init() OK ....\n");
 
-    /* TODO we may also need civaddr for Icom */
-
+    /* Set CI-V address if necessary. */
+    char civ_addr[5];
+    snprintf(civ_addr, 5, "0x%0X", civ_hex);
+    fprintf(stderr, "hamlib: setting CI-V address to: %s\n", civ_addr);
+    rig_set_conf(m_rig, rig_token_lookup(m_rig, "civaddr"), civ_addr);
+    
     strncpy(m_rig->state.rigport.pathname, serial_port, FILPATHLEN - 1);
     if (serial_rate) {
         fprintf(stderr, "hamlib: setting serial rate: %d\n", serial_rate);

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -14,7 +14,7 @@ class Hamlib {
         Hamlib();
         ~Hamlib();
         void populateComboBox(wxComboBox *cb);
-        bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate);
+        bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex = 0);
         bool ptt(bool press, wxString &hamlibError);
         void enable_sideband_detection(wxStaticText* statusBox);
         void disable_sideband_detection();


### PR DESCRIPTION
This adds support (both in the PTT configuration UI and in the Hamlib class) for using a different CI-V address on Icom radios. This may be necessary for allowing usage of new radios not yet supported by Hamlib, as well as existing radios that need to use the non-default value for whatever reason.

(Speaking of unsupported radios, apparently the Mac build has the IC-9700 listed but the Windows build does not. @drowe67, does Docker potentially need to be updated to install a newer version of Hamlib? The Mac build process currently uses the latest master on GitHub, so we could possibly modify the Windows/Linux builds to use a similar mechanism.)

Tests run so far (Mac only right now on a IC-7200):

- Ensuring that the PTT configuration UI only supports A-F and 0-9 for valid characters.
- Canceling out of the PTT configuration UI without modifying anything.
- Select non-Icom radio (Radio Address field becomes hidden).
- Select Icom radio (Radio Address field appears).
- Testing PTT settings with the following:
    - CI-V address of 00 (radio allows connection regardless of its actual address)
    - CI-V address equal to the radio's (radio connection allowed)
    - CI-V address not equal to the radio's (FreeDV complains of a Hamlib connection timeout)