### PR TITLE
Resolves crash and UI issues with "click to tune" feature.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,7 +326,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent)
     {
         // Add Waterfall Plot window
         m_panelWaterfall = new PlotWaterfall((wxFrame*) m_auiNbookCtrl, false, 0);
-        m_panelWaterfall->SetToolTip(_("Left click to tune"));
+        m_panelWaterfall->SetToolTip(_("Double-click to tune"));
         m_auiNbookCtrl->AddPage(m_panelWaterfall, _("Waterfall"), true, wxNullBitmap);
     }
     if(wxGetApp().m_show_spect)
@@ -334,7 +334,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent)
         // Add Spectrum Plot window
         m_panelSpectrum = new PlotSpectrum((wxFrame*) m_auiNbookCtrl, g_avmag,
                                            MODEM_STATS_NSPEC*((float)MAX_F_HZ/MODEM_STATS_MAX_F_HZ));
-        m_panelSpectrum->SetToolTip(_("Left click to tune"));
+        m_panelSpectrum->SetToolTip(_("Double-click to tune"));
         m_auiNbookCtrl->AddPage(m_panelSpectrum, _("Spectrum"), true, wxNullBitmap);
     }
     if(wxGetApp().m_show_scatter)

--- a/src/plot_spectrum.cpp
+++ b/src/plot_spectrum.cpp
@@ -30,6 +30,7 @@ BEGIN_EVENT_TABLE(PlotSpectrum, PlotPanel)
     EVT_LEFT_DOWN       (PlotSpectrum::OnMouseLeftDown)
     EVT_LEFT_DCLICK     (PlotSpectrum::OnMouseLeftDoubleClick)
     EVT_LEFT_UP         (PlotSpectrum::OnMouseLeftUp)
+    EVT_RIGHT_DCLICK    (PlotSpectrum::OnMouseRightDoubleClick)
     EVT_MOUSEWHEEL      (PlotSpectrum::OnMouseWheelMoved)
     EVT_PAINT           (PlotSpectrum::OnPaint)
     EVT_SHOW            (PlotSpectrum::OnShow)
@@ -232,9 +233,9 @@ void PlotSpectrum::drawGraticule(wxGraphicsContext* ctx)
 }
 
 //-------------------------------------------------------------------------
-// OnMouseDown()
+// OnDoubleClickCommon()
 //-------------------------------------------------------------------------
-void PlotSpectrum::OnMouseLeftDoubleClick(wxMouseEvent& event)
+void PlotSpectrum::OnDoubleClickCommon(wxMouseEvent& event)
 {
     m_mouseDown = true;
     wxClientDC dc(this);
@@ -254,4 +255,20 @@ void PlotSpectrum::OnMouseLeftDoubleClick(wxMouseEvent& event)
 
         clickTune(clickFreq);
     }
+}
+
+//-------------------------------------------------------------------------
+// OnLeftMouseDown()
+//-------------------------------------------------------------------------
+void PlotSpectrum::OnMouseLeftDoubleClick(wxMouseEvent& event)
+{
+    OnDoubleClickCommon(event);
+}
+
+//-------------------------------------------------------------------------
+// OnRightMouseDown()
+//-------------------------------------------------------------------------
+void PlotSpectrum::OnMouseRightDoubleClick(wxMouseEvent& event)
+{
+    OnDoubleClickCommon(event);
 }

--- a/src/plot_spectrum.h
+++ b/src/plot_spectrum.h
@@ -42,6 +42,7 @@ class PlotSpectrum : public PlotPanel
         void        drawGraticule(wxGraphicsContext* ctx);
         void        draw(wxGraphicsContext* ctx);
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
+        void        OnMouseRightDoubleClick(wxMouseEvent& event);
 
    private:
         float       m_rxFreq;
@@ -51,6 +52,8 @@ class PlotSpectrum : public PlotPanel
         int         m_n_magdB;  
         bool        m_clickTune;
 
+        void        OnDoubleClickCommon(wxMouseEvent& event);
+        
         DECLARE_EVENT_TABLE()
 };
 

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -32,6 +32,7 @@ BEGIN_EVENT_TABLE(PlotWaterfall, PlotPanel)
     EVT_MOTION          (PlotWaterfall::OnMouseMove)
     EVT_LEFT_DCLICK     (PlotWaterfall::OnMouseLeftDoubleClick)
     EVT_LEFT_UP         (PlotWaterfall::OnMouseLeftUp)
+    EVT_RIGHT_DCLICK    (PlotWaterfall::OnMouseRightDoubleClick)
     EVT_MOUSEWHEEL      (PlotWaterfall::OnMouseWheelMoved)
     EVT_SIZE            (PlotWaterfall::OnSize)
     EVT_SHOW            (PlotWaterfall::OnShow)
@@ -412,9 +413,9 @@ void PlotWaterfall::plotPixelData()
 }
 
 //-------------------------------------------------------------------------
-// OnMouseLeftDown()
+// OnDoubleClickCommon()
 //-------------------------------------------------------------------------
-void PlotWaterfall::OnMouseLeftDoubleClick(wxMouseEvent& event)
+void PlotWaterfall::OnDoubleClickCommon(wxMouseEvent& event)
 {
     m_mouseDown = true;
     wxClientDC dc(this);
@@ -436,4 +437,19 @@ void PlotWaterfall::OnMouseLeftDoubleClick(wxMouseEvent& event)
     }
 }
 
+//-------------------------------------------------------------------------
+// OnMouseLeftDown()
+//-------------------------------------------------------------------------
+void PlotWaterfall::OnMouseLeftDoubleClick(wxMouseEvent& event)
+{
+    OnDoubleClickCommon(event);
+}
+
+//-------------------------------------------------------------------------
+// OnMouseRightDown()
+//-------------------------------------------------------------------------
+void PlotWaterfall::OnMouseRightDoubleClick(wxMouseEvent& event)
+{
+    OnDoubleClickCommon(event);
+}
 

--- a/src/plot_waterfall.h
+++ b/src/plot_waterfall.h
@@ -56,6 +56,7 @@ class PlotWaterfall : public PlotPanel
         void        draw(wxGraphicsContext* gc);
         void        plotPixelData();
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
+        void        OnMouseRightDoubleClick(wxMouseEvent& event);
 
     private:
         float       m_dT;
@@ -69,6 +70,8 @@ class PlotWaterfall : public PlotPanel
         wxBitmap* m_fullBmp;
         int m_imgHeight;
         int m_imgWidth;
+        
+        void        OnDoubleClickCommon(wxMouseEvent& event);
 
         DECLARE_EVENT_TABLE()
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -10,9 +10,9 @@
 // work out a way to do this without globals.
 extern float           g_RxFreqOffsetHz;
 extern float           g_TxFreqOffsetHz;
-extern int            *g_split;
+extern int             g_split;
 extern FreeDVInterface freedvInterface;
-extern int   g_tx;
+extern int             g_tx;
 
 void clickTune(float freq) {
 


### PR DESCRIPTION
Fixes #155 by doing the following:

1. Make definition of g_split consistent (util.cpp).
2. Update tooltips in main window to reflect existing click to tune behavior.

Thanks to @Tyrbiter for the patch!