### PR TITLE
Remove dependency on golay23.h.

### DIFF
--- a/src/callsign_encoder.cpp
+++ b/src/callsign_encoder.cpp
@@ -24,6 +24,11 @@
 #include <cstring>
 #include "callsign_encoder.h"
 
+extern "C" {
+    extern int  golay23_encode(int data);
+    extern int  golay23_decode(int received_codeword);
+}
+
 CallsignEncoder::CallsignEncoder()
 {
     memset(&translatedCallsign_, 0, MAX_CALLSIGN);

--- a/src/callsign_encoder.h
+++ b/src/callsign_encoder.h
@@ -25,7 +25,6 @@
 
 #include <deque>
 #include "fdmdv2_defines.h"
-#include "golay23.h"
 
 class CallsignEncoder
 {

--- a/src/fdmdv2_main.cpp
+++ b/src/fdmdv2_main.cpp
@@ -24,7 +24,6 @@
 #include <deque>
 #include "fdmdv2_main.h"
 #include "osx_interface.h"
-#include "golay23.h"
 #include "callsign_encoder.h"
 
 #define wxUSE_FILEDLG   1
@@ -33,6 +32,10 @@
 #define wxUSE_GIF       1
 #define wxUSE_PCX       1
 #define wxUSE_LIBTIFF   1
+
+extern "C" {
+    extern void golay23_init(void);
+}
 
 //-------------------------------------------------------------------
 // Bunch of globals used for communication with sound card call


### PR DESCRIPTION
Resolves #94 by replacing #include with manually copied extern references.