### PR TITLE
Bring back rig_get_vfo_list logic for new enough Hamlib installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,16 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     message(STATUS "Hamlib library found.")
     include_directories(${HAMLIB_INCLUDE_DIR})
     list(APPEND FREEDV_LINK_LIBS ${HAMLIB_LIBRARY})
+
+    try_compile(
+        HAMLIB_HAS_GET_RIG_LIST
+        SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib_rig_list.c)
+    if (HAMLIB_HAS_GET_RIG_LIST)
+        message(STATUS "Enabling rig_get_vfo_list support.")
+        add_definitions(-DHAMLIB_HAS_GET_RIG_LIST)
+    else (HAMLIB_HAS_GET_RIG_LIST)
+        message(STATUS "No rig_get_vfo_list support found, using alternate method.")
+    endif (HAMLIB_HAS_GET_RIG_LIST)
 else(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     message(STATUS "Using own Hamlib build")
     include(cmake/BuildHamlib.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,16 +389,15 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
 
     try_compile(
         HAMLIB_HAS_GET_RIG_LIST
-        SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib_rig_list.c)
-    if (HAMLIB_HAS_GET_RIG_LIST)
-        message(STATUS "Enabling rig_get_vfo_list support.")
-        add_definitions(-DHAMLIB_HAS_GET_RIG_LIST)
-    else (HAMLIB_HAS_GET_RIG_LIST)
-        message(STATUS "No rig_get_vfo_list support found, using alternate method.")
-    endif (HAMLIB_HAS_GET_RIG_LIST)
+        SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib_rig_list.c
+        LINK_LIBRARIES ${HAMLIB_LIBRARY}
+        CMAKE_FLAGS 
+            "-DINCLUDE_DIRECTORIES=${HAMLIB_INCLUDE_DIR}"
+        )
 else(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     message(STATUS "Using own Hamlib build")
     include(cmake/BuildHamlib.cmake)
+    set(HAMLIB_HAS_GET_RIG_LIST TRUE) # We're assuming we're running a version that has it.
 endif(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
 
 

--- a/cmake/hamlib_rig_list.c
+++ b/cmake/hamlib_rig_list.c
@@ -1,0 +1,7 @@
+#include "hamlib/rig.h"
+
+int main()
+{
+    char buf[256]
+    return rig_get_vfo_list(NULL, buf, 256); // XXX: not intended to be run
+}

--- a/cmake/hamlib_rig_list.c
+++ b/cmake/hamlib_rig_list.c
@@ -2,6 +2,6 @@
 
 int main()
 {
-    char buf[256]
+    char buf[256];
     return rig_get_vfo_list(NULL, buf, 256); // XXX: not intended to be run
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,13 @@ if(FREEDV_VERSION_TAG)
 add_definitions(-DFREEDV_VERSION_TAG="${FREEDV_VERSION_TAG}")
 endif(FREEDV_VERSION_TAG)
 
+if (HAMLIB_HAS_GET_RIG_LIST)
+    message(STATUS "[Hamlib] Enabling rig_get_vfo_list support.")
+    add_definitions(-DHAMLIB_HAS_GET_RIG_LIST)
+else (HAMLIB_HAS_GET_RIG_LIST)
+    message(STATUS "[Hamlib] No rig_get_vfo_list support found, using alternate method.")
+endif (HAMLIB_HAS_GET_RIG_LIST)
+
 # Insert source and generated header directories before other search directories.
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -396,6 +396,12 @@ void Hamlib::setModeHelper_(vfo_t currVfo, rmode_t mode)
 {
     bool setOkay = false;
     
+    if (mode == m_curMode)
+    {
+        // Don't attempt to update hamlib if we're already on this mode.
+        return;
+    }
+    
 modeAttempt:
     int result = rig_set_mode(m_rig, currVfo, mode, RIG_PASSBAND_NOCHANGE);
     if (result != RIG_OK && currVfo == RIG_VFO_CURR)
@@ -431,6 +437,12 @@ modeAttempt:
 void Hamlib::setFrequencyHelper_(vfo_t currVfo, uint64_t frequencyHz)
 {
     bool setOkay = false;
+    
+    if (m_currFreq == frequencyHz)
+    {
+        // Don't attempt to set frequency if we're already there.
+        return;
+    }
     
 freqAttempt:
     int result = rig_set_freq(m_rig, currVfo, frequencyHz);

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -53,8 +53,8 @@ Hamlib::Hamlib() :
     m_vhfUhfMode(false),
     pttSet_(false),
     updatesSuppressed_(false),
-    threadRunning_(false),
-    readOnly_(false)  {
+    readOnly_(false),
+    threadRunning_(false)  {
     /* Stop hamlib from spewing info to stderr. */
     rig_set_debug(RIG_DEBUG_NONE);
 
@@ -217,11 +217,21 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
         
         // Determine whether we have multiple VFOs.
         multipleVfos_ = false;
+
+#if defined(HAMLIB_HAS_GET_RIG_LIST)
+        char tmpBuf[256];
+        if (rig_get_vfo_list(m_rig, tmpBuf, 256) == RIG_OK)
+        {
+            std::string tmpStr = tmpBuf;
+            multipleVfos_ = tmpStr.find("VFOB") != std::string::npos;
+        }
+#else
         vfo_t vfo;
         if (rig_get_vfo (m_rig, &vfo) == RIG_OK && (m_rig->state.vfo_list & RIG_VFO_B))
         {
             multipleVfos_ = true;
         }
+#endif // defined(HAMLIB_HAS_GET_RIG_LIST)
 
         // Get current frequency and mode when we first connect so we can 
         // revert on close.        

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -223,11 +223,14 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
         if (rig_get_vfo_list(m_rig, tmpBuf, 256) == RIG_OK)
         {
             std::string tmpStr = tmpBuf;
-            multipleVfos_ = tmpStr.find("VFOB") != std::string::npos;
+            multipleVfos_ = 
+                tmpStr.find("VFOB") != std::string::npos ||
+                tmpStr.find("SUB") != std::string::npos;
         }
 #else
         vfo_t vfo;
-        if (rig_get_vfo (m_rig, &vfo) == RIG_OK && (m_rig->state.vfo_list & RIG_VFO_B))
+        if (rig_get_vfo (m_rig, &vfo) == RIG_OK && 
+            (m_rig->state.vfo_list & RIG_VFO_B || m_rig->state.vfo_list & RIG_VFO_SUB))
         {
             multipleVfos_ = true;
         }

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -396,7 +396,7 @@ void Hamlib::setModeHelper_(vfo_t currVfo, rmode_t mode)
 {
     bool setOkay = false;
     
-    if (mode == m_curMode)
+    if (mode == m_currMode)
     {
         // Don't attempt to update hamlib if we're already on this mode.
         return;


### PR DESCRIPTION
Brings back previous `rig_get_vfo_list` logic for new enough Hamlib installations ([context](https://github.com/drowe67/freedv-gui/pull/385#issuecomment-1537343695) for why it was removed before).