### PR TITLE
Additional optimizations for PlotWaterfall

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -855,7 +855,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         m_panelWaterfall->setRxFreq(FDMDV_FCENTRE - g_RxFreqOffsetHz);
         m_panelWaterfall->m_newdata = true;
         m_panelWaterfall->setColor(wxGetApp().m_waterfallColor);
-        m_panelWaterfall->Refresh();
+        m_panelWaterfall->RefreshWaterfallOnly();
     }
 
     m_panelSpectrum->setRxFreq(FDMDV_FCENTRE - g_RxFreqOffsetHz);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -855,7 +855,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         m_panelWaterfall->setRxFreq(FDMDV_FCENTRE - g_RxFreqOffsetHz);
         m_panelWaterfall->m_newdata = true;
         m_panelWaterfall->setColor(wxGetApp().m_waterfallColor);
-        m_panelWaterfall->RefreshWaterfallOnly();
+        m_panelWaterfall->Refresh();
     }
 
     m_panelSpectrum->setRxFreq(FDMDV_FCENTRE - g_RxFreqOffsetHz);

--- a/src/osx_interface.h
+++ b/src/osx_interface.h
@@ -32,4 +32,18 @@ extern "C" bool VerifyMicrophonePermissions();
 extern "C" bool VerifyMicrophonePermissions() { return true; }
 #endif // __APPLE__
 
+#ifdef __APPLE__
+// macOS does color space conversions in the background when rendering PlotWaterfall.
+// This causes FreeDV to use ~30-50% more CPU that it otherwise would (despite wxWidgets
+// using sRGB internally). Because of this, we reset the main window's color space to 
+// sRGB ourselves on every frame render.
+//
+// See https://github.com/OpenTTD/OpenTTD/issues/7644 and https://trac.wxwidgets.org/ticket/18516
+// for more details.
+extern "C" void ResetMainWindowColorSpace();
+#else
+// Stub for non-Apple platforms
+extern "C" void ResetMainWindowColorSpace() { }
+#endif // __APPLE__
+
 #endif // __OSX_INTERFACE__

--- a/src/osx_interface.h
+++ b/src/osx_interface.h
@@ -29,7 +29,7 @@
 extern "C" bool VerifyMicrophonePermissions();
 #else
 // Stub for non-Apple platforms
-extern "C" bool VerifyMicrophonePermissions() { return true; }
+#define VerifyMicrophonePermissions() (true)
 #endif // __APPLE__
 
 #ifdef __APPLE__
@@ -43,7 +43,7 @@ extern "C" bool VerifyMicrophonePermissions() { return true; }
 extern "C" void ResetMainWindowColorSpace();
 #else
 // Stub for non-Apple platforms
-extern "C" void ResetMainWindowColorSpace() { }
+#define ResetMainWindowColorSpace() 
 #endif // __APPLE__
 
 #endif // __OSX_INTERFACE__

--- a/src/osx_interface.mm
+++ b/src/osx_interface.mm
@@ -21,6 +21,7 @@
 //==========================================================================
 
 #import <AVFoundation/AVFoundation.h>
+#import <AppKit/AppKit.h>
 #include <mutex>
 #include <condition_variable>
 #include "osx_interface.h"
@@ -79,3 +80,12 @@ bool VerifyMicrophonePermissions()
     return hasAccess;
 }
 
+void ResetMainWindowColorSpace()
+{
+    NSWindow* win = [NSApp mainWindow];
+    CGColorSpaceRef cs = CGColorSpaceCreateWithName( kCGColorSpaceSRGB );
+    [win setColorSpace:[[[NSColorSpace alloc]initWithCGColorSpace:cs] autorelease]];
+    
+    assert(cs != nullptr);
+    CGColorSpaceRelease(cs);
+}

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -92,6 +92,17 @@ void PlotWaterfall::OnSize(wxSizeEvent& event)
     
     m_dT = DT;
     
