### PR TITLE
Add required Ubuntu packages to README for building.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       shell: bash
       run: |
            sudo apt-get update
-           sudo apt-get install libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.0-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev
+           sudo apt-get install libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.0-gtk3-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev
             
     - name: Build freedv-gui
       shell: bash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This document describes how to build the FreeDV GUI program for various operatin
 ## Building on Ubuntu Linux (16-20)
   ```
   $ sudo apt install libc6-i386 libspeexdsp-dev libsamplerate0-dev sox git \
-  libwxgtk3.0-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev \
+  libwxgtk3.0-gtk3-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev \
   libgsm1-dev libsndfile-dev cmake module-assistant build-essential
   $ git clone https://github.com/drowe67/freedv-gui.git
   $ cd freedv-gui

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This document describes how to build the FreeDV GUI program for various operatin
   ```
   $ sudo apt install libc6-i386 libspeexdsp-dev libsamplerate0-dev sox git \
   libwxgtk3.0-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev \
-  libgsm1-dev libsndfile-dev cmake
+  libgsm1-dev libsndfile-dev cmake module-assistant build-essential
   $ git clone https://github.com/drowe67/freedv-gui.git
   $ cd freedv-gui
   $ ./build_linux.sh


### PR DESCRIPTION
Updating README per JH0PCF's email to digitalvoice:

> FreeDV source code on Ubuntu 20.04
When building, the procedure in the manual
I couldn't handle it well
By adding module-assistant build-essntial
You can now process safely

\+ @drowe67 