### PR TITLE
Add sync mode labels for 800XA and 2400B.

### DIFF
--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -241,6 +241,10 @@ const char* FreeDVInterface::getCurrentModeStr() const
                 return "1600";
             case FREEDV_MODE_2020:
                 return "2020";
+            case FREEDV_MODE_800XA:
+                return "800XA";
+            case FREEDV_MODE_2400B:
+                return "2400B";
             default:
                 return "unk";
         }


### PR DESCRIPTION
This was originally missed when multi-RX was implemented, causing "unk" to display when using 800XA or 2400B. 