+    m_fullBmp = new wxBitmap(std::max(1,m_imgWidth), std::max(1,m_imgHeight));
+    
+    // Paint to black to avoid random garbage appearing.
+    wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
+    wxMemoryDC fullBmpDestDC(*m_fullBmp);
+    wxGraphicsContext* tmpGc = wxGraphicsContext::Create(fullBmpDestDC);
+    tmpGc->SetBrush(ltGraphBkgBrush);
+    tmpGc->SetPen(wxPen(BLACK_COLOR, 0));
+    tmpGc->DrawRectangle(0, 0, m_imgWidth, m_imgHeight);
+    delete tmpGc;
+    
     event.Skip();
 }
 
@@ -178,12 +189,21 @@ void PlotWaterfall::draw(wxGraphicsContext* gc)
     m_rGrid = m_rGrid.Deflate(PLOT_BORDER + (XLEFT_OFFSET/2), (PLOT_BORDER + (YBOTTOM_OFFSET/2)));
 
     // we want a bit map the size of m_rGrid
+    wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
     if (m_fullBmp == NULL) 
     {
         // we want a bit map the size of m_rGrid
         m_imgHeight = m_rGrid.GetHeight();
         m_imgWidth = m_rGrid.GetWidth();
         m_fullBmp = new wxBitmap(std::max(1,m_imgWidth), std::max(1,m_imgHeight));
+        
+        // Paint to black to avoid random garbage appearing.
+        wxMemoryDC fullBmpDestDC(*m_fullBmp);
+        wxGraphicsContext* tmpGc = wxGraphicsContext::Create(fullBmpDestDC);
+        tmpGc->SetBrush(ltGraphBkgBrush);
+        tmpGc->SetPen(wxPen(BLACK_COLOR, 0));
+        tmpGc->DrawRectangle(0, 0, m_imgWidth, m_imgHeight);
+        delete tmpGc;
     }
 
     if(m_newdata)
@@ -203,7 +223,6 @@ void PlotWaterfall::draw(wxGraphicsContext* gc)
         // Bug on Linux: When Stop is pressed this code doesn't erase
         // the lower 25% of the Waterfall Window
 
-        wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
         gc->SetBrush(ltGraphBkgBrush);
         gc->SetPen(wxPen(BLACK_COLOR, 0));
         gc->DrawRectangle(PLOT_BORDER + XLEFT_OFFSET, PLOT_BORDER + YBOTTOM_OFFSET, m_imgWidth, m_imgHeight);

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -347,7 +347,7 @@ void PlotWaterfall::plotPixelData(wxGraphicsContext* gc)
     float       px_per_sec;
     int         index;
     int         dy;
-    int         dy_blocks;
+    unsigned int         dy_blocks;
     int         px;
     int         py;
     int         intensity;

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -60,7 +60,6 @@ PlotWaterfall::PlotWaterfall(wxWindow* parent, bool graticule, int colour): Plot
     m_newdata       = false;
     m_firstPass     = true;
     m_line_color    = 0;
-    m_updateOnlyWaterfall = false;
     m_modem_stats_max_f_hz = MODEM_STATS_MAX_F_HZ;
 
     SetLabelSize(10.0);
@@ -108,40 +107,6 @@ void PlotWaterfall::OnShow(wxShowEvent& event)
 PlotWaterfall::~PlotWaterfall()
 {
     m_waterfallBlocks.clear();
-}
-
-void PlotWaterfall::OnPaint(wxPaintEvent& event)
-{
-    // Determine whether we're only updating the waterfall area or the whole
-    // control.
-    m_updateOnlyWaterfall = false;
-    wxRegionIterator upd(GetUpdateRegion()); // get the update rect list
-    while (upd)
-    {
-        wxRect rect(upd.GetRect());
-        
-        fprintf(stderr, "rect(%d,%d,%d,%d) grid(%d,%d,%d,%d)\n", rect.x, rect.y, rect.width, rect.height, m_rGrid.x, m_rGrid.y, m_rGrid.width, m_rGrid.height);
-        if (rect.x < m_rGrid.x || rect.x > m_rGrid.x ||
-            rect.y < m_rGrid.y || rect.y > m_rGrid.y)
-        {
-            fprintf(stderr, "Invalidating the entire PlotWaterfall.\n");
-            //m_updateOnlyWaterfall = false;
-            //break;
-        }
-        upd++;
-    }
-    
-    PlotPanel::OnPaint(event);
-}
-
-//----------------------------------------------------------------
-// RefreshWaterfall(): only requests redraw of the waterfall area
-// (not graticules).
-//----------------------------------------------------------------
-void PlotWaterfall::RefreshWaterfallOnly()
-{
-    wxRect tmpRect(m_rGrid);
-    RefreshRect(tmpRect, false);
 }
 
 //----------------------------------------------------------------
