### PR TITLE
Use CMake to generate macOS app bundle.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,11 +489,6 @@ add_subdirectory(contrib)
 
 message(STATUS "Build type will be: ${CMAKE_BUILD_TYPE}")
 
-if(APPLE)
-configure_file ("${PROJECT_SOURCE_DIR}/src/info.plist.in"
-                "${PROJECT_BINARY_DIR}/src/info.plist" )
-endif(APPLE)
-
 # Adds support for "make dist" target.
 set(ARCHIVE_NAME "freedv-${FREEDV_VERSION_MAJOR}.${FREEDV_VERSION_MINOR}.${FREEDV_VERSION_PATCH}")
 add_custom_target(dist

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -11,7 +11,7 @@ export HAMLIBDIR=$FREEDVGUIDIR/hamlib
 
 # Prerequisite: build dylibbundler
 git clone https://github.com/tmiw/macdylibbundler.git
-cd macdylibbundler && git checkout master && git pull
+cd macdylibbundler && git checkout main && git pull
 make -j4
 
 # Prerequisite: build hamlib

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -10,9 +10,9 @@ export LPCNETDIR=$FREEDVGUIDIR/LPCNet
 export HAMLIBDIR=$FREEDVGUIDIR/hamlib
 
 # Prerequisite: build dylibbundler
-git clone https://github.com/auriamg/macdylibbundler.git
+git clone https://github.com/tmiw/macdylibbundler.git
 cd macdylibbundler && git checkout master && git pull
-make
+make -j4
 
 # Prerequisite: build hamlib
 cd $FREEDVGUIDIR
@@ -20,14 +20,14 @@ git clone https://github.com/Hamlib/Hamlib.git hamlib-code
 cd hamlib-code && git checkout master && git pull
 ./bootstrap
 CFLAGS="-g -O2 -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" CXXFLAGS="-g -O2 -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" ./configure --disable-shared --prefix $HAMLIBDIR
-make
+make -j4
 make install
 
 # First build and install vanilla codec2 as we need -lcodec2 to build LPCNet
 cd $FREEDVGUIDIR
 git clone https://github.com/drowe67/codec2.git
-cd codec2 && git checkout master && git pull
-mkdir -p build_osx && cd build_osx && rm -Rf * && cmake -DBUILD_OSX_UNIVERSAL=1 .. && make
+cd codec2 && git checkout ms-reliable-text && git pull
+mkdir -p build_osx && cd build_osx && rm -Rf * && cmake -DBUILD_OSX_UNIVERSAL=1 .. && make -j4
 
 # OK, build and test LPCNet
 cd $FREEDVGUIDIR
@@ -35,14 +35,14 @@ git clone https://github.com/drowe67/LPCNet.git
 cd $LPCNETDIR && git checkout master && git pull
 mkdir  -p build_osx && cd build_osx && rm -Rf *
 cmake -DCODEC2_BUILD_DIR=$CODEC2DIR/build_osx -DBUILD_OSX_UNIVERSAL=1 ..
-make
+make -j4
 # sanity check test
 cd src && sox ../../wav/wia.wav -t raw -r 16000 - | ./lpcnet_enc -s | ./lpcnet_dec -s > /dev/null
 
 # Re-build codec2 with LPCNet and test FreeDV 2020 support
 cd $CODEC2DIR/build_osx && rm -Rf *
 cmake -DLPCNET_BUILD_DIR=$LPCNETDIR/build_osx -DBUILD_OSX_UNIVERSAL=1 ..
-make VERBOSE=1
+make VERBOSE=1 -j4
 # sanity check test
 cd src
 export LD_LIBRARY_PATH=$LPCNETDIR/build_osx/src
@@ -52,9 +52,9 @@ export LD_LIBRARY_PATH=$LPCNETDIR/build_osx/src
 cd $FREEDVGUIDIR && git pull
 mkdir  -p build_osx && cd build_osx && rm -Rf *
 cmake -DBUILD_OSX_UNIVERSAL=1 -DCMAKE_BUILD_TYPE=Debug  -DBOOTSTRAP_WXWIDGETS=1 -DUSE_STATIC_SPEEXDSP=1 -DHAMLIB_INCLUDE_DIR=${HAMLIBDIR}/include -DHAMLIB_LIBRARY=${HAMLIBDIR}/lib/libhamlib.a -DCODEC2_BUILD_DIR=$CODEC2DIR/build_osx -DLPCNET_BUILD_DIR=$LPCNETDIR/build_osx ..
-make VERBOSE=1
+make VERBOSE=1 -j4
 
 # Rebuild now that wxWidgets is bootstrapped
 cmake -DBUILD_OSX_UNIVERSAL=1 -DCMAKE_BUILD_TYPE=Debug  -DBOOTSTRAP_WXWIDGETS=1 -DUSE_STATIC_SPEEXDSP=1 -DHAMLIB_INCLUDE_DIR=${HAMLIBDIR}/include -DHAMLIB_LIBRARY=${HAMLIBDIR}/lib/libhamlib.a -DCODEC2_BUILD_DIR=$CODEC2DIR/build_osx -DLPCNET_BUILD_DIR=$LPCNETDIR/build_osx ..
-make VERBOSE=1
+make VERBOSE=1 -j4
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,13 +70,30 @@ set(FREEDV_LINK_LIBS_OSX
 # WIN32 is needed for Windows GUI apps and is ignored for UNIX like systems.
 # In addition, there are some required OSX-specific code files for platform specific handling.
 if(APPLE)
-    add_executable(freedv WIN32 ${FREEDV_SOURCES} ${RES_FILES} ${FREEDV_SOURCES_OSX})
+    set(RES_FILES freedv.icns)
+    set_source_files_properties(freedv.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+    add_executable(FreeDV MACOSX_BUNDLE ${FREEDV_SOURCES} ${RES_FILES} ${FREEDV_SOURCES_OSX})
+    set_target_properties(FreeDV PROPERTIES
+        BUNDLE True
+        MACOSX_BUNDLE_GUI_IDENTIFIER org.freedv.freedv
+        MACOSX_BUNDLE_BUNDLE_NAME FreeDV
+        MACOSX_BNUDLE_COPYRIGHT "Copyright (c) 2021 FreeDV"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${FREEDV_VERSION}"
+        MACOSX_BUNDLE_BUNDLE_SHORT_VERSION_STRING "${FREEDV_VERSION}"
+        MACOSX_BUNDLE_BUNDLE_LONG_VERSION_STRING "${FREEDV_VERSION}"
+        MACOSX_BUNDLE_ICON_FILE "freedv"
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/src/info.plist.in
+    )
 else()
     add_executable(freedv WIN32 ${FREEDV_SOURCES} ${RES_FILES})
 endif(APPLE)
 
 # Link imported or build tree targets.
+if(APPLE)
+target_link_libraries(FreeDV codec2 lpcnetfreedv)
+else(APPLE)
 target_link_libraries(freedv codec2 lpcnetfreedv)
+endif(APPLE)
 
 # Add build dependencies for interally built external libraries.
 if(USE_INTERNAL_CODEC2)
@@ -85,12 +102,16 @@ endif()
 
 # Add depenencies for other statically built libraries, if applicable.
 if(FREEDV_STATIC_DEPS)
+    if(APPLE)
+    add_dependencies(FreeDV ${FREEDV_STATIC_DEPS})
+    else(APPLE)
     add_dependencies(freedv ${FREEDV_STATIC_DEPS})
+    endif(APPLE)
 endif(FREEDV_STATIC_DEPS)
 
 # Link other dependencies
 if(APPLE)
-target_link_libraries(freedv ${FREEDV_LINK_LIBS} ${FREEDV_LINK_LIBS_OSX})
+target_link_libraries(FreeDV ${FREEDV_LINK_LIBS} ${FREEDV_LINK_LIBS_OSX})
 elseif(WIN32)
 target_link_libraries(freedv ${FREEDV_LINK_LIBS} ws2_32)
 else()
@@ -107,23 +128,24 @@ endif(APPLE)
 # Insert source and generated header directories before other search directories.
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
+if(APPLE)
+install(TARGETS FreeDV
+    BUNDLE DESTINATION bin
+)
+else(APPLE)
 install(TARGETS freedv
     RUNTIME DESTINATION bin
 )
+endif(APPLE)
 
 # Custom commands to build OSX images.
 if(APPLE)
     add_custom_command(
-        TARGET freedv
+        TARGET FreeDV
         POST_BUILD
-        COMMAND rm ARGS -rf FreeDV.* dist_tmp
-        COMMAND mkdir ARGS -p FreeDV.app/Contents/MacOS
-        COMMAND mkdir ARGS -p FreeDV.app/Contents/Resources/English.lproj
-        COMMAND cp ARGS ${CMAKE_CURRENT_BINARY_DIR}/info.plist FreeDV.app/Contents
+        COMMAND rm -rf dist_tmp || true
+        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/ -i /usr/lib -s ${LPCNET_BUILD_DIR}/src -s ${CODEC2_BUILD_DIR}/src 
         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
-        COMMAND echo ARGS -n "APPL????" > FreeDV.app/Contents/PkgInfo
-        COMMAND cp ARGS freedv FreeDV.app/Contents/MacOS/FreeDV
-        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/ -i /usr/lib -s ${CODEC2_BUILD_DIR}/src -s ${LPCNET_BUILD_DIR}/src
         COMMAND mkdir dist_tmp
         COMMAND cp -r FreeDV.app dist_tmp
         COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO -fs HFS+ ./FreeDV.dmg

--- a/src/info.plist.in
+++ b/src/info.plist.in
@@ -1,37 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>English</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Required to transmit your voice to the other party.</string>
 	<key>CFBundleExecutable</key>
-	<string>freedv</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.freedv.freedv</string>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleName</key>
-	<string>FreeDV</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.5</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
-	<!--<key>NSMainNibFile</key>
-	<string>MainMenu</string>-->
-	<key>CFBundleIconFile</key>
-	<string>freedv</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>


### PR DESCRIPTION
Some cleanups in the CMakefiles to allow CMake to generate the app bundle for macOS instead of running commands manually. This also uses a forked copy of macdylibbundler that fixes a build issue discovered while building on macOS Monterey.