### PR TITLE
Fix spelling errors

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -291,11 +291,12 @@ hardware, what you have tried, and the exact nature of the problem.
 
 ## FreeDV 2020 mode is greyed out
 
-You must have a modern CPU with AVX support to run FreeDV 2020.  If
-you do not have AVX the FreeDV 2020 mode button will be greyed out.
-A Microsoft utility called [coreinfo](https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo)
-can be also used to determine if your CPU supports AVX.  A * means
-you have AVX, a - means no AVX:
+In order to use FreeDV 2020 mode, you must have one of the following:
+
+1. An Intel based CPU with AVX support. A Microsoft utility called [coreinfo](https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo)
+can be used to determine if your CPU supports AVX.  A * means you have 
+AVX, a - means no AVX:
+
 ```
 AES             -       Supports AES extensions
 AVX             *       Supports AVX instruction extensions
@@ -308,6 +309,10 @@ or the output of the `lscpu` command:
 lscpu | grep -o "avx[^ ]*"
 ```
 will display `avx` (or `avx2`) if your CPU supports the instructions.
+
+2. A Mac with an ARM processor (e.g. 2020 Mac Mini or later).
+
+If your system does not meet either (1) or (2), the 2020 option will be grayed out.
 
 ## FreeDV 2020 mode is slow on ARM Macs
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -121,7 +121,7 @@ nudged.  More **is not better** with the FreeDV transmit signal.
 Overdriving your transmitter will lead to a distorted transit signal, and
 a poor SNR at the receiver.  This is a very common problem.
 
-1. FreeDV 700D and 700E can drive your transmitter at an average power of 40% of it's peak power rating.  For example 40W RMS for a 100W PEP radio. Make sure your transmitter can handle continuous power output at these levels, and reduce the power if necessary.
+1. FreeDV 700D and 700E can drive your transmitter at an average power of 40% of its peak power rating.  For example 40W RMS for a 100W PEP radio. Make sure your transmitter can handle continuous power output at these levels, and reduce the power if necessary.
 
 1. Adjust the microphone audio so the peaks are not clipping, and the
 average is about half the maximum.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -160,7 +160,7 @@ Once you have configured PTT, try the **Test** button.
 
 Serial PTT support is complex.  We get many reports that FreeDV
 PTT doesn't work on a particular radio, but may work fine with other
-programs such as Fldigi.  This is often a mis-match between the serial
+programs such as Fldigi.  This is often a mismatch between the serial
 parameters Hamlib is using with FreeDV and your radio. For example you
 may have changed the default serial rate on your radio. Carefully
 check the serial parameters on your radio match those used by FreeDV
@@ -293,12 +293,12 @@ hardware, what you have tried, and the exact nature of the problem.
 
 You must have a modern CPU with AVX support to run FreeDV 2020.  If
 you do not have AVX the FreeDV 2020 mode button will be greyed out.
-A Microsoft utlity called [coreinfo](https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo)
+A Microsoft utility called [coreinfo](https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo)
 can be also used to determine if your CPU supports AVX.  A * means
 you have AVX, a - means no AVX:
 ```
 AES             -       Supports AES extensions
-AVX             *       Supports AVX intruction extensions
+AVX             *       Supports AVX instruction extensions
 FMA             -       Supports FMA extensions using YMM state
 ```
 
@@ -525,7 +525,7 @@ This section describes features on Tools-Filter.
 
 Control | Description
  -------------------------- | ------------------------------------------------------------------------ |
-Noise Supression | Enable noise supression, dereverberation, AGC of mic signal using the Speex pre-processor
+Noise Suppression | Enable noise suppression, dereverberation, AGC of mic signal using the Speex pre-processor
 700C/700D Auto EQ | Automatic equalisation for FreeDV 700C and FreeDV 700D Codec input audio
 
 Auto EQ (Automatic Equalisation) adjusts the input speech spectrum to best fit the speech codec. It can remove annoying bass artefacts and make the codec speech easier to understand.

