### PR TITLE
Allow FM for mode detection if using 2400B.

### DIFF
--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2445,7 +2445,7 @@ void MainFrame::OnExit(wxCommandEvent& event)
     // of in the destructor due to its need to touch the UI.
     if (wxGetApp().m_hamlib)
     {
-        wxGetApp().m_hamlib->disable_sideband_detection();
+        wxGetApp().m_hamlib->disable_mode_detection();
     }
 
     //fprintf(stderr, "MainFrame::OnExit\n");
@@ -2635,7 +2635,7 @@ bool MainFrame::OpenHamlibRig() {
         wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
     else
     {
-        wxGetApp().m_hamlib->enable_sideband_detection(m_txtSSBStatus, g_mode == FREEDV_MODE_2400B);
+        wxGetApp().m_hamlib->enable_mode_detection(m_txtModeStatus, g_mode == FREEDV_MODE_2400B);
     }
 
     return status;
@@ -2903,7 +2903,7 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
                 if (hamlib->ptt(false, hamlibError) == false) {
                     wxMessageBox(wxString("Hamlib PTT Error: ") + hamlibError, wxT("Error"), wxOK | wxICON_ERROR, this);
                 }
-                hamlib->disable_sideband_detection();
+                hamlib->disable_mode_detection();
                 hamlib->close();
             }
         }

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -2635,7 +2635,7 @@ bool MainFrame::OpenHamlibRig() {
         wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
     else
     {
-        wxGetApp().m_hamlib->enable_sideband_detection(m_txtSSBStatus);
+        wxGetApp().m_hamlib->enable_sideband_detection(m_txtSSBStatus, g_mode == FREEDV_MODE_2400B);
     }
 
     return status;

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -33,7 +33,7 @@ static int build_list(const struct rig_caps *rig, rig_ptr_t);
 
 Hamlib::Hamlib() : 
     m_rig(NULL),
-    m_sidebandBox(NULL),
+    m_modeBox(NULL),
     m_currFreq(0),
     m_currMode(RIG_MODE_USB),
     m_vhfUhfMode(false)  {
@@ -172,7 +172,7 @@ int Hamlib::hamlib_freq_cb(RIG* rig, vfo_t currVFO, freq_t currFreq, void* ptr)
 {
     Hamlib* thisPtr = (Hamlib*)ptr;
     thisPtr->m_currFreq = currFreq;
-    thisPtr->update_sideband_status();
+    thisPtr->update_mode_status();
     return RIG_OK;
 }
 
@@ -180,18 +180,18 @@ int Hamlib::hamlib_mode_cb(RIG* rig, vfo_t currVFO, rmode_t currMode, pbwidth_t 
 {
     Hamlib* thisPtr = (Hamlib*)ptr;
     thisPtr->m_currMode = currMode;
-    thisPtr->update_sideband_status();
+    thisPtr->update_mode_status();
     return RIG_OK;
 }
 
-void Hamlib::enable_sideband_detection(wxStaticText* statusBox, bool vhfUhfMode)
+void Hamlib::enable_mode_detection(wxStaticText* statusBox, bool vhfUhfMode)
 {
     // Set VHF/UHF mode. This governs whether FM is an acceptable mode for the detection display.
     m_vhfUhfMode = vhfUhfMode;
     
     // Enable control.
-    m_sidebandBox = statusBox;
-    m_sidebandBox->Enable(true);
+    m_modeBox = statusBox;
+    m_modeBox->Enable(true);
 
     // Populate initial state.
     rmode_t mode = RIG_MODE_NONE;
@@ -213,16 +213,16 @@ void Hamlib::enable_sideband_detection(wxStaticText* statusBox, bool vhfUhfMode)
         {
             m_currMode = mode;
             m_currFreq = freq;
-            update_sideband_status();
+            update_mode_status();
         }
     }
 
     // If we couldn't get current mode/frequency for any reason, disable the UI for it.
     if (result != RIG_OK)
     {
-        m_sidebandBox->SetLabel(wxT("unk"));
-        m_sidebandBox->Enable(false);
-        m_sidebandBox = NULL;
+        m_modeBox->SetLabel(wxT("unk"));
+        m_modeBox->Enable(false);
+        m_modeBox = NULL;
     }
     else
     {
@@ -238,9 +238,9 @@ void Hamlib::enable_sideband_detection(wxStaticText* statusBox, bool vhfUhfMode)
     }
 }
 
-void Hamlib::disable_sideband_detection()
+void Hamlib::disable_mode_detection()
 {
-    if (m_sidebandBox != NULL) 
+    if (m_modeBox != NULL) 
     {
         // TBD: Due to hamlib not supporting polling on Windows, the bottom is temporarily
         // disabled. When/if that changes, re-enabling is a simple matter of removing
@@ -253,40 +253,40 @@ void Hamlib::disable_sideband_detection()
 #endif
     
         // Disable control.
-        m_sidebandBox->SetLabel(wxT("unk"));
-        m_sidebandBox->Enable(false);
-        m_sidebandBox = NULL;
+        m_modeBox->SetLabel(wxT("unk"));
+        m_modeBox->Enable(false);
+        m_modeBox = NULL;
     }
 }
 
-void Hamlib::update_sideband_status()
+void Hamlib::update_mode_status()
 {
     // Update string value.
     if (m_currMode == RIG_MODE_USB || m_currMode == RIG_MODE_PKTUSB)
-        m_sidebandBox->SetLabel(wxT("USB"));
+        m_modeBox->SetLabel(wxT("USB"));
     else if (m_currMode == RIG_MODE_LSB || m_currMode == RIG_MODE_PKTLSB)
-        m_sidebandBox->SetLabel(wxT("LSB"));
+        m_modeBox->SetLabel(wxT("LSB"));
     else if (m_currMode == RIG_MODE_FM || m_currMode == RIG_MODE_FM)
-        m_sidebandBox->SetLabel(wxT("FM"));
+        m_modeBox->SetLabel(wxT("FM"));
     else
-        m_sidebandBox->SetLabel(rig_strrmode(m_currMode));
+        m_modeBox->SetLabel(rig_strrmode(m_currMode));
 
     // Update color
-    bool isMatchingSideband = 
+    bool isMatchingMode = 
         (m_currFreq >= 10000000 && (m_currMode == RIG_MODE_USB || m_currMode == RIG_MODE_PKTUSB)) ||
         (m_currFreq < 10000000 && (m_currMode == RIG_MODE_LSB || m_currMode == RIG_MODE_PKTLSB)) ||
         (m_vhfUhfMode && m_currFreq >= 29510000 && (m_currMode == RIG_MODE_FM || m_currMode == RIG_MODE_PKTFM));
-    if (isMatchingSideband)
+    if (isMatchingMode)
     {
-        m_sidebandBox->SetForegroundColour(wxColor(*wxBLACK));
+        m_modeBox->SetForegroundColour(wxColor(*wxBLACK));
     }
     else
     {
-        m_sidebandBox->SetForegroundColour(wxColor(*wxRED));
+        m_modeBox->SetForegroundColour(wxColor(*wxRED));
     }
 
     // Refresh
-    m_sidebandBox->Refresh();
+    m_modeBox->Refresh();
 }
 
 void Hamlib::close(void) {

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -16,8 +16,8 @@ class Hamlib {
         void populateComboBox(wxComboBox *cb);
         bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate);
         bool ptt(bool press, wxString &hamlibError);
-        void enable_sideband_detection(wxStaticText* statusBox, bool vhfUhfMode);
-        void disable_sideband_detection();
+        void enable_mode_detection(wxStaticText* statusBox, bool vhfUhfMode);
+        void disable_mode_detection();
         void close(void);
         int get_serial_rate(void);
         int get_data_bits(void);
@@ -29,14 +29,14 @@ class Hamlib {
         static int hamlib_freq_cb(RIG* rig, vfo_t currVFO, freq_t currFreq, void* ptr);
         static int hamlib_mode_cb(RIG* rig, vfo_t currVFO, rmode_t currMode, pbwidth_t passband, void* ptr);
 
-        void update_sideband_status();
+        void update_mode_status();
 
         RIG *m_rig;
         /* Sorted list of rigs. */
         riglist_t m_rigList;
 
-        /* Sideband detection status box and state. */
-        wxStaticText* m_sidebandBox;
+        /* Mode detection status box and state. */
+        wxStaticText* m_modeBox;
         freq_t m_currFreq;
         rmode_t m_currMode;
         bool m_vhfUhfMode;

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -16,7 +16,7 @@ class Hamlib {
         void populateComboBox(wxComboBox *cb);
         bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate);
         bool ptt(bool press, wxString &hamlibError);
-        void enable_sideband_detection(wxStaticText* statusBox);
+        void enable_sideband_detection(wxStaticText* statusBox, bool vhfUhfMode);
         void disable_sideband_detection();
         void close(void);
         int get_serial_rate(void);
@@ -39,6 +39,7 @@ class Hamlib {
         wxStaticText* m_sidebandBox;
         freq_t m_currFreq;
         rmode_t m_currMode;
+        bool m_vhfUhfMode;
 };
 
 #endif /*HAMLIB_H*/

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -234,13 +234,13 @@ TopFrame::TopFrame(wxString plugInName, wxWindow* parent, wxWindowID id, const w
     wxBoxSizer* lowerSizer;
     lowerSizer = new wxBoxSizer(wxHORIZONTAL);
 
-    wxBoxSizer* ssbStatusSizer;
-    ssbStatusSizer = new wxBoxSizer(wxVERTICAL);
-    m_txtSSBStatus = new wxStaticText(this, wxID_ANY, wxT("unk"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
-    m_txtSSBStatus->Enable(false); // enabled only if Hamlib is turned on
-    m_txtSSBStatus->SetMinSize(wxSize(40,-1));
-    ssbStatusSizer->Add(m_txtSSBStatus, 0, wxALL|wxEXPAND, 1);
-    lowerSizer->Add(ssbStatusSizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 1);
+    wxBoxSizer* modeStatusSizer;
+    modeStatusSizer = new wxBoxSizer(wxVERTICAL);
+    m_txtModeStatus = new wxStaticText(this, wxID_ANY, wxT("unk"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_txtModeStatus->Enable(false); // enabled only if Hamlib is turned on
+    m_txtModeStatus->SetMinSize(wxSize(40,-1));
+    modeStatusSizer->Add(m_txtModeStatus, 0, wxALL|wxEXPAND, 1);
+    lowerSizer->Add(modeStatusSizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 1);
 
     m_BtnCallSignReset = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxDefaultSize, 0);
     lowerSizer->Add(m_BtnCallSignReset, 0, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL, 1);

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -90,7 +90,7 @@ class TopFrame : public wxFrame
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;
-        wxStaticText* m_txtSSBStatus;
+        wxStaticText* m_txtModeStatus;
         wxStaticText* m_txtChecksumGood;
         wxStaticText* m_txtChecksumBad;
 


### PR DESCRIPTION
@drowe67, as mentioned in PR #73, here's the change to allow FM if using 2400B. With this change, if 2400B is chosen and the radio is in the 10 meter FM subband or higher, "FM" will not show as red. Tested on my FT-817 and seemed to work with no issues.