### PR TITLE
Remove requirement to restart FreeDV after resetting configuration to defaults.

### DIFF
--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -773,7 +773,7 @@ void OptionsDlg::OnOK(wxCommandEvent& event)
     ExchangeData(EXCHANGE_DATA_OUT, true);
     //this->EndModal(wxID_OK);
     g_modal = false;
-    this->Show(false);
+    EndModal(wxOK);
 }
 
 //-------------------------------------------------------------------------
@@ -783,7 +783,7 @@ void OptionsDlg::OnCancel(wxCommandEvent& event)
 {
     //this->EndModal(wxID_CANCEL);
     g_modal = false;
-    this->Show(false);
+    EndModal(wxCANCEL);
 }
 
 //-------------------------------------------------------------------------

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -166,7 +166,7 @@ void FreeDVInterface::start(int txMode, int fifoSizeMs, bool singleRxThread, boo
     }
     
     // Loop back through SNR adjust list and subtract minimum from each entry.
-    for (int index = 0; index < snrAdjust_.size(); index++)
+    for (size_t index = 0; index < snrAdjust_.size(); index++)
     {
         snrAdjust_[index] -= minimumSnr;
     }

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -34,8 +34,8 @@ class Hamlib {
 
         void update_mode_status();
 
-        rig_model_t m_rig_model;
         RIG *m_rig;
+        rig_model_t m_rig_model;
         /* Sorted list of rigs. */
         riglist_t m_rigList;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,12 +283,6 @@ void MainFrame::loadConfiguration_()
     Fit();
     wxSize size = GetBestSize();
 
-    // Add to the "best" width and height to prevent hiding of the waterfall
-    // and the controls just below it. The values here were determined by 
-    // experimentation.
-    size.SetWidth(size.GetWidth() + 375);
-    size.SetHeight(size.GetHeight() + 100);
-
     if (w < size.GetWidth()) w = size.GetWidth();
     if (h < size.GetHeight()) h = size.GetHeight();
     SetClientSize(w, h);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -456,6 +456,9 @@ void MainFrame::loadConfiguration_()
 
     m_ckboxSNR->SetValue(wxGetApp().m_snrSlow);
     setsnrBeta(wxGetApp().m_snrSlow);
+    
+    // Show/hide frequency box based on PSK Reporter enablement
+    m_freqBox->Show(wxGetApp().m_psk_enable);
 }
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1093,7 +1093,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         strncpy(callsign, (const char*) wxGetApp().m_callSign.mb_str(wxConvUTF8), MAX_CALLSIGN - 2);
         if (strlen(callsign) < MAX_CALLSIGN - 1)
         {
-            strncat(callsign, "\r", 1);
+            strcat(callsign, "\r");
         }     
      
         // buffer 1 txt message to ensure tx data fifo doesn't "run dry"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent)
     wxMenuItem* m_menuItemToolsConfigDelete;
     m_menuItemToolsConfigDelete = new wxMenuItem(tools, wxID_ANY, wxString(_("&Restore defaults")) , wxT("Delete config file/keys and restore defaults"), wxITEM_NORMAL);
     this->Connect(m_menuItemToolsConfigDelete->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(MainFrame::OnDeleteConfig));
+    this->Connect(m_menuItemToolsConfigDelete->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnDeleteConfigUI));
 
     tools->Append(m_menuItemToolsConfigDelete);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,18 +273,6 @@ void MainFrame::loadConfiguration_()
     if (w < 0 || w > 2048) w = 800;
     if (h < 0 || h > 2048) h = 780;
 
