### PR TITLE
Build: Better error handling and let git ignore temporary build directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+/build_linux/
+/build_osx/
+/codec2/
+/hamlib/
+/hamlib-code/
+/LPCNet/
+/macdylibbundler/
+
+a.out
+*.o
+*.make
+*.log
+*.marks

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,8 +1,11 @@
-#!/bin/bash
+#!/usr/bin/bash
 # build_ubuntu.sh
 #
 # Build script for Ubuntu and Fedora Linux, git pulls codec2 and
 # lpcnet repos so they are available for parallel development.
+
+# Echo what you are doing, and fail if any of the steps fail:
+set -x -e
 
 export FREEDVGUIDIR=${PWD}
 export CODEC2DIR=$FREEDVGUIDIR/codec2


### PR DESCRIPTION
The `build_linux.sh` script says what it is doing and stops when encountering an error.

Directories that are constructed temporarily during the build
are now ignored by git, as we do not want to version those.

Ah, one more thing: `bash` now officially lives in `/usr/bin`, the `/bin` directory is deprecated.

Vy 73, Andreas, DJ3EI