### PR TITLE
Make multi-RX in single threaded mode the default.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,8 +440,8 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent)
     // PTT -------------------------------------------------------------------
 
     wxGetApp().m_boolHalfDuplex     = pConfig->ReadBool(wxT("/Rig/HalfDuplex"),     true);
-    wxGetApp().m_boolMultipleRx     = pConfig->ReadBool(wxT("/Rig/MultipleRx"),     false);
-    wxGetApp().m_boolSingleRxThread = pConfig->ReadBool(wxT("/Rig/SingleRxThread"), false);
+    wxGetApp().m_boolMultipleRx     = pConfig->ReadBool(wxT("/Rig/MultipleRx"),     true);
+    wxGetApp().m_boolSingleRxThread = pConfig->ReadBool(wxT("/Rig/SingleRxThread"), true);
     wxGetApp().m_leftChannelVoxTone = pConfig->ReadBool("/Rig/leftChannelVoxTone",  false);
 
     wxGetApp().m_txtVoiceKeyerWaveFilePath = pConfig->Read(wxT("/VoiceKeyer/WaveFilePath"), wxT(""));


### PR DESCRIPTION
Per discussion with @drowe67, this makes single threaded mode the default for multi-RX.

(Additionally, this PR also makes multi-RX enabled by default. I don't think it'll hurt to do so but I can keep multi-RX itself disabled by default if desired.)