-    // TBD -- these aren't set anywhere in the code.
-    wxGetApp().m_show_wf            = pConfig->Read(wxT("/MainFrame/show_wf"),           1);
-    wxGetApp().m_show_spect         = pConfig->Read(wxT("/MainFrame/show_spect"),        1);
-    wxGetApp().m_show_scatter       = pConfig->Read(wxT("/MainFrame/show_scatter"),      1);
-    wxGetApp().m_show_timing        = pConfig->Read(wxT("/MainFrame/show_timing"),       1);
-    wxGetApp().m_show_freq          = pConfig->Read(wxT("/MainFrame/show_freq"),         1);
-    wxGetApp().m_show_speech_in     = pConfig->Read(wxT("/MainFrame/show_speech_in"),    1);
-    wxGetApp().m_show_speech_out    = pConfig->Read(wxT("/MainFrame/show_speech_out"),   1);
-    wxGetApp().m_show_demod_in      = pConfig->Read(wxT("/MainFrame/show_demod_in"),     1);
-    wxGetApp().m_show_test_frame_errors = pConfig->Read(wxT("/MainFrame/show_test_frame_errors"),     1);
-    wxGetApp().m_show_test_frame_errors_hist = pConfig->Read(wxT("/MainFrame/show_test_frame_errors_hist"),     1);
-
     wxGetApp().m_rxNbookCtrl        = pConfig->Read(wxT("/MainFrame/rxNbookCtrl"),    (long)0);
 
     g_SquelchActive = pConfig->Read(wxT("/Audio/SquelchActive"), (long)0);
@@ -514,79 +502,53 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent)
 
     loadConfiguration_();
     
-    if(wxGetApp().m_show_wf)
-    {
-        // Add Waterfall Plot window
-        m_panelWaterfall = new PlotWaterfall((wxFrame*) m_auiNbookCtrl, false, 0);
-        m_panelWaterfall->SetToolTip(_("Double-click to tune"));
-        m_auiNbookCtrl->AddPage(m_panelWaterfall, _("Waterfall"), true, wxNullBitmap);
-    }
-    if(wxGetApp().m_show_spect)
-    {
-        // Add Spectrum Plot window
-        m_panelSpectrum = new PlotSpectrum((wxFrame*) m_auiNbookCtrl, g_avmag,
-                                           MODEM_STATS_NSPEC*((float)MAX_F_HZ/MODEM_STATS_MAX_F_HZ));
-        m_panelSpectrum->SetToolTip(_("Double-click to tune"));
-        m_auiNbookCtrl->AddPage(m_panelSpectrum, _("Spectrum"), true, wxNullBitmap);
-    }
-    if(wxGetApp().m_show_scatter)
-    {
-        // Add Scatter Plot window
-        m_panelScatter = new PlotScatter((wxFrame*) m_auiNbookCtrl);
-        m_auiNbookCtrl->AddPage(m_panelScatter, _("Scatter"), true, wxNullBitmap);
-    }
-    if(wxGetApp().m_show_demod_in)
-    {
-        // Add Demod Input window
-        m_panelDemodIn = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
-        m_auiNbookCtrl->AddPage(m_panelDemodIn, _("Frm Radio"), true, wxNullBitmap);
-        g_plotDemodInFifo = codec2_fifo_create(2*WAVEFORM_PLOT_BUF);
-    }
+    // Add Waterfall Plot window
+    m_panelWaterfall = new PlotWaterfall((wxFrame*) m_auiNbookCtrl, false, 0);
+    m_panelWaterfall->SetToolTip(_("Double-click to tune"));
+    m_auiNbookCtrl->AddPage(m_panelWaterfall, _("Waterfall"), true, wxNullBitmap);
 
-    if(wxGetApp().m_show_speech_in)
-    {
-        // Add Speech Input window
-        m_panelSpeechIn = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
-        m_auiNbookCtrl->AddPage(m_panelSpeechIn, _("Frm Mic"), true, wxNullBitmap);
-        g_plotSpeechInFifo = codec2_fifo_create(4*WAVEFORM_PLOT_BUF);
-    }
+    // Add Spectrum Plot window
+    m_panelSpectrum = new PlotSpectrum((wxFrame*) m_auiNbookCtrl, g_avmag,
+                                       MODEM_STATS_NSPEC*((float)MAX_F_HZ/MODEM_STATS_MAX_F_HZ));
+    m_panelSpectrum->SetToolTip(_("Double-click to tune"));
+    m_auiNbookCtrl->AddPage(m_panelSpectrum, _("Spectrum"), true, wxNullBitmap);
 
-    if(wxGetApp().m_show_speech_out)
-    {
-        // Add Speech Output window
-        m_panelSpeechOut = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
-        m_auiNbookCtrl->AddPage(m_panelSpeechOut, _("To Spkr/Hdphns"), true, wxNullBitmap);
-        g_plotSpeechOutFifo = codec2_fifo_create(2*WAVEFORM_PLOT_BUF);
-    }
+    // Add Scatter Plot window
+    m_panelScatter = new PlotScatter((wxFrame*) m_auiNbookCtrl);
+    m_auiNbookCtrl->AddPage(m_panelScatter, _("Scatter"), true, wxNullBitmap);
 
