### PR TITLE
Resolve heap overflow during txCallback triggered by BT usage.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3035,19 +3035,36 @@ int MainFrame::txCallback(
 
     if (wptr) {
         if (codec2_fifo_read(cbData->outfifo2, outdata, framesPerBuffer) == 0) {
-
-            // write signal to both channels */
-            for(i = 0; i < framesPerBuffer; i++, wptr += 2) {
-                wptr[0] = outdata[i];
-                wptr[1] = outdata[i];
+            if (cbData->outputChannels2 == 2)
+            {
+                // write signal to both channels */
+                for(i = 0; i < framesPerBuffer; i++, wptr += 2) {
+                    wptr[0] = outdata[i];
+                    wptr[1] = outdata[i];
+                }
+            }
+            else
+            {
+                for(i = 0; i < framesPerBuffer; i++, wptr++) {
+                    wptr[0] = outdata[i];
+                }
             }
         }
         else {
             g_outfifo2_empty++;
             // zero output if no data available
-            for(i = 0; i < framesPerBuffer; i++, wptr += 2) {
-                wptr[0] = 0;
-                wptr[1] = 0;
+            if (cbData->outputChannels2 == 2)
+            {
+                for(i = 0; i < framesPerBuffer; i++, wptr += 2) {
+                    wptr[0] = 0;
+                    wptr[1] = 0;
+                }
+            }
+            else
+            {
+                for(i = 0; i < framesPerBuffer; i++, wptr++) {
+                    wptr[0] = 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Possible fix for #144. I noticed the following AddressSanitizer output while trying to use my Bluetooth headset with FreeDV:

```
rig.c(2173):rig_get_freq return(0)
    #0 0x105eff12d in MainFrame::txCallback(void const*, void*, unsigned long, PaStreamCallbackTimeInfo const*, unsigned long, void*) main.cpp:3047
    #1 0x1073cf8dc in AdaptingOutputOnlyProcess+0x22c (libportaudio.2.dylib:x86_64+0x88dc)
    #2 0x1073ceb35 in PaUtil_EndBufferProcessing+0x1a7 (libportaudio.2.dylib:x86_64+0x7b35)
    #3 0x1073d38b3 in AudioIOProc+0x532 (libportaudio.2.dylib:x86_64+0xc8b3)
    #4 0x11b231a7d  (CoreAudio:x86_64+0xea7d)
    #5 0x11b257993  (CoreAudio:x86_64+0x34993)
    #6 0x11b234c86  (CoreAudio:x86_64+0x11c86)
    #7 0x7fff21e59a8b in invocation function for block in HALC_ProxyIOContext::HALC_ProxyIOContext(unsigned int, unsigned int)+0x1985 (CoreAudio:x86_64+0x17ea8b)
    #8 0x7fff21ff4b03 in HALB_IOThread::Entry(void*)+0x47 (CoreAudio:x86_64+0x319b03)
    #9 0x7fff204de8fb in _pthread_start+0xdf (libsystem_pthread.dylib:x86_64+0x68fb)
    #10 0x7fff204da442 in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x2442)

0x615000179d00 is located 0 bytes to the right of 512-byte region [0x615000179b00,0x615000179d00)
allocated by thread T0 here:
    #0 0x1086d6460 in wrap_malloc+0xa0 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x48460)
    #1 0x1073ce40a in PaUtil_InitializeBufferProcessor+0x3d8 (libportaudio.2.dylib:x86_64+0x740a)
    #2 0x1073d1bbe in OpenStream+0x6b5 (libportaudio.2.dylib:x86_64+0xabbe)
    #3 0x1073cd944 in Pa_OpenStream+0x104 (libportaudio.2.dylib:x86_64+0x6944)
    #4 0x105f15d69 in PortAudioWrap::streamOpen() pa_wrapper.cpp:64
    #5 0x105efbb36 in MainFrame::startRxStream() main.cpp:2424
    #6 0x105ef267e in MainFrame::OnTogBtnOnOff(wxCommandEvent&) main.cpp:1686
    #7 0x1065a727b in wxEvtHandler::SearchDynamicEventTable(wxEvent&)+0x11b (freedv:x86_64+0x1007c327b)
    #8 0x1065a6faa in wxEvtHandler::ProcessEventLocally(wxEvent&)+0x3a (freedv:x86_64+0x1007c2faa)
    #9 0x1065a6e5f in wxEvtHandler::ProcessEvent(wxEvent&)+0x5f (freedv:x86_64+0x1007c2e5f)
    #10 0x1065a74eb in wxEvtHandler::SafelyProcessEvent(wxEvent&)+0xb (freedv:x86_64+0x1007c34eb)
    #11 0x1062def5f in wxToggleButton::OSXHandleClicked(double)+0xaf (freedv:x86_64+0x1004faf5f)
    #12 0x10636aa75 in wxWidgetCocoaImpl::controlAction(NSView*, void*, void*)+0x55 (freedv:x86_64+0x100586a75)
    #13 0x106365e04 in wxOSX_controlAction(NSView*, objc_selector*, objc_object*)+0x54 (freedv:x86_64+0x100581e04)
    #14 0x7fff22ffe2ba in -[NSApplication(NSResponder) sendAction:to:from:]+0x11f (AppKit:x86_64+0x2602ba)
    #15 0x7fff22ffe15e in -[NSControl sendAction:to:]+0x55 (AppKit:x86_64+0x26015e)
    #16 0x7fff22ffe090 in __26-[NSCell _sendActionFrom:]_block_invoke+0x82 (AppKit:x86_64+0x260090)
    #17 0x7fff22ffdf97 in -[NSCell _sendActionFrom:]+0xaa (AppKit:x86_64+0x25ff97)
    #18 0x7fff22ffdedd in -[NSButtonCell _sendActionFrom:]+0x5f (AppKit:x86_64+0x25fedd)
    #19 0x7fff22ffafc6 in NSControlTrackMouse+0x71b (AppKit:x86_64+0x25cfc6)
    #20 0x7fff22ffa882 in -[NSCell trackMouse:inRect:ofView:untilMouseUp:]+0x81 (AppKit:x86_64+0x25c882)
    #21 0x7fff22ffa749 in -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]+0x2b8 (AppKit:x86_64+0x25c749)
    #22 0x7fff22ff9a71 in -[NSControl mouseDown:]+0x2d1 (AppKit:x86_64+0x25ba71)
    #23 0x10636698a in wxWidgetCocoaImpl::mouseEvent(NSEvent*, NSView*, void*)+0x1ea (freedv:x86_64+0x10058298a)
    #24 0x106365125 in wxOSX_mouseEvent(NSView*, objc_selector*, NSEvent*)+0x75 (freedv:x86_64+0x100581125)
    #25 0x7fff22ff7e5d in -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]+0x1360 (AppKit:x86_64+0x259e5d)
    #26 0x7fff22f67647 in -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]+0xa21 (AppKit:x86_64+0x1c9647)
    #27 0x7fff22f66a05 in -[NSWindow(NSEventRouting) sendEvent:]+0x15a (AppKit:x86_64+0x1c8a05)
    #28 0x1063467a8 in -[wxNSWindow sendEvent:]+0xe8 (freedv:x86_64+0x1005627a8)
    #29 0x7fff22f64e13 in -[NSApplication(NSEvent) sendEvent:]+0x15f (AppKit:x86_64+0x1c6e13)

Thread T17 created by T0 here:
    #0 0x1086d058a in wrap_pthread_create+0x5a (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4258a)
    #1 0x7fff21ff5084 in HALB_IOThread::StartAndWaitForState(unsigned int)+0x444 (CoreAudio:x86_64+0x31a084)
    #2 0x7fff21e5c020 in HALC_ProxyIOContext::_StartIOProc(int (*)(unsigned int, AudioTimeStamp const*, AudioBufferList const*, AudioTimeStamp const*, AudioBufferList*, AudioTimeStamp const*, void*))+0xa8 (CoreAudio:x86_64+0x181020)
    #3 0x7fff21e250bd in HAL_HardwarePlugIn_DeviceStart(AudioHardwarePlugInInterface**, unsigned int, int (*)(unsigned int, AudioTimeStamp const*, AudioBufferList const*, AudioTimeStamp const*, AudioBufferList*, AudioTimeStamp const*, void*))+0x2ec (CoreAudio:x86_64+0x14a0bd)
    #4 0x7fff22218eeb in HALDevice::StartIOProc(int (*)(unsigned int, AudioTimeStamp const*, AudioBufferList const*, AudioTimeStamp const*, AudioBufferList*, AudioTimeStamp const*, void*))+0x55 (CoreAudio:x86_64+0x53deeb)
    #5 0x7fff21ce3e40 in AudioDeviceStart+0x233 (CoreAudio:x86_64+0x8e40)
    #6 0x11b23447f  (CoreAudio:x86_64+0x1147f)
    #7 0x11b23361f  (CoreAudio:x86_64+0x1061f)
    #8 0x11b3095bf  (CoreAudio:x86_64+0xe65bf)
    #9 0x1073d221a in StartStream+0x71 (libportaudio.2.dylib:x86_64+0xb21a)
    #10 0x105f15dc7 in PortAudioWrap::streamStart() pa_wrapper.cpp:81
    #11 0x105efc24f in MainFrame::startRxStream() main.cpp:2448
    #12 0x105ef267e in MainFrame::OnTogBtnOnOff(wxCommandEvent&) main.cpp:1686
    #13 0x1065a727b in wxEvtHandler::SearchDynamicEventTable(wxEvent&)+0x11b (freedv:x86_64+0x1007c327b)
    #14 0x1065a6faa in wxEvtHandler::ProcessEventLocally(wxEvent&)+0x3a (freedv:x86_64+0x1007c2faa)
    #15 0x1065a6e5f in wxEvtHandler::ProcessEvent(wxEvent&)+0x5f (freedv:x86_64+0x1007c2e5f)
    #16 0x1065a74eb in wxEvtHandler::SafelyProcessEvent(wxEvent&)+0xb (freedv:x86_64+0x1007c34eb)
    #17 0x1062def5f in wxToggleButton::OSXHandleClicked(double)+0xaf (freedv:x86_64+0x1004faf5f)
    #18 0x10636aa75 in wxWidgetCocoaImpl::controlAction(NSView*, void*, void*)+0x55 (freedv:x86_64+0x100586a75)
    #19 0x106365e04 in wxOSX_controlAction(NSView*, objc_selector*, objc_object*)+0x54 (freedv:x86_64+0x100581e04)
    #20 0x7fff22ffe2ba in -[NSApplication(NSResponder) sendAction:to:from:]+0x11f (AppKit:x86_64+0x2602ba)
    #21 0x7fff22ffe15e in -[NSControl sendAction:to:]+0x55 (AppKit:x86_64+0x26015e)
    #22 0x7fff22ffe090 in __26-[NSCell _sendActionFrom:]_block_invoke+0x82 (AppKit:x86_64+0x260090)
    #23 0x7fff22ffdf97 in -[NSCell _sendActionFrom:]+0xaa (AppKit:x86_64+0x25ff97)
    #24 0x7fff22ffdedd in -[NSButtonCell _sendActionFrom:]+0x5f (AppKit:x86_64+0x25fedd)
    #25 0x7fff22ffafc6 in NSControlTrackMouse+0x71b (AppKit:x86_64+0x25cfc6)
    #26 0x7fff22ffa882 in -[NSCell trackMouse:inRect:ofView:untilMouseUp:]+0x81 (AppKit:x86_64+0x25c882)
    #27 0x7fff22ffa749 in -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]+0x2b8 (AppKit:x86_64+0x25c749)
    #28 0x7fff22ff9a71 in -[NSControl mouseDown:]+0x2d1 (AppKit:x86_64+0x25ba71)
    #29 0x10636698a in wxWidgetCocoaImpl::mouseEvent(NSEvent*, NSView*, void*)+0x1ea (freedv:x86_64+0x10058298a)
    #30 0x106365125 in wxOSX_mouseEvent(NSView*, objc_selector*, NSEvent*)+0x75 (freedv:x86_64+0x100581125)
    #31 0x7fff22ff7e5d in -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]+0x1360 (AppKit:x86_64+0x259e5d)
    #32 0x7fff22f67647 in -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]+0xa21 (AppKit:x86_64+0x1c9647)
    #33 0x7fff22f66a05 in -[NSWindow(NSEventRouting) sendEvent:]+0x15a (AppKit:x86_64+0x1c8a05)
    #34 0x1063467a8 in -[wxNSWindow sendEvent:]+0xe8 (freedv:x86_64+0x1005627a8)
    #35 0x7fff22f64e13 in -[NSApplication(NSEvent) sendEvent:]+0x15f (AppKit:x86_64+0x1c6e13)
    #36 0x10629d199 in -[wxNSApplication sendEvent:]+0xa9 (freedv:x86_64+0x1004b9199)
    #37 0x7fff2323dbe0 in -[NSApplication _handleEvent:]+0x40 (AppKit:x86_64+0x49fbe0)
    #38 0x7fff22dcdc8d in -[NSApplication run]+0x26e (AppKit:x86_64+0x2fc8d)
    #39 0x10633579a in wxGUIEventLoop::OSXDoRun()+0xaa (freedv:x86_64+0x10055179a)
    #40 0x1065796ec in wxCFEventLoop::DoRun()+0x1c (freedv:x86_64+0x1007956ec)
    #41 0x1064d245d in wxEventLoopBase::Run()+0x9d (freedv:x86_64+0x1006ee45d)
    #42 0x10649dc82 in wxAppConsoleBase::MainLoop()+0x62 (freedv:x86_64+0x1006b9c82)
    #43 0x1062e5589 in wxApp::OnRun()+0x19 (freedv:x86_64+0x100501589)
    #44 0x106513c27 in wxEntry(int&, wchar_t**)+0x37 (freedv:x86_64+0x10072fc27)
    #45 0x105ec6943 in main main.cpp:180
    #46 0x7fff204f9f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)

SUMMARY: AddressSanitizer: heap-buffer-overflow main.cpp:3047 in MainFrame::txCallback(void const*, void*, unsigned long, PaStreamCallbackTimeInfo const*, unsigned long, void*)
Shadow bytes around the buggy address:
  0x1c2a0002f350: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c2a0002f360: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c2a0002f370: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c2a0002f380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c2a0002f390: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x1c2a0002f3a0:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c2a0002f3b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2a0002f3c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2a0002f3d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2a0002f3e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2a0002f3f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==41332==ABORTING
Abort trap: 6
```

The fix in this PR seems to be working well so far, FWIW. I'm not sure yet if there are any other factors affecting the operation of BT headsets.