### PR TITLE
Add correct libraries for building static PortAudio on Linux.

### DIFF
--- a/cmake/BuildPortaudio.cmake
+++ b/cmake/BuildPortaudio.cmake
@@ -54,10 +54,9 @@ if(WIN32)
     list(APPEND PORTAUDIO_LIBRARIES ${WINMM} ${DSOUND}
 )
 elseif(NOT APPLE)
-#else(WIN32)
     find_library(RT rt)
     find_library(ASOUND asound)
-    set(PORTAUDIO_LIBRARIES ${RT} ${ASOUND}
+    list(APPEND PORTAUDIO_LIBRARIES ${RT} ${ASOUND}
     )
 endif(WIN32)
 include_directories(${CMAKE_BINARY_DIR}/external/dist/include)


### PR DESCRIPTION
@drowe67, here's a quick fix to CMake for something I discovered while investigating the PulseAudio stuff. (I was hoping that the latest PortAudio snapshot would work a bit better than the behavior I saw tonight, but it doesn't seem to be the case thus far.) Basically, this makes it so that the PortAudio static library enabled by -DUSE_STATIC_PORTAUDIO=1 is actually linked into the binary correctly along with ALSA. 

Anyway, I'll update #16 with what I found so far.