### PR TITLE
Var update for all modes using Codec 2 700C

### DIFF
--- a/src/dlg_filter.cpp
+++ b/src/dlg_filter.cpp
@@ -92,7 +92,7 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
     sbSizer_speexpp->Add(m_ckboxSpeexpp, 0, wxALIGN_LEFT, 2);
     m_ckboxSpeexpp->SetToolTip(_("Enable noise suppression, dereverberation, AGC of mic signal"));
 
-    m_ckbox700C_EQ = new wxCheckBox(this, wxID_ANY, _("700C/700D/700E Auto EQ"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    m_ckbox700C_EQ = new wxCheckBox(this, wxID_ANY, _("700C/700D/700E/800XA Auto EQ"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizer_speexpp->Add(m_ckbox700C_EQ, 0, wxALIGN_LEFT, 2);
     m_ckbox700C_EQ->SetToolTip(_("Automatic equalisation for FreeDV 700C/700D/700E Codec input audio"));
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -193,8 +193,10 @@ int FreeDVInterface::getTotalBitErrors()
 float FreeDVInterface::getVariance() const
 {
     struct CODEC2 *c2 = freedv_get_codec2(currentRxMode_);
-    assert(c2 != NULL);
-    return codec2_get_var(c2);
+    if (c2 != NULL)
+        return codec2_get_var(c2);
+    else
+        return 0.0;
 }
 
 int FreeDVInterface::getErrorPattern(short** outputPattern)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1229,13 +1229,10 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
     sprintf(syncmetric, "Sync: %3.2f", g_stats.sync_metric);
     wxString syncmetric_string(syncmetric); m_textSyncMetric->SetLabel(syncmetric_string);
 
-    // Codec 2 700C VQ "auto EQ" equaliser variance
-    int currentMode = freedvInterface.getCurrentMode();
-    if ((currentMode == FREEDV_MODE_700C) || (currentMode == FREEDV_MODE_700D) || (currentMode == FREEDV_MODE_700E)) {
-        auto var = freedvInterface.getVariance();
-        char var_str[80]; sprintf(var_str, "Var: %4.1f", var);
-        wxString var_string(var_str); m_textCodec2Var->SetLabel(var_string);
-    }
+    // Codec 2 700C/D/E & 800XA VQ "auto EQ" equaliser variance
+    auto var = freedvInterface.getVariance();
+    char var_str[80]; sprintf(var_str, "Var: %4.1f", var);
+    wxString var_string(var_str); m_textCodec2Var->SetLabel(var_string);
 
     if (g_State) {
 


### PR DESCRIPTION
freedv-gui side of https://github.com/drowe67/codec2/pull/196

I tested all modes using full duplex as per https://github.com/drowe67/codec2/pull/194 - Var was updates in FreeDV 700C/D/E and 800XA, and not updated in the other modes (which still worked OK).