### PR TITLE
Generate PDF/HTML docs only on PR merge.

### DIFF
--- a/.github/workflows/update_freedv_manual.yml
+++ b/.github/workflows/update_freedv_manual.yml
@@ -4,7 +4,9 @@ name: Render User Manual
  
 on:
   # Only run when User Manual markdown source changes
-  push:
+  pull_request:
+    types:
+      - closed
     paths: 
       - 'USER_MANUAL.md'
       
@@ -15,7 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    if: contains(github.ref, 'refs/tags/') == false
+    if: github.event.pull_request.merged
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -885,6 +885,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Preserve size and position of Audio Configuration dialog. (PR #466)
 3. Build system:
     * Bump Codec2 version to v1.1.1. (PR #437)
+    * Generate PDF/HTML docs only on PR merge. (PR #471)
 4. Cleanup:
     * Refactor configuration handling in the codebase. (PR #457)
 4. Miscellaneous:


### PR DESCRIPTION
This PR updates the GitHub actions to only generate HTML/PDF docs on merge, not whenever USER_MANUAL.md is updated. By doing this, the number of unnecessary conflict resolutions should decrease.