### PR TITLE
Only use device names when doing startup checks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3077,7 +3077,7 @@ int MainFrame::txCallback(
     return paContinue;
 }
 
-int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate)
+int MainFrame::getSoundCardIDFromName(wxString& name, bool input)
 {
     int result = -1;
     
@@ -3112,10 +3112,10 @@ bool MainFrame::validateSoundCardSetup()
     bool canRun = true;
     
     // Translate device names to IDs
-    g_soundCard1InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1InDeviceName, true, g_soundCard1SampleRate);
-    g_soundCard1OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1OutDeviceName, false, g_soundCard1SampleRate);
-    g_soundCard2InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2InDeviceName, true, g_soundCard2SampleRate);
-    g_soundCard2OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2OutDeviceName, false, g_soundCard2SampleRate);
+    g_soundCard1InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1InDeviceName, true);
+    g_soundCard1OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1OutDeviceName, false);
+    g_soundCard2InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2InDeviceName, true);
+    g_soundCard2OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2OutDeviceName, false);
 
     if (wxGetApp().m_soundCard1InDeviceName != "none" && g_soundCard1InDeviceNum == -1)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3093,23 +3093,8 @@ int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate
                 deviceName = deviceName.Trim();
                 if (name == deviceName)
                 {
-#if 0
-                    PaStreamParameters baseParams;
-                    baseParams.device = index;
-                    baseParams.channelCount = input ? device->maxInputChannels : device->maxOutputChannels;
-                    baseParams.sampleFormat = paInt16;
-                    baseParams.suggestedLatency = 0;
-                    baseParams.hostApiSpecificStreamInfo = NULL;
-                    
-                    if (baseParams.channelCount == 0) continue;
-                    
-                    paResult = Pa_IsFormatSupported(input ? &baseParams : NULL, !input ? &baseParams : NULL, sampleRate);
-                    if (paResult == paFormatIsSupported)
-#endif
-                    {
-                        result = index;
-                        break;
-                    }
+                    result = index;
+                    break;
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3089,7 +3089,7 @@ int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate
             for (PaDeviceIndex index = 0; index < Pa_GetDeviceCount(); index++)
             {
                 const PaDeviceInfo* device = Pa_GetDeviceInfo(index);
-                wxString deviceName = wxString::FromUTF8(device->name);
+                wxString deviceName = wxString::FromUTF8(device->name).Trim();
                 deviceName = deviceName.Trim();
                 if (name == deviceName)
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3077,7 +3077,7 @@ int MainFrame::txCallback(
     return paContinue;
 }
 
-int MainFrame::getSoundCardIDFromName(wxString& name, bool input)
+int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate)
 {
     int result = -1;
     
@@ -3102,18 +3102,8 @@ int MainFrame::getSoundCardIDFromName(wxString& name, bool input)
                     
                     if (baseParams.channelCount == 0) continue;
                     
-                    bool supported = false;
-                    for(int sampleIndex = 0; PortAudioWrap::standardSampleRates[sampleIndex] > 0; sampleIndex++)
-                    {
-                        paResult = Pa_IsFormatSupported(input ? &baseParams : NULL, !input ? &baseParams : NULL, PortAudioWrap::standardSampleRates[sampleIndex]);
-                        if (paResult == paFormatIsSupported)
-                        {
-                            supported = true;
-                            break;
-                        }
-                    }
-                    
-                    if (supported)
+                    paResult = Pa_IsFormatSupported(input ? &baseParams : NULL, !input ? &baseParams : NULL, sampleRate);
+                    if (paResult == paFormatIsSupported)
                     {
                         result = index;
                         break;
@@ -3135,10 +3125,10 @@ bool MainFrame::validateSoundCardSetup()
     bool canRun = true;
     
     // Translate device names to IDs
-    g_soundCard1InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1InDeviceName, true);
-    g_soundCard1OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1OutDeviceName, false);
-    g_soundCard2InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2InDeviceName, true);
-    g_soundCard2OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2OutDeviceName, false);
+    g_soundCard1InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1InDeviceName, true, g_soundCard1SampleRate);
+    g_soundCard1OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard1OutDeviceName, false, g_soundCard1SampleRate);
+    g_soundCard2InDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2InDeviceName, true, g_soundCard2SampleRate);
+    g_soundCard2OutDeviceNum = getSoundCardIDFromName(wxGetApp().m_soundCard2OutDeviceName, false, g_soundCard2SampleRate);
 
     if (wxGetApp().m_soundCard1InDeviceName != "none" && g_soundCard1InDeviceNum == -1)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3093,6 +3093,7 @@ int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate
                 deviceName = deviceName.Trim();
                 if (name == deviceName)
                 {
+#if 0
                     PaStreamParameters baseParams;
                     baseParams.device = index;
                     baseParams.channelCount = input ? device->maxInputChannels : device->maxOutputChannels;
@@ -3104,6 +3105,7 @@ int MainFrame::getSoundCardIDFromName(wxString& name, bool input, int sampleRate
                     
                     paResult = Pa_IsFormatSupported(input ? &baseParams : NULL, !input ? &baseParams : NULL, sampleRate);
                     if (paResult == paFormatIsSupported)
+#endif
                     {
                         result = index;
                         break;

--- a/src/main.h
+++ b/src/main.h
@@ -686,7 +686,7 @@ class MainFrame : public TopFrame
         void       checkAvxSupport();
         bool       isAvxPresent;
         
-        int         getSoundCardIDFromName(wxString& name, bool input);
+        int         getSoundCardIDFromName(wxString& name, bool input, int sampleRate);
         bool        validateSoundCardSetup();
 };
 

--- a/src/main.h
+++ b/src/main.h
@@ -686,7 +686,7 @@ class MainFrame : public TopFrame
         void       checkAvxSupport();
         bool       isAvxPresent;
         
-        int         getSoundCardIDFromName(wxString& name, bool input, int sampleRate);
+        int         getSoundCardIDFromName(wxString& name, bool input);
         bool        validateSoundCardSetup();
 };
 


### PR DESCRIPTION
Per additional debug output in #190, it looks like PortAudio outputs two error codes for the problematic sound device:

* -9997 (paInvalidSampleRate)
* -9993 (paBadIODeviceCombination)

As it's unnecessary to check all possible sample rates just to determine the device ID, this PR  ~modifies the startup check to only check against the configured sample rate~ removes the sample rate check. This should keep PortAudio from entering a state that prevents use of the configured sample rate.