### PR TITLE
Remove unnecessary error message indicating that PSK Reporter will be disabled

### DIFF
--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -173,14 +173,7 @@ bool MainFrame::OpenHamlibRig() {
     bool status = wxGetApp().m_hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate, wxGetApp().m_intHamlibIcomCIVHex);
     if (status == false)
     {
-        if (wxGetApp().m_psk_enable)
-        {
-            wxMessageBox("Couldn't connect to Radio with hamlib. PSK Reporter reporting will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
-        }
-        else
-        {
-            wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
-        }
+        wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);
     }
     else
     {


### PR DESCRIPTION
Oops, forgot about this one. Since we're no longer disabling PSK Reporter if Hamlib isn't working/enabled, we can remove this message.

\+ @drowe67 