### PR TITLE
Remove unneeded checks to reflect codec2 PR #194.

### DIFF
--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -307,15 +307,9 @@ int FreeDVInterface::getSync() const
 
 void FreeDVInterface::setEq(int val)
 {
-    int index = 0;
     for (auto& dv : dvObjects_)
     {
-        int mode = enabledModes_[index];
-        if ((mode == FREEDV_MODE_700C) || (mode == FREEDV_MODE_700D) || (mode == FREEDV_MODE_700E))
-        {
-            freedv_set_eq(dv, val);
-        }
-        index++;
+        freedv_set_eq(dv, val);
     }
 }
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -315,15 +315,9 @@ void FreeDVInterface::setEq(int val)
 
 void FreeDVInterface::setCarrierAmplitude(int c, float amp)
 {
-    int index = 0;
     for (auto& dv : dvObjects_)
     {
-        int mode = enabledModes_[index];
-        if (mode == FREEDV_MODE_700C)
-        {
-            freedv_set_carrier_ampl(dv, c, amp);
-        }
-        index++;
+        freedv_set_carrier_ampl(dv, c, amp);
     }
 }
 


### PR DESCRIPTION
As the subject says. Since codec2 is the one doing the checks before applying the equalizer setting, freedv-gui doesn't need to do them too. The other stuff in FreeDVInterface also doesn't do checks for the most part (except for setCarrierAmplitude() as Codec2 currently asserts on mode == 700C).