### PR TITLE
Add ability to suppress automatic frequency reporting on radio changes.

### DIFF
--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -33,6 +33,8 @@ ReportingConfiguration::ReportingConfiguration()
         
     , reportingFrequency("/Reporting/Frequency", 0)
         
+    , manualFrequencyReporting("/Reporting/ManualFrequencyReporting", false)
+        
     , pskReporterEnabled("/Reporting/PSKReporter/Enable", false)
         
     , freedvReporterEnabled("/Reporting/FreeDV/Enable", true)
@@ -87,6 +89,8 @@ void ReportingConfiguration::load(wxConfigBase* config)
     
     load_(config, reportingFrequencyList);
     
+    load_(config, manualFrequencyReporting);
+    
     // Special load handling for reporting below.
     wxString freqStr = config->Read(reportingFrequency.getElementName(), oldFreqStr);
     reportingFrequency.setWithoutProcessing(atoll(freqStr.ToUTF8()));
@@ -108,6 +112,8 @@ void ReportingConfiguration::save(wxConfigBase* config)
     save_(config, useUTCForReporting);
     
     save_(config, reportingFrequencyList);
+    
+    save_(config, manualFrequencyReporting);
     
     // Special save handling for reporting below.
     wxString tempFreqStr = wxString::Format(wxT("%" PRIu64), reportingFrequency.getWithoutProcessing());

--- a/src/config/ReportingConfiguration.h
+++ b/src/config/ReportingConfiguration.h
@@ -42,6 +42,8 @@ public:
     // uint64_t inside the FreeDV application.
     ConfigurationDataElement<uint64_t> reportingFrequency; 
     
+    ConfigurationDataElement<bool> manualFrequencyReporting;
+    
     ConfigurationDataElement<bool> pskReporterEnabled;
     
     ConfigurationDataElement<bool> freedvReporterEnabled;

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -116,6 +116,11 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     sbSizerReportingRows->Add(sbSizerReportingGeneral, 0, wxALL | wxEXPAND, 5);
     
+    wxBoxSizer* sbSizerReportingManualFrequency = new wxBoxSizer(wxHORIZONTAL);
+    m_ckboxManualFrequencyReporting = new wxCheckBox(m_reportingTab, wxID_ANY, _("Manual Frequency Reporting"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    sbSizerReportingManualFrequency->Add(m_ckboxManualFrequencyReporting, 0, wxALL | wxEXPAND, 5);
+    sbSizerReportingRows->Add(sbSizerReportingManualFrequency, 0, wxALL | wxEXPAND, 5);
+    
     // PSK Reporter options
     wxBoxSizer* sbSizerReportingPSK = new wxBoxSizer(wxHORIZONTAL);
     m_ckboxPskReporterEnable = new wxCheckBox(m_reportingTab, wxID_ANY, _("Enable PSK Reporter"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
@@ -737,7 +742,8 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_ckboxReportingEnable->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled);
         m_txt_callsign->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign);
         m_txt_grid_square->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare);
-
+        m_ckboxManualFrequencyReporting->SetValue(wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting);
+        
         // PSK Reporter options
         m_ckboxPskReporterEnable->SetValue(wxGetApp().appConfiguration.reportingConfiguration.pskReporterEnabled);
         
@@ -869,7 +875,8 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled = m_ckboxReportingEnable->GetValue();
         wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign = m_txt_callsign->GetValue();
         wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare = m_txt_grid_square->GetValue();
-
+        wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting = m_ckboxManualFrequencyReporting->GetValue();
+        
         // PSK Reporter options
         wxGetApp().appConfiguration.reportingConfiguration.pskReporterEnabled = m_ckboxPskReporterEnable->GetValue();
         
@@ -1070,6 +1077,7 @@ void OptionsDlg::updateReportingState()
             m_txtCtrlCallSign->Enable(false);
             m_txt_callsign->Enable(true);
             m_txt_grid_square->Enable(true);
+            m_ckboxManualFrequencyReporting->Enable(true);
             m_ckboxPskReporterEnable->Enable(true);
             m_ckboxFreeDVReporterEnable->Enable(true);
             
@@ -1090,6 +1098,7 @@ void OptionsDlg::updateReportingState()
             m_ckboxPskReporterEnable->Enable(false);
             m_ckboxFreeDVReporterEnable->Enable(false);
             m_freedvReporterHostname->Enable(false);
+            m_ckboxManualFrequencyReporting->Enable(false);
         }    
     }
     else
@@ -1099,6 +1108,7 @@ void OptionsDlg::updateReportingState()
         m_txtCtrlCallSign->Enable(false);
         m_txt_callsign->Enable(false);
         m_txt_grid_square->Enable(false);
+        m_ckboxManualFrequencyReporting->Enable(false);
         m_ckboxPskReporterEnable->Enable(false);
         m_ckboxFreeDVReporterEnable->Enable(false);
         m_freedvReporterHostname->Enable(false);

--- a/src/dlg_options.h
+++ b/src/dlg_options.h
@@ -130,6 +130,8 @@ class OptionsDlg : public wxDialog
         wxTextCtrl    *m_txt_callsign;
         wxTextCtrl    *m_txt_grid_square;
         
+        wxCheckBox    *m_ckboxManualFrequencyReporting;
+        
         wxCheckBox    *m_ckboxPskReporterEnable;
         
         wxCheckBox    *m_ckboxFreeDVReporterEnable;

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -648,7 +648,10 @@ void Hamlib::update_mode_status()
     }
 
     // Update frequency box
-    m_freqBox->SetValue(wxString::Format("%.4f", m_currFreq/1000.0/1000.0));
+    if (m_freqBox != nullptr)
+    {
+        m_freqBox->SetValue(wxString::Format("%.4f", m_currFreq/1000.0/1000.0));
+    }
     
     // Refresh
     m_modeBox->Refresh();

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -263,7 +263,11 @@ bool MainFrame::OpenHamlibRig() {
             {
                 wxGetApp().m_hamlib->setFrequencyAndMode(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency, wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseAnalogModes ? true : g_analog);
             }
-            wxGetApp().m_hamlib->enable_mode_detection(m_txtModeStatus, m_cboReportFrequency, g_mode == FREEDV_MODE_2400B);
+            wxGetApp().m_hamlib->enable_mode_detection(
+                m_txtModeStatus, 
+                wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled &&
+                    wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting ? nullptr : m_cboReportFrequency, 
+                g_mode == FREEDV_MODE_2400B);
         }
     
         return status;


### PR DESCRIPTION
For some setups (i.e. ALE), it's not preferred to have FreeDV automatically report frequency changes to FreeDV/PSK Reporter. This PR adds a new setting in Tools->Options->Reporting ("Manual Frequency Reporting") to prevent frequency updates from the radio from being propagated to the FreeDV UI and further upward to the various reporting services.