-    if(wxGetApp().m_show_timing)
-    {
-        // Add Timing Offset window
-        m_panelTimeOffset = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 5.0, DT, -0.5, 0.5, 1, 0.1, "%2.1f", 0);
-        m_auiNbookCtrl->AddPage(m_panelTimeOffset, L"Timing \u0394", true, wxNullBitmap);
-    }
-    if(wxGetApp().m_show_freq)
-    {
-        // Add Frequency Offset window
-        m_panelFreqOffset = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 5.0, DT, -200, 200, 1, 50, "%3.0fHz", 0);
-        m_auiNbookCtrl->AddPage(m_panelFreqOffset, L"Frequency \u0394", true, wxNullBitmap);
-    }
+    // Add Demod Input window
+    m_panelDemodIn = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
+    m_auiNbookCtrl->AddPage(m_panelDemodIn, _("Frm Radio"), true, wxNullBitmap);
+    g_plotDemodInFifo = codec2_fifo_create(2*WAVEFORM_PLOT_BUF);
 
-    if(wxGetApp().m_show_test_frame_errors)
-    {
-        // Add Test Frame Errors window
-        m_panelTestFrameErrors = new PlotScalar((wxFrame*) m_auiNbookCtrl, 2*MODEM_STATS_NC_MAX, 30.0, DT, 0, 2*MODEM_STATS_NC_MAX+2, 1, 1, "", 1);
-        m_auiNbookCtrl->AddPage(m_panelTestFrameErrors, L"Test Frame Errors", true, wxNullBitmap);
-    }
+    // Add Speech Input window
+    m_panelSpeechIn = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
+    m_auiNbookCtrl->AddPage(m_panelSpeechIn, _("Frm Mic"), true, wxNullBitmap);
+    g_plotSpeechInFifo = codec2_fifo_create(4*WAVEFORM_PLOT_BUF);
 
-    if(wxGetApp().m_show_test_frame_errors_hist)
-    {
-        // Add Test Frame Historgram window.  1 column for every bit, 2 bits per carrier
-        m_panelTestFrameErrorsHist = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 1.0, 1.0/(2*MODEM_STATS_NC_MAX), 0.001, 0.1, 1.0/MODEM_STATS_NC_MAX, 0.1, "%0.0E", 0);
-        m_auiNbookCtrl->AddPage(m_panelTestFrameErrorsHist, L"Test Frame Histogram", true, wxNullBitmap);
-        m_panelTestFrameErrorsHist->setBarGraph(1);
-        m_panelTestFrameErrorsHist->setLogY(1);
-    }
+    // Add Speech Output window
+    m_panelSpeechOut = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
+    m_auiNbookCtrl->AddPage(m_panelSpeechOut, _("To Spkr/Hdphns"), true, wxNullBitmap);
+    g_plotSpeechOutFifo = codec2_fifo_create(2*WAVEFORM_PLOT_BUF);
+
+    // Add Timing Offset window
+    m_panelTimeOffset = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 5.0, DT, -0.5, 0.5, 1, 0.1, "%2.1f", 0);
+    m_auiNbookCtrl->AddPage(m_panelTimeOffset, L"Timing \u0394", true, wxNullBitmap);
+
+    // Add Frequency Offset window
+    m_panelFreqOffset = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 5.0, DT, -200, 200, 1, 50, "%3.0fHz", 0);
+    m_auiNbookCtrl->AddPage(m_panelFreqOffset, L"Frequency \u0394", true, wxNullBitmap);
+
+    // Add Test Frame Errors window
+    m_panelTestFrameErrors = new PlotScalar((wxFrame*) m_auiNbookCtrl, 2*MODEM_STATS_NC_MAX, 30.0, DT, 0, 2*MODEM_STATS_NC_MAX+2, 1, 1, "", 1);
+    m_auiNbookCtrl->AddPage(m_panelTestFrameErrors, L"Test Frame Errors", true, wxNullBitmap);
+
+    // Add Test Frame Historgram window.  1 column for every bit, 2 bits per carrier
+    m_panelTestFrameErrorsHist = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, 1.0, 1.0/(2*MODEM_STATS_NC_MAX), 0.001, 0.1, 1.0/MODEM_STATS_NC_MAX, 0.1, "%0.0E", 0);
+    m_auiNbookCtrl->AddPage(m_panelTestFrameErrorsHist, L"Test Frame Histogram", true, wxNullBitmap);
+    m_panelTestFrameErrorsHist->setBarGraph(1);
+    m_panelTestFrameErrorsHist->setLogY(1);
 
     validateSoundCardSetup();
 
