### PR TITLE
Build Windows builds for PRs

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,4 +1,4 @@
-name: Build FreeDV
+name: Build FreeDV (Linux)
 
 on:
   push:

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,4 +1,4 @@
-name: Build FreeDV (Linux)
+name: Build FreeDV (Windows)
 
 on:
   push:

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,4 +1,4 @@
-name: Build FreeDV (macOS)
+name: Build FreeDV (Linux)
 
 on:
   push:
@@ -15,12 +15,12 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build freedv-gui using PortAudio
+    - name: Build freedv-gui
       shell: bash
-      working-directory: ${{github.workspace}}
-      run: ./build_osx.sh
+      working-directory: ${{github.workspace}}/docker
+      run: ./freedv_build_windows.sh --branch ${{github.ref}} 64

--- a/.github/workflows/cmake_mac.yml
+++ b/.github/workflows/cmake_mac.yml
@@ -1,0 +1,26 @@
+name: Build FreeDV (macOS)
+
+on:
+  push:
+    branches-ignore:
+    - 'dr-render-manual'
+    
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build freedv-gui using PortAudio
+      shell: bash
+      working-directory: ${{github.workspace}}
+      run: ./build_osx.sh


### PR DESCRIPTION
Just an experiment for now. We should be able to build Windows ~and macOS~ binaries when creating PRs to ensure there's no OS-specific compiler issues. (In the past, the GitHub actions have occasionally passed while MinGW also spit out errors.)

EDIT: macOS builds currently take too long to be practical for PRs, so this PR is just to add Windows builds.