### PR TITLE
Fix off by one error preventing UTF8 encoded callsign from being null terminated.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1606,8 +1606,9 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         }
         else
         {
-            char temp[1024];
-            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), wxGetApp().m_psk_callsign.Length() + 1);
+            char temp[9];
+            memset(temp, 0, 10);
+            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), 8);
             fprintf(stderr, "Setting callsign to %s\n", temp);
             freedvInterface.setReliableText(temp);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1607,7 +1607,7 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         else
         {
             char temp[1024];
-            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), wxGetApp().m_psk_callsign.Length());
+            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), wxGetApp().m_psk_callsign.Length() + 1);
             fprintf(stderr, "Setting callsign to %s\n", temp);
             freedvInterface.setReliableText(temp);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1607,8 +1607,8 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
         else
         {
             char temp[9];
-            memset(temp, 0, 10);
-            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), 8);
+            memset(temp, 0, 9);
+            strncpy(temp, wxGetApp().m_psk_callsign.ToUTF8(), 8); // One less than the size of temp to ensure we don't overwrite the null.
             fprintf(stderr, "Setting callsign to %s\n", temp);
             freedvInterface.setReliableText(temp);
         }


### PR DESCRIPTION
Looks like an off by one error in freedv-gui was causing my callsign to be reported incorrectly by others on PSK Reporter. This PR fixes that issue.

\+ @drowe67