### PR TITLE
Reset scatter plot state when multi-RX switches modes

### DIFF
--- a/src/freedv_interface.h
+++ b/src/freedv_interface.h
@@ -86,6 +86,9 @@ public:
     
     void transmit(short mod_out[], short speech_in[]);
     void complexTransmit(short mod_out[], short speech_in[], float txOffset, int nfreedv);
+    
+    struct MODEM_STATS* getCurrentRxModemStats() { return &modemStatsList_[modemStatsIndex_]; }
+    
 private:
     int txMode_;
     int rxMode_;
@@ -96,6 +99,8 @@ private:
     std::deque<SRC_STATE*> rateConvObjs_;
     COMP txFreqOffsetPhaseRectObj_;
     std::deque<COMP*> rxFreqOffsetPhaseRectObjs_;
+    struct MODEM_STATS* modemStatsList_;
+    int modemStatsIndex_;
     
     struct freedv* currentTxMode_;
     struct freedv* currentRxMode_; 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,6 @@ int                 g_Nc;
 int                 g_mode;
 
 FreeDVInterface     freedvInterface;
-struct MODEM_STATS  g_stats;
 float               g_pwr_scale;
 int                 g_clip;
 int                 g_freedv_verbose;
@@ -861,7 +860,7 @@ void MainFrame::OnIdle(wxIdleEvent &evt) {
 // keeps CPU load reasonable
 //----------------------------------------------------------------
 void MainFrame::OnTimer(wxTimerEvent &evt)
-{
+{    
     if (evt.GetTimer().GetId() == ID_TIMER_PSKREPORTER)
     {
         // PSK Reporter timer fired; send in-progress packet.
@@ -885,6 +884,13 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
     if (freedvInterface.isRunning()) {
         int currentMode = freedvInterface.getCurrentMode();
+        if (currentMode != wxGetApp().m_prevMode)
+        {
+            // The receive mode changed, so the previous samples are no longer valid.
+            m_panelScatter->clearCurrentSamples();
+        }
+        wxGetApp().m_prevMode = currentMode;
+        
         if ((currentMode == FREEDV_MODE_800XA) || (currentMode == FREEDV_MODE_2400B) ) {
 
             /* FSK Mode - eye diagram ---------------------------------------------------------*/
@@ -892,26 +898,51 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             /* add samples row by row */
 
             int i;
-            for (i=0; i<g_stats.neyetr; i++) {
-                m_panelScatter->add_new_samples_eye(&g_stats.rx_eye[i][0], g_stats.neyesamp);
+            for (i=0; i<freedvInterface.getCurrentRxModemStats()->neyetr; i++) {
+                m_panelScatter->add_new_samples_eye(&freedvInterface.getCurrentRxModemStats()->rx_eye[i][0], freedvInterface.getCurrentRxModemStats()->neyesamp);
             }
         }
         else {
+            // Reset g_Nc accordingly.
+            switch(currentMode)
+            {
+                case FREEDV_MODE_1600:
+                    g_Nc = 16;
+                    m_panelScatter->setNc(g_Nc+1);  /* +1 for BPSK pilot */
+                    break;
+                case FREEDV_MODE_700C:
+                    /* m_FreeDV700Combine may have changed at run time */
+                    g_Nc = 14;
+                    if (wxGetApp().m_FreeDV700Combine) {
+                        m_panelScatter->setNc(g_Nc/2);  /* diversity combnation */
+                    }
+                    else {
+                        m_panelScatter->setNc(g_Nc);
+                    }
+                    break;
+                case FREEDV_MODE_700D:
+                case FREEDV_MODE_700E:
+                    g_Nc = 17; 
+                    m_panelScatter->setNc(g_Nc);
+                    break;
+                case FREEDV_MODE_2020:
+                    g_Nc = 31;
+                    m_panelScatter->setNc(g_Nc);
+                    break;
+            }
+            
             /* PSK Modes - scatter plot -------------------------------------------------------*/
-            for (r=0; r<g_stats.nr; r++) {
+            for (r=0; r<freedvInterface.getCurrentRxModemStats()->nr; r++) {
 
                 if ((currentMode == FREEDV_MODE_1600) ||
                     (currentMode == FREEDV_MODE_700D) ||
                     (currentMode == FREEDV_MODE_700E) ||
                     (currentMode == FREEDV_MODE_2020)) {
-                    m_panelScatter->add_new_samples_scatter(&g_stats.rx_symbols[r][0]);
+                    m_panelScatter->add_new_samples_scatter(&freedvInterface.getCurrentRxModemStats()->rx_symbols[r][0]);
                 }
-
-                if (currentMode == FREEDV_MODE_700C) {
+                else if (currentMode == FREEDV_MODE_700C) {
 
                     if (wxGetApp().m_FreeDV700Combine) {
-                        m_panelScatter->setNc(g_Nc/2); /* m_FreeDV700Combine may have changed at run time */
-
                         /*
                            FreeDV 700C uses diversity, so optionaly combine
                            symbols for scatter plot, as combined symbols are
@@ -923,16 +954,15 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
                         COMP rx_symbols_copy[g_Nc/2];
 
                         for(c=0; c<g_Nc/2; c++)
-                            rx_symbols_copy[c] = fcmult(0.5, cadd(g_stats.rx_symbols[r][c], g_stats.rx_symbols[r][c+g_Nc/2]));
+                            rx_symbols_copy[c] = fcmult(0.5, cadd(freedvInterface.getCurrentRxModemStats()->rx_symbols[r][c], freedvInterface.getCurrentRxModemStats()->rx_symbols[r][c+g_Nc/2]));
                         m_panelScatter->add_new_samples_scatter(rx_symbols_copy);
                     }
                     else {
-                        m_panelScatter->setNc(g_Nc); /* m_FreeDV700Combine may have changed at run time */
                         /*
                           Sometimes useful to plot carriers separately, e.g. to determine if tx carrier power is constant
                           across carriers.
                         */
-                        m_panelScatter->add_new_samples_scatter(&g_stats.rx_symbols[r][0]);
+                        m_panelScatter->add_new_samples_scatter(&freedvInterface.getCurrentRxModemStats()->rx_symbols[r][0]);
                     }
                 }
 
@@ -967,16 +997,16 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
     // Demod states -----------------------------------------------------------------------
 
-    m_panelTimeOffset->add_new_sample(0, (float)g_stats.rx_timing/FDMDV_NOM_SAMPLES_PER_FRAME);
+    m_panelTimeOffset->add_new_sample(0, (float)freedvInterface.getCurrentRxModemStats()->rx_timing/FDMDV_NOM_SAMPLES_PER_FRAME);
     m_panelTimeOffset->Refresh();
 
-    m_panelFreqOffset->add_new_sample(0, g_stats.foff);
+    m_panelFreqOffset->add_new_sample(0, freedvInterface.getCurrentRxModemStats()->foff);
     m_panelFreqOffset->Refresh();
 
     // SNR text box and gauge ------------------------------------------------------------
 
-    // LP filter g_stats.snr_est some more to stabilise the
-    // display. g_stats.snr_est already has some low pass filtering
+    // LP filter freedvInterface.getCurrentRxModemStats()->snr_est some more to stabilise the
+    // display. freedvInterface.getCurrentRxModemStats()->snr_est already has some low pass filtering
     // but we need it fairly fast to activate squelch.  So we
     // optionally perform some further filtering for the display
     // version of SNR.  The "Slow" checkbox controls the amount of
@@ -984,8 +1014,8 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
     float snr_limited;
     // some APIs pass us invalid values, so lets trap it rather than bombing
-    if (!(isnan(g_stats.snr_est) || isinf(g_stats.snr_est))) {
-        g_snr = m_snrBeta*g_snr + (1.0 - m_snrBeta)*g_stats.snr_est;
+    if (!(isnan(freedvInterface.getCurrentRxModemStats()->snr_est) || isinf(freedvInterface.getCurrentRxModemStats()->snr_est))) {
+        g_snr = m_snrBeta*g_snr + (1.0 - m_snrBeta)*freedvInterface.getCurrentRxModemStats()->snr_est;
     }
     snr_limited = g_snr;
     if (snr_limited < -5.0) snr_limited = -5.0;
@@ -1224,9 +1254,9 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
     sprintf(ber, "BER: %4.3f", b); wxString ber_string(ber); m_textBER->SetLabel(ber_string);
     sprintf(resyncs, "Resyncs: %d", g_resyncs); wxString resyncs_string(resyncs); m_textResyncs->SetLabel(resyncs_string);
 
-    sprintf(freqoffset, "FrqOff: %3.1f", g_stats.foff);
+    sprintf(freqoffset, "FrqOff: %3.1f", freedvInterface.getCurrentRxModemStats()->foff);
     wxString freqoffset_string(freqoffset); m_textFreqOffset->SetLabel(freqoffset_string);
-    sprintf(syncmetric, "Sync: %3.2f", g_stats.sync_metric);
+    sprintf(syncmetric, "Sync: %3.2f", freedvInterface.getCurrentRxModemStats()->sync_metric);
     wxString syncmetric_string(syncmetric); m_textSyncMetric->SetLabel(syncmetric_string);
 
     // Codec 2 700C/D/E & 800XA VQ "auto EQ" equaliser variance
@@ -1236,7 +1266,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
     if (g_State) {
 
-        sprintf(clockoffset, "ClkOff: %+-d", (int)round(g_stats.clock_offset*1E6) % 10000);
+        sprintf(clockoffset, "ClkOff: %+-d", (int)round(freedvInterface.getCurrentRxModemStats()->clock_offset*1E6) % 10000);
         wxString clockoffset_string(clockoffset); m_textClockOffset->SetLabel(clockoffset_string);
 
         // update error pattern plots if supported
@@ -1554,7 +1584,9 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
             m_rb2400b->Disable();
         }
         
+        wxGetApp().m_prevMode = g_mode;
         freedvInterface.start(g_mode, wxGetApp().m_fifoSize_ms);
+
         if (wxGetApp().m_FreeDV700ManualUnSync) {
             freedvInterface.setSync(FREEDV_SYNC_MANUAL);
         } else {
@@ -1611,7 +1643,6 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
             m_panelScatter->setEyeScatter(PLOT_SCATTER_MODE_SCATTER);
         }
 
-        modem_stats_open(&g_stats);
         int src_error;
         g_spec_src = src_new(SRC_SINC_FASTEST, 1, &src_error);
         assert(g_spec_src != NULL);
@@ -1731,7 +1762,6 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
 
         stopRxStream();
         src_delete(g_spec_src);
-        modem_stats_close(&g_stats);
 
         // FreeDV clean up
         delete[] g_error_hist;
@@ -2527,7 +2557,7 @@ void txRxProcessing()
             nspec = nout;
         }
 
-        modem_stats_get_rx_spectrum(&g_stats, rx_spec, rx_fdm, nspec);
+        modem_stats_get_rx_spectrum(freedvInterface.getCurrentRxModemStats(), rx_spec, rx_fdm, nspec);
 
         // Average rx spectrum data using a simple IIR low pass filter
 
@@ -2548,7 +2578,7 @@ void txRxProcessing()
             // Write 20ms chunks of input samples for modem rx processing
             g_State = freedvInterface.processRxAudio(
                 infreedv, nfreedv, cbData->rxoutfifo, g_channel_noise, wxGetApp().m_noise_snr, 
-                g_RxFreqOffsetHz, &g_stats, &g_sig_pwr_av);
+                g_RxFreqOffsetHz, freedvInterface.getCurrentRxModemStats(), &g_sig_pwr_av);
   
             // Read 20ms chunk of samples from modem rx processing,
             // this will typically be decoded output speech, and is

--- a/src/main.h
+++ b/src/main.h
@@ -350,6 +350,8 @@ class MainApp : public wxApp
 
         bool       m_txRxThreadHighPriority;
 
+        int                     m_prevMode;
+
     protected:
 };
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -16,7 +16,6 @@ extern int   g_split;
 extern int   g_tx;
 extern int   g_State, g_prev_State;
 extern FreeDVInterface freedvInterface;
-extern struct MODEM_STATS  g_stats;
 extern bool g_queueResync;
 extern short *g_error_hist, *g_error_histn;
 extern int g_resyncs;
@@ -534,7 +533,7 @@ void MainFrame::OnTogBtnAnalogClick (wxCommandEvent& event)
     }
 
     g_State = g_prev_State = 0;
-    g_stats.snr_est = 0;
+    freedvInterface.getCurrentRxModemStats()->snr_est = 0;
 
     event.Skip();
 }

--- a/src/plot_scatter.cpp
+++ b/src/plot_scatter.cpp
@@ -77,26 +77,6 @@ void PlotScatter::draw(wxGraphicsContext* ctx)
     int   i,j;
     int   x;
     int   y;
-    wxColour sym_to_colour[] = {wxColor(0,0,255), 
-                                wxColor(0,255,0),
-                                wxColor(0,255,255),
-                                wxColor(255,0,0),
-                                wxColor(255,0,255), 
-                                wxColor(255,255,0),
-                                wxColor(255,255,255),
-                                wxColor(0,0,255), 
-                                wxColor(0,255,0),
-                                wxColor(0,255,255),
-                                wxColor(255,0,0),
-                                wxColor(255,0,255), 
-                                wxColor(255,255,0),
-                                wxColor(255,255,255),
-                                wxColor(0,0,255), 
-                                wxColor(0,255,0),
-                                wxColor(0,255,255),
-                                wxColor(255,0,0),
-                                wxColor(255,0,255)
-    };
 
     m_rCtrl = GetClientRect();
     m_rGrid = m_rCtrl;

--- a/src/plot_scatter.cpp
+++ b/src/plot_scatter.cpp
@@ -155,7 +155,9 @@ void PlotScatter::draw(wxGraphicsContext* ctx)
             {
                 pen.SetColour(DARK_GREEN_COLOR);
                 ctx->SetPen(pen);
-                ctx->StrokeLine(x, y, x, y);
+                wxGraphicsPath path = ctx->CreatePath();
+                path.AddCircle(x, y, 1);
+                ctx->DrawPath(path);
             }
         }
     }

--- a/src/plot_scatter.cpp
+++ b/src/plot_scatter.cpp
@@ -94,31 +94,36 @@ void PlotScatter::draw(wxGraphicsContext* ctx)
 
     if (mode == PLOT_SCATTER_MODE_SCATTER) {
 
-        // automatically scale, first measure the maximum value
+        // automatically scale, first measure the maximum magnitude, in other words
+        // the max distance from the origin
 
-        float max_xy = 1E-12;
+        float max_mag = 1E-12;
         float real,imag,mag;
         for(i=0; i< scatterMemSyms; i++) {
             real = fabs(m_mem[i].real);
             imag = fabs(m_mem[i].imag);
             mag = sqrt(pow(real,2) + pow(imag, 2));
-            if (mag > max_xy)
+            if (mag > max_mag)
             {
-                max_xy = mag;
+                max_mag = mag;
             }
         }
 
-        // smooth it out and set a lower limit to prevent divide by 0 issues
+        // the maximum side to side distance needs to be at least twice the maximum distance 
+        // from the centre, add a little extra so the scatter blobs are just inside the outer edges 
 
-        m_filter_max_xy = BETA*m_filter_max_xy + (1 - BETA)*2.5*max_xy;
+        float max_xy = 2.5*max_mag;
+        
+        // smooth the estimate so we don't get rapid changes in the scaling due to short term 
+        // noise fluctuations. Set a lower limit to prevent divide by 0 issues
+
+        m_filter_max_xy = BETA*m_filter_max_xy + (1 - BETA)*max_xy;
         if (m_filter_max_xy < 0.001)
             m_filter_max_xy = 0.001;
 
-        // quantise to log steps to prevent scatter scaling bobbing about too
-        // much as scaling varies
+        // quantise to log steps to prevent scatter scaling bobbing about too much 
 
         float quant_m_filter_max_xy = exp(floor(0.5+log(m_filter_max_xy)));
-        //printf("max_xy: %f m_filter_max_xy: %f quant_m_filter_max_xy: %f\n", max_xy, m_filter_max_xy, quant_m_filter_max_xy);
 
         x_scale = (float)m_rGrid.GetWidth()/quant_m_filter_max_xy;
         y_scale = (float)m_rGrid.GetHeight()/quant_m_filter_max_xy;
@@ -137,6 +142,9 @@ void PlotScatter::draw(wxGraphicsContext* ctx)
                 ctx->SetPen(pen);
                 wxGraphicsPath path = ctx->CreatePath();
                 path.AddCircle(x, y, 1);
+                // Uncomment to show boundaries of plot:
+                // path.AddCircle(PLOT_BORDER+XLEFT_OFFSET, PLOT_BORDER, 2); 
+                // path.AddCircle(m_rGrid.GetWidth()+PLOT_BORDER+XLEFT_OFFSET, m_rGrid.GetHeight()+PLOT_BORDER, 2);
                 ctx->DrawPath(path);
             }
         }
@@ -267,16 +275,18 @@ void PlotScatter::OnShow(wxShowEvent& event)
 {
 }
 
-//----------------------------------------------------------------
-// Ensures that points stay within the bounding box.
-//----------------------------------------------------------------
+/*----------------------------------------------------------------
+  Ensure that points stay within the bounding box:
+    upper LH bounding point (PLOT_BORDER+XLEFT_OFFSET, PLOT_BORDER)
+    lower RH bounding point (PLOT_BORDER+XLEFT_OFFSET + GetWidth(), PLOT_BORDER + GetHeight())
+----------------------------------------------------------------*/
 bool PlotScatter::pointsInBounds_(int x, int y)
 {
-    bool inBounds = true;
-    inBounds = !(x <= (PLOT_BORDER + XLEFT_OFFSET));
-    inBounds = inBounds && !(x >= m_rGrid.GetWidth());
-    inBounds = inBounds && !(y <= PLOT_BORDER);
-    inBounds = inBounds && !(y >= m_rGrid.GetHeight());
+    bool inBounds;
+    inBounds = x >= PLOT_BORDER + XLEFT_OFFSET;
+    inBounds = inBounds && x <= PLOT_BORDER + XLEFT_OFFSET + m_rGrid.GetWidth();
+    inBounds = inBounds && y >= PLOT_BORDER;
+    inBounds = inBounds && y <= PLOT_BORDER + m_rGrid.GetHeight();
     
     return inBounds;
 }

--- a/src/plot_scatter.cpp
+++ b/src/plot_scatter.cpp
@@ -36,15 +36,7 @@ BEGIN_EVENT_TABLE(PlotScatter, PlotPanel)
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 PlotScatter::PlotScatter(wxWindow* parent) : PlotPanel(parent)
 {
-    int i;
-
-    for(i=0; i < SCATTER_MEM_SYMS_MAX; i++)
-    {
-        m_mem[i].real = 0.0;
-        m_mem[i].imag = 0.0;
-    }
-
-    m_filter_max_xy = m_filter_max_y = 0.1;
+    clearCurrentSamples();
 
     // defaults so we start off with something sensible
 
@@ -64,6 +56,15 @@ void PlotScatter::setNc(int Nc) {
     assert(Nsym <= (MODEM_STATS_NC_MAX+1));
     scatterMemSyms = ((int)(SCATTER_MEM_SECS*(Nsym/DT)));
     assert(scatterMemSyms <= SCATTER_MEM_SYMS_MAX);
+}
+
+void PlotScatter::clearCurrentSamples() {
+    m_filter_max_xy = m_filter_max_y = 0.1;
+    for(int i=0; i < SCATTER_MEM_SYMS_MAX; i++)
+    {
+        m_mem[i].real = 0.0;
+        m_mem[i].imag = 0.0;
+    }
 }
 
 //----------------------------------------------------------------

--- a/src/plot_scatter.h
+++ b/src/plot_scatter.h
@@ -37,10 +37,11 @@ class PlotScatter : public PlotPanel
     public:
         PlotScatter(wxWindow* parent);
         ~PlotScatter(){};
-    void add_new_samples_scatter(COMP samples[]);
-    void add_new_samples_eye(float samples[], int n);
-    void setNc(int Nc);
+        void add_new_samples_scatter(COMP samples[]);
+        void add_new_samples_eye(float samples[], int n);
+        void setNc(int Nc);
         void setEyeScatter(int eye_mode) {mode = eye_mode;}
+        void clearCurrentSamples();
 
     protected:
         int  mode;


### PR DESCRIPTION
As reported on the digitalvoice list, 700C scatter plots have odd behavior when multi-RX is on:

![Screenshot from 2021-07-12 19-18-39](https://user-images.githubusercontent.com/449242/125423187-07bc8c26-b7d1-48a3-bc2d-69eee3262605.png)

On investigation, it was discovered that state needed by PlotScatter has to be reset whenever FreeDV starts receiving a new mode. This PR implements that functionality.

(This is not part of ms-optimization due to the significant code changes this requires.)