@@ -215,10 +180,7 @@ void PlotWaterfall::draw(wxGraphicsContext* gc)
     m_imgHeight = m_rGrid.GetHeight();
     m_imgWidth = m_rGrid.GetWidth();
     
-    if (!m_updateOnlyWaterfall)
-    {
-        drawGraticule(gc);
-    } 
+    drawGraticule(gc);
     
     float px_per_sec = (float)m_imgHeight / WATERFALL_SECS_Y;
     int dy = m_dT * px_per_sec;

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -182,18 +182,24 @@ void PlotWaterfall::draw(wxGraphicsContext* gc)
     
     drawGraticule(gc);
     
-    wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
-    gc->SetBrush(ltGraphBkgBrush);
-    gc->SetPen(wxPen(BLACK_COLOR, 0));
-    gc->DrawRectangle(PLOT_BORDER + XLEFT_OFFSET, PLOT_BORDER + YBOTTOM_OFFSET, m_imgWidth, m_imgHeight);
+    float px_per_sec = (float)m_imgHeight / WATERFALL_SECS_Y;
+    int dy = m_dT * px_per_sec;
+    int remainingBlackBoxHeight = m_imgHeight - dy * m_waterfallBlocks.size();
+    int remainingBlackBoxY = PLOT_BORDER + YBOTTOM_OFFSET + dy * m_waterfallBlocks.size();
+    
+    if (remainingBlackBoxHeight > 0)
+    {
+        wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
+        gc->SetBrush(ltGraphBkgBrush);
+        gc->SetPen(wxPen(BLACK_COLOR, 0));
+        gc->DrawRectangle(PLOT_BORDER + XLEFT_OFFSET, remainingBlackBoxY, m_imgWidth, remainingBlackBoxHeight);
+    }
     
     if(m_newdata)
     {
         m_newdata = false;
         plotPixelData(gc);
         
-        float px_per_sec = (float)m_imgHeight / WATERFALL_SECS_Y;
-        int dy = m_dT * px_per_sec;
         int y = 0;
         
         for (auto& bmp : m_waterfallBlocks)

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -346,8 +346,8 @@ void PlotWaterfall::plotPixelData(wxGraphicsContext* gc)
     spec_index_per_px = ((float)(MAX_F_HZ)/(float)m_modem_stats_max_f_hz)*(float)MODEM_STATS_NSPEC / (float)m_imgWidth;
 
     // Draw last line of blocks using latest amplitude data ------------------
-    unsigned char dyImageData[3 * (dy + 1) * m_imgWidth];
-    for(py = dy; py >= 0; py--)
+    unsigned char dyImageData[3 * dy * m_imgWidth];
+    for(py = dy - 1; py >= 0; py--)
     {
         for(px = 0; px < m_imgWidth; px++)
         {
@@ -388,7 +388,7 @@ void PlotWaterfall::plotPixelData(wxGraphicsContext* gc)
     // on macOS due to how it handles color spaces.
     ResetMainWindowColorSpace();
 
-    wxImage* tmpImage = new wxImage(m_imgWidth, dy + 1, (unsigned char*)&dyImageData, true);
+    wxImage* tmpImage = new wxImage(m_imgWidth, dy, (unsigned char*)&dyImageData, true);
     m_waterfallBlocks.push_front(gc->CreateBitmapFromImage(*tmpImage));
     
     if (m_waterfallBlocks.size() > dy_blocks)

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -60,6 +60,7 @@ PlotWaterfall::PlotWaterfall(wxWindow* parent, bool graticule, int colour): Plot
     m_newdata       = false;
     m_firstPass     = true;
     m_line_color    = 0;
+    m_updateOnlyWaterfall = false;
     m_modem_stats_max_f_hz = MODEM_STATS_MAX_F_HZ;
 
     SetLabelSize(10.0);
@@ -107,6 +108,40 @@ void PlotWaterfall::OnShow(wxShowEvent& event)
 PlotWaterfall::~PlotWaterfall()
 {
     m_waterfallBlocks.clear();
+}
+
+void PlotWaterfall::OnPaint(wxPaintEvent& event)
+{
+    // Determine whether we're only updating the waterfall area or the whole
+    // control.
+    m_updateOnlyWaterfall = false;
+    wxRegionIterator upd(GetUpdateRegion()); // get the update rect list
+    while (upd)
+    {
+        wxRect rect(upd.GetRect());
+        
+        fprintf(stderr, "rect(%d,%d,%d,%d) grid(%d,%d,%d,%d)\n", rect.x, rect.y, rect.width, rect.height, m_rGrid.x, m_rGrid.y, m_rGrid.width, m_rGrid.height);
+        if (rect.x < m_rGrid.x || rect.x > m_rGrid.x ||
+            rect.y < m_rGrid.y || rect.y > m_rGrid.y)
+        {
+            fprintf(stderr, "Invalidating the entire PlotWaterfall.\n");
+            //m_updateOnlyWaterfall = false;
+            //break;
+        }
+        upd++;
+    }
+    
+    PlotPanel::OnPaint(event);
+}
+
+//----------------------------------------------------------------
+// RefreshWaterfall(): only requests redraw of the waterfall area
+// (not graticules).
+//----------------------------------------------------------------
+void PlotWaterfall::RefreshWaterfallOnly()
+{
+    wxRect tmpRect(m_rGrid);
+    RefreshRect(tmpRect, false);
 }
 
 //----------------------------------------------------------------
@@ -180,12 +215,21 @@ void PlotWaterfall::draw(wxGraphicsContext* gc)
     m_imgHeight = m_rGrid.GetHeight();
     m_imgWidth = m_rGrid.GetWidth();
     
-    drawGraticule(gc);
+    if (!m_updateOnlyWaterfall)
+    {
+        drawGraticule(gc);
+    } 
     
     float px_per_sec = (float)m_imgHeight / WATERFALL_SECS_Y;
     int dy = m_dT * px_per_sec;
     int remainingBlackBoxHeight = m_imgHeight - dy * m_waterfallBlocks.size();
     int remainingBlackBoxY = PLOT_BORDER + YBOTTOM_OFFSET + dy * m_waterfallBlocks.size();
+    
+    if (!m_newdata)
+    {
+        remainingBlackBoxHeight = m_imgHeight;
+        remainingBlackBoxY = PLOT_BORDER + YBOTTOM_OFFSET;
+    }
     
     if (remainingBlackBoxHeight > 0)
     {

--- a/src/plot_waterfall.h
+++ b/src/plot_waterfall.h
@@ -21,6 +21,7 @@
 #ifndef __FDMDV2_PLOT_WATERFALL__
 #define __FDMDV2_PLOT_WATERFALL__
 
+#include <deque>
 #include "plot.h"
 #include "defines.h"
 
@@ -54,7 +55,7 @@ class PlotWaterfall : public PlotPanel
         void        OnShow(wxShowEvent& event);
         void        drawGraticule(wxGraphicsContext* ctx);
         void        draw(wxGraphicsContext* gc);
-        void        plotPixelData();
+        void        plotPixelData(wxGraphicsContext* gc);
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
 
     private:
@@ -65,8 +66,9 @@ class PlotWaterfall : public PlotPanel
         float       m_max_mag;
         int         m_colour;
         int         m_modem_stats_max_f_hz;
+
+        std::deque<wxGraphicsBitmap> m_waterfallBlocks;
         
-        wxBitmap* m_fullBmp;
         int m_imgHeight;
         int m_imgWidth;
 

--- a/src/plot_waterfall.h
+++ b/src/plot_waterfall.h
@@ -46,8 +46,6 @@ class PlotWaterfall : public PlotPanel
         void setFs(int fs) { m_modem_stats_max_f_hz = fs/2; }
         void setColor(int color) { m_colour = color; }
         
-        void RefreshWaterfallOnly();
-        
     protected:
         unsigned    m_heatmap_lut[256];
 
@@ -59,7 +57,6 @@ class PlotWaterfall : public PlotPanel
         void        draw(wxGraphicsContext* gc);
         void        plotPixelData(wxGraphicsContext* gc);
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
-        void        OnPaint(wxPaintEvent& event);
 
     private:
         float       m_dT;
@@ -69,7 +66,6 @@ class PlotWaterfall : public PlotPanel
         float       m_max_mag;
         int         m_colour;
         int         m_modem_stats_max_f_hz;
-        bool        m_updateOnlyWaterfall;
 
         std::deque<wxGraphicsBitmap> m_waterfallBlocks;
         

--- a/src/plot_waterfall.h
+++ b/src/plot_waterfall.h
@@ -21,7 +21,6 @@
 #ifndef __FDMDV2_PLOT_WATERFALL__
 #define __FDMDV2_PLOT_WATERFALL__
 
-#include <deque>
 #include "plot.h"
 #include "defines.h"
 
@@ -55,7 +54,7 @@ class PlotWaterfall : public PlotPanel
         void        OnShow(wxShowEvent& event);
         void        drawGraticule(wxGraphicsContext* ctx);
         void        draw(wxGraphicsContext* gc);
-        void        plotPixelData(wxGraphicsContext* gc);
+        void        plotPixelData();
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
 
     private:
@@ -67,8 +66,7 @@ class PlotWaterfall : public PlotPanel
         int         m_colour;
         int         m_modem_stats_max_f_hz;
 
-        std::deque<wxGraphicsBitmap> m_waterfallBlocks;
-        
+        wxBitmap* m_fullBmp;
         int m_imgHeight;
         int m_imgWidth;
 

--- a/src/plot_waterfall.h
+++ b/src/plot_waterfall.h
@@ -46,6 +46,8 @@ class PlotWaterfall : public PlotPanel
         void setFs(int fs) { m_modem_stats_max_f_hz = fs/2; }
         void setColor(int color) { m_colour = color; }
         
+        void RefreshWaterfallOnly();
+        
     protected:
         unsigned    m_heatmap_lut[256];
 
@@ -57,6 +59,7 @@ class PlotWaterfall : public PlotPanel
         void        draw(wxGraphicsContext* gc);
         void        plotPixelData(wxGraphicsContext* gc);
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
+        void        OnPaint(wxPaintEvent& event);
 
     private:
         float       m_dT;
@@ -66,6 +69,7 @@ class PlotWaterfall : public PlotPanel
         float       m_max_mag;
         int         m_colour;
         int         m_modem_stats_max_f_hz;
+        bool        m_updateOnlyWaterfall;
 
         std::deque<wxGraphicsBitmap> m_waterfallBlocks;
         


### PR DESCRIPTION
Additional optimizations for PlotWaterfall:

1. macOS: Force main window's color space to be the same as wxWidgets (sRGB). This prevents background color space conversions and reduces CPU usage. Based on info and code from https://github.com/OpenTTD/OpenTTD/issues/7644 and https://trac.wxwidgets.org/ticket/18516.
2. Cache each displayed waterfall segment using wxGraphicsBitmap instead of re-rendering the entire visible area as a single bitmap.

These changes result in FreeDV CPU usage dropping to ~15% on both macOS and Linux when the waterfall's displayed (2019 MacBook Pro, latter using a VM on said machine).