### PR TITLE
Update mode display in status bar on PTT start/stop.

### DIFF
--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -259,6 +259,7 @@ void Hamlib::enable_mode_detection(wxStaticText* statusBox, bool vhfUhfMode)
     {
         m_modeBox->SetLabel(wxT("unk"));
         m_modeBox->Enable(false);
+        m_modeBox->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
         m_modeBox = NULL;
     }
     else
@@ -292,6 +293,7 @@ void Hamlib::disable_mode_detection()
         // Disable control.
         m_modeBox->SetLabel(wxT("unk"));
         m_modeBox->Enable(false);
+        m_modeBox->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
         m_modeBox = NULL;
     }
 }

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -487,7 +487,8 @@ void MainFrame::togglePTT(void) {
         Hamlib *hamlib = wxGetApp().m_hamlib;
         wxString hamlibError;
         if (wxGetApp().m_boolHamlibUseForPTT && hamlib != NULL) {
-            if (hamlib->ptt(g_tx, hamlibError) == false) {
+            // Update mode display on the bottom of the main UI.
+            if (hamlib->update_frequency_and_mode() != 0 || hamlib->ptt(g_tx, hamlibError) == false) {
                 wxMessageBox(wxString("Hamlib PTT Error: ") + hamlibError, wxT("Error"), wxOK | wxICON_ERROR, this);
             }
         }


### PR DESCRIPTION
Per request on digitalvoice mailing list, this performs an update of the mode display whenever the user pushes the PTT button. This allows earlier notification of incorrect mode usage (vs. waiting for stop/start or a PSK Reporter report).