@@ -719,16 +681,6 @@ MainFrame::~MainFrame()
         pConfig->Write(wxT("/MainFrame/width"),              (long) w);
         pConfig->Write(wxT("/MainFrame/height"),             (long) h);
     }
-    pConfig->Write(wxT("/MainFrame/show_wf"),           wxGetApp().m_show_wf);
-    pConfig->Write(wxT("/MainFrame/show_spect"),        wxGetApp().m_show_spect);
-    pConfig->Write(wxT("/MainFrame/show_scatter"),      wxGetApp().m_show_scatter);
-    pConfig->Write(wxT("/MainFrame/show_timing"),       wxGetApp().m_show_timing);
-    pConfig->Write(wxT("/MainFrame/show_freq"),         wxGetApp().m_show_freq);
-    pConfig->Write(wxT("/MainFrame/show_speech_in"),    wxGetApp().m_show_speech_in);
-    pConfig->Write(wxT("/MainFrame/show_speech_out"),   wxGetApp().m_show_speech_out);
-    pConfig->Write(wxT("/MainFrame/show_demod_in"),     wxGetApp().m_show_demod_in);
-    pConfig->Write(wxT("/MainFrame/show_test_frame_errors"), wxGetApp().m_show_test_frame_errors);
-    pConfig->Write(wxT("/MainFrame/show_test_frame_errors_hist"), wxGetApp().m_show_test_frame_errors_hist);
 
     pConfig->Write(wxT("/MainFrame/rxNbookCtrl"), wxGetApp().m_rxNbookCtrl);
 

--- a/src/main.h
+++ b/src/main.h
@@ -636,6 +636,7 @@ class MainFrame : public TopFrame
         void OnSize( wxSizeEvent& event );
         void OnUpdateUI( wxUpdateUIEvent& event );
         void OnDeleteConfig(wxCommandEvent&);
+        void OnDeleteConfigUI( wxUpdateUIEvent& event );
 #ifdef _USE_TIMER
         void OnTimer(wxTimerEvent &evt);
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -265,18 +265,6 @@ class MainApp : public wxApp
         float               m_SpkOutMidQ;
         bool                m_SpkOutEQEnable;
 
-        // Flags for displaying windows
-        int                 m_show_wf;
-        int                 m_show_spect;
-        int                 m_show_scatter;
-        int                 m_show_timing;
-        int                 m_show_freq;
-        int                 m_show_speech_in;
-        int                 m_show_speech_out;
-        int                 m_show_demod_in;
-        int                 m_show_test_frame_errors;
-        int                 m_show_test_frame_errors_hist;
-
         // optional vox trigger tone
         bool                m_leftChannelVoxTone;
 

--- a/src/main.h
+++ b/src/main.h
@@ -688,6 +688,9 @@ class MainFrame : public TopFrame
         
         int         getSoundCardIDFromName(wxString& name, bool input);
         bool        validateSoundCardSetup();