--- a/docker/freedv_build_windows.sh
+++ b/docker/freedv_build_windows.sh
@@ -9,7 +9,7 @@ function print_help {
     echo "    -d                  debug mode; trace script execution"
     echo "    --noclean           start from a previous build (git pull && make), which is faster for small changes."
     echo "                        The default is a clean build from a fresh git clone (slow but safer)"
-    echo "    --build             Update docker image first (run if you have modifed the docker scripts in fdv_win_fedora)"
+    echo "    --build             Update docker image first (run if you have modified the docker scripts in fdv_win_fedora)"
     echo "    --rebuild           Completely recreate docker image first (e.g. run if you have new rpm packages)"
     echo "    --repo GitRepo      (default https://github.com/drowe67/freedv-gui.git)"
     echo "    --branch GitBranch  (default master)"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,12 +101,12 @@ else(APPLE)
 target_link_libraries(freedv codec2 lpcnetfreedv fdv_audio)
 endif(APPLE)
 
-# Add build dependencies for interally built external libraries.
+# Add build dependencies for internally built external libraries.
 if(USE_INTERNAL_CODEC2)
     add_dependencies(freedv build_codec2 build_lpcnetfreedv)
 endif()
 
-# Add depenencies for other statically built libraries, if applicable.
+# Add dependencies for other statically built libraries, if applicable.
 if(FREEDV_STATIC_DEPS)
     if(APPLE)
     add_dependencies(FreeDV ${FREEDV_STATIC_DEPS})

--- a/src/dlg_audiooptions.cpp
+++ b/src/dlg_audiooptions.cpp
@@ -357,7 +357,7 @@ void AudioOptsDialog::OnInitDialog( wxInitDialogEvent& event )
 // setTextCtrlIfDevNameValid()
 //
 // helper function to look up name of devName, and if it exists write
-// name to textCtrl.  Used to trap dissapearing devices.
+// name to textCtrl.  Used to trap disappearing devices.
 //-------------------------------------------------------------------------
 bool AudioOptsDialog::setTextCtrlIfDevNameValid(wxTextCtrl *textCtrl, wxListCtrl *listCtrl, wxString devName)
 {
@@ -1106,7 +1106,7 @@ void AudioOptsDialog::OnRefreshClick(wxCommandEvent& event)
     populateParams(m_TxInDevices);
     populateParams(m_TxOutDevices);
 
-    // some devices may have dissapeared, so possibily change sound
+    // some devices may have disappeared, so possibly change sound
     // card config
 
     ExchangeData(EXCHANGE_DATA_IN);
@@ -1142,7 +1142,7 @@ void AudioOptsDialog::OnOkAudioParameters(wxCommandEvent& event)
 {
     int status = ExchangeData(EXCHANGE_DATA_OUT);
 
-    // We only accept OK if config sucessful
+    // We only accept OK if config successful
 
     if (g_verbose) fprintf(stderr,"status: %d m_isPaInitialized: %d\n", status, m_isPaInitialized);
     if (status == 0) {

--- a/src/dlg_audiooptions.h
+++ b/src/dlg_audiooptions.h
@@ -120,7 +120,7 @@ class AudioOptsDialog : public wxDialog
         wxButton* m_sdbSizer1Apply;
         wxButton* m_sdbSizer1Cancel;
         
-        // Virtual event handlers, overide them in your derived class
+        // Virtual event handlers, override them in your derived class
         //virtual void OnActivateApp( wxActivateEvent& event ) { event.Skip(); }
 //        virtual void OnCloseFrame( wxCloseEvent& event ) { event.Skip(); }
 
@@ -138,7 +138,7 @@ class AudioOptsDialog : public wxDialog
         void OnApplyAudioParameters( wxCommandEvent& event );
         void OnCancelAudioParameters( wxCommandEvent& event );
         void OnOkAudioParameters( wxCommandEvent& event );
-        // Virtual event handlers, overide them in your derived class
+        // Virtual event handlers, override them in your derived class
         void OnClose( wxCloseEvent& event ) { event.Skip(); }
         void OnHibernate( wxActivateEvent& event ) { event.Skip(); }
         void OnIconize( wxIconizeEvent& event ) { event.Skip(); }

--- a/src/dlg_filter.cpp
+++ b/src/dlg_filter.cpp
@@ -942,7 +942,7 @@ void FilterDlg::calcFilterSpectrum(float magdB[], int argc, char *argv[]) {
     //    out[i] = 0.0;
     //out[0] = IMP_AMP;
 
-    // calculate discrete time continous frequency Fourer transform
+    // calculate discrete time continuous frequency Fourer transform
     // doing this from first principles rather than FFT for no good reason
 
     for(f=0,i=0; f<MAX_F_HZ; f+=F_STEP_DFT,i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -927,7 +927,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
                     if (wxGetApp().m_FreeDV700Combine) {
                         /*
-                           FreeDV 700C uses diversity, so optionaly combine
+                           FreeDV 700C uses diversity, so optionally combine
                            symbols for scatter plot, as combined symbols are
                            used for demodulation.  Note we need to use a copy
                            of the symbols, as we are not sure when the stats
@@ -2432,7 +2432,7 @@ void MainFrame::startRxStream()
 
 
 //---------------------------------------------------------------------------------------------
-// Main real time procesing for tx and rx of FreeDV signals, run in its own threads
+// Main real time processing for tx and rx of FreeDV signals, run in its own threads
 //---------------------------------------------------------------------------------------------
 
 void txProcessing()
@@ -2972,7 +2972,7 @@ int MainFrame::PollUDP(void)
 
         }
         else {
-            printf("We only accept messages from locahost!\n");
+            printf("We only accept messages from localhost!\n");
         }
 
        if ( m_udp_sock->SendTo(m_udp_addr, reply, strlen(reply)).LastCount() != strlen(reply)) {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -419,7 +419,7 @@ void MainFrame::togglePTT(void) {
         m_textSync->Enable();
         m_textCurrentDecodeMode->Enable();
         
-        // Reenable On/Off button.
+        // Re-enable On/Off button.
         m_togBtnOnOff->Enable(true);
     }
     else

--- a/src/playrec.cpp
+++ b/src/playrec.cpp
@@ -337,7 +337,7 @@ void MainFrame::OnRecFileFromRadio(wxCommandEvent& event)
             return;
         }
 
-        // Bug: on Win32 I cant read m_recFileFromRadioSecs, so have hard coded it
+        // Bug: on Win32 I can't read m_recFileFromRadioSecs, so have hard coded it
 #ifdef __WIN32__
         long secs = wxGetApp().m_recFileFromRadioSecs;
         g_recFromRadioSamples = FS*(unsigned int)secs;
@@ -468,7 +468,7 @@ void MainFrame::OnRecFileFromModulator(wxCommandEvent& event)
             return;
         }
 
-        // Bug: on Win32 I cant read m_recFileFromModemSecs, so have hard coded it
+        // Bug: on Win32 I can't read m_recFileFromModemSecs, so have hard coded it
 #ifdef __WIN32__
         long secs = wxGetApp().m_recFileFromModulatorSecs;
         g_recFromModulatorSamples = sample_rate * (unsigned int)secs;

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -56,7 +56,7 @@ bool Serialport::openport(const char name[], bool useRTS, bool RTSPos, bool useD
 
             1/ Run->devmgmnt.msc
             2/ Change COM port Ports (COM & LPT) -> Serial Device -> Properties Tab -> Advanced
-            3/ Unplug USB serial devce and plug in again.  This is really important.  FreeDV won't recognise
+            3/ Unplug USB serial device and plug in again.  This is really important.  FreeDV won't recognise
                new COM port number until this is done.
             4/ Test PTT on FreeDV Tools->PTT
 	*/

--- a/src/sox/sox.h
+++ b/src/sox/sox.h
@@ -712,7 +712,7 @@ Min value for sox_sample_t = 0x80000000.
  * Rounding: halves toward +inf, all others to nearest integer.
  *
  * Clips? shows whether on not there is the possibility of a conversion
- * clipping to the minimum or maximum value when inputing from or outputing
+ * clipping to the minimum or maximum value when inputing from or outputting
  * to a given type.
  *
  * Unsigned integers are converted to and from signed integers by flipping

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -131,7 +131,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     snrSizer = new wxStaticBoxSizer(snrBox, wxVERTICAL);
 
     //------------------------------
-    // S/N ratio Guage (vert. bargraph)
+    // S/N ratio Gauge (vert. bargraph)
     //------------------------------
     m_gaugeSNR = new wxGauge(snrBox, wxID_ANY, 25, wxDefaultPosition, wxSize(15,150), wxGA_SMOOTH|wxGA_VERTICAL);
     m_gaugeSNR->SetToolTip(_("Displays signal to noise ratio in dB."));

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -127,7 +127,7 @@ class TopFrame : public wxFrame
         wxMenuItem* m_menuItemRecFileFromModulator;
         wxMenuItem* m_menuItemPlayFileFromRadio;
     
-        // Virtual event handlers, overide them in your derived class
+        // Virtual event handlers, override them in your derived class
         virtual void topFrame_OnClose( wxCloseEvent& event ) { event.Skip(); }
         virtual void topFrame_OnPaint( wxPaintEvent& event ) { event.Skip(); }
         virtual void topFrame_OnSize( wxSizeEvent& event ) { event.Skip(); }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -192,7 +192,7 @@ void freq_shift_coh(COMP rx_fdm_fcorr[], COMP rx_fdm[], float foff, float Fs, CO
 	rx_fdm_fcorr[i] = cmult(rx_fdm[i], *foff_phase_rect);
     }
 
-    /* normalise digital oscilator as the magnitude can drift over time */
+    /* normalise digital oscillator as the magnitude can drift over time */
 
     mag = cabsolute(*foff_phase_rect);
     foff_phase_rect->real /= mag;
@@ -285,7 +285,7 @@ void MainFrame::DetectSyncProcessEvent(void) {
 
     case DS_SYNC_WAIT:
 
-        // In this state we wait fo a few seconds of valid sync, then
+        // In this state we wait for a few seconds of valid sync, then
         // send UDP message
 
         if (freedvInterface.getSync() == 0) {


### PR DESCRIPTION
This PR fixes some small typos in a string, in the documentation and in comments.
The only change in the code is in the string is "locahost" corrected as "localhost".

Maybe you could add codespell to Travis?
This command would return a non-zero exit code if there is a new error or a new word to ignore:
`codespell --ignore-words-list=inout,nin,ontop,parm,tthe,ue`