+        
+    private:
+        void loadConfiguration_();
 };
 
 void txRxProcessing();

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -228,18 +228,8 @@ void MainFrame::OnDeleteConfig(wxCommandEvent&)
     {
         wxLogMessage(wxT("Config file/registry key successfully deleted."));
         
-        // Save current window position and size. While loadConfiguration_()
-        // will reset those, we don't actually want to update the window size
-        // or position.
-        wxSize currentSize = GetSize();
-        wxPoint currentPosition = GetPosition();
-        
         // Resets all configuration to defaults.
         loadConfiguration_();
-        
-        // Restore size and position.
-        SetSize(currentSize);
-        SetPosition(currentPosition);
     }
     else
     {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -85,7 +85,10 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
     wxUnusedVar(event);
     g_modal = true;
     //fprintf(stderr,"g_modal: %d\n", g_modal);
-    optionsDlg->Show();
+    optionsDlg->ShowModal();
+    
+    // Show/hide frequency box based on PSK Reporter status.
+    m_freqBox->Show(wxGetApp().m_psk_enable);
 }
 
 //-------------------------------------------------------------------------

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -228,8 +228,18 @@ void MainFrame::OnDeleteConfig(wxCommandEvent&)
     {
         wxLogMessage(wxT("Config file/registry key successfully deleted."));
         
+        // Save current window position and size. While loadConfiguration_()
+        // will reset those, we don't actually want to update the window size
+        // or position.
+        wxSize currentSize = GetSize();
+        wxPoint currentPosition = GetPosition();
+        
         // Resets all configuration to defaults.
         loadConfiguration_();
+        
+        // Restore size and position.
+        SetSize(currentSize);
+        SetPosition(currentPosition);
     }
     else
     {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -226,8 +226,10 @@ void MainFrame::OnDeleteConfig(wxCommandEvent&)
 {
     if(pConfig->DeleteAll())
     {
-        wxLogMessage(wxT("Config file/registry key successfully deleted.  Please restart FreeDV."));
-        wxConfigBase::DontCreateOnDemand();
+        wxLogMessage(wxT("Config file/registry key successfully deleted."));
+        
+        // Resets all configuration to defaults.
+        loadConfiguration_();
     }
     else
     {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -238,6 +238,14 @@ void MainFrame::OnDeleteConfig(wxCommandEvent&)
 }
 
 //-------------------------------------------------------------------------
+// OnDeleteConfigUI()
+//-------------------------------------------------------------------------
+void MainFrame::OnDeleteConfigUI( wxUpdateUIEvent& event )
+{
+    event.Enable(!m_RxRunning);
+}
+
+//-------------------------------------------------------------------------
 // Paint()
 //-------------------------------------------------------------------------
 void MainFrame::OnPaint(wxPaintEvent& WXUNUSED(event))

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -439,12 +439,12 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     rightSizer->Add(sbSizer5, 2, wxALL|wxEXPAND, 1);
     
     // Frequency text field (PSK Reporter)
-    wxStaticBox* freqBox = new wxStaticBox(panel, wxID_ANY, _("Report Frequency"));
-    wxBoxSizer* reportFrequencySizer = new wxStaticBoxSizer(freqBox, wxHORIZONTAL);
+    m_freqBox = new wxStaticBox(panel, wxID_ANY, _("Report Frequency"));
+    wxBoxSizer* reportFrequencySizer = new wxStaticBoxSizer(m_freqBox, wxHORIZONTAL);
     
-    wxStaticText* reportFrequencyUnits = new wxStaticText(freqBox, wxID_ANY, wxT(" kHz"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    wxStaticText* reportFrequencyUnits = new wxStaticText(m_freqBox, wxID_ANY, wxT(" kHz"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
     wxBoxSizer* txtReportFreqSizer = new wxBoxSizer(wxVERTICAL);
-    m_txtCtrlReportFrequency = new wxTextCtrl(freqBox, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RIGHT);
+    m_txtCtrlReportFrequency = new wxTextCtrl(m_freqBox, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RIGHT);
     m_txtCtrlReportFrequency->SetMinSize(wxSize(100,-1));
     txtReportFreqSizer->Add(m_txtCtrlReportFrequency, 1, 0, 1);
     reportFrequencySizer->Add(txtReportFreqSizer, 1, wxEXPAND, 1);

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -193,6 +193,7 @@ class TopFrame : public wxFrame
         wxToggleButton* m_togBtnLoopTx;
         wxAuiNotebook* m_auiNbookCtrl;
         wxTextCtrl*   m_txtCtrlReportFrequency;
+        wxStaticBox*  m_freqBox;
 
         TopFrame( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("FreeDV ") + _(FREEDV_VERSION), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(561,300 ), long style = wxDEFAULT_FRAME_STYLE|wxRESIZE_BORDER );
 


### PR DESCRIPTION
Resolves #202 by resetting configuration options immediately upon selecting Tools->Restore Defaults. This means that the user can continue using the application after configuration reset instead of needing to restart.