### PR TITLE
Resolve filter-specific logic errors due to config migration

### DIFF
--- a/src/config/FilterConfiguration.cpp
+++ b/src/config/FilterConfiguration.cpp
@@ -23,12 +23,14 @@
 
 DEFINE_FILTER_CONFIG_NAMES(MicIn);
 DEFINE_FILTER_CONFIG_NAMES(SpkOut);
+DEFINE_FILTER_CONFIG_NAMES_OLD(MicIn);
+DEFINE_FILTER_CONFIG_NAMES_OLD(SpkOut);
 
 FilterConfiguration::FilterConfiguration()
     : codec2LPCPostFilterEnable("/Filter/codec2LPCPostFilterEnable", true)
     , codec2LPCPostFilterBassBoost("/Filter/codec2LPCPostFilterBassBoost", true)
-    , codec2LPCPostFilterGamma("/Filter/codec2LPCPostFilterGamma", CODEC2_LPC_PF_GAMMA*100)
-    , codec2LPCPostFilterBeta("/Filter/codec2LPCPostFilterBeta", CODEC2_LPC_PF_BETA*100)
+    , codec2LPCPostFilterGamma("/Filter/codec2LPCPostFilter/Gamma", CODEC2_LPC_PF_GAMMA*100)
+    , codec2LPCPostFilterBeta("/Filter/codec2LPCPostFilter/Beta", CODEC2_LPC_PF_BETA*100)
     , speexppEnable("/Filter/speexpp_enable", true)
     , enable700CEqualizer("/Filter/700C_EQ", true)
 {
@@ -48,6 +50,21 @@ FilterConfiguration::FilterConfiguration()
 
 void FilterConfiguration::load(wxConfigBase* config)
 {
+    // Migration: these values were using incorrect data types, so we have to
+    // move to new names in order to prevent Windows errors (for example:)
+    //
+    // 14:03:28: Registry value "HKCU\Software\freedv\Filter\codec2LPCPostFilterGamma" is not text (but of type DWORD)
+    // 14:03:28: Registry value "HKCU\Software\freedv\Filter\codec2LPCPostFilterBeta" is not text (but of type DWORD)
+    auto oldPostFilterGamma = (float)config->Read(
+        wxT("/Filter/codec2LPCPostFilterGamma"), 
+        CODEC2_LPC_PF_GAMMA*100);
+    codec2LPCPostFilterGamma.setDefaultVal(oldPostFilterGamma);
+    
+    auto oldPostFilterBeta = (float)config->Read(
+        wxT("/Filter/codec2LPCPostFilterBeta"), 
+        CODEC2_LPC_PF_BETA*100);
+    codec2LPCPostFilterBeta.setDefaultVal(oldPostFilterBeta);
+    
     micInChannel.load(config);
     spkOutChannel.load(config);
     

--- a/src/dlg_filter.cpp
+++ b/src/dlg_filter.cpp
@@ -489,30 +489,30 @@ void FilterDlg::ExchangeData(int inout)
         // Mic In Equaliser
 
         wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassFreqHz = (int)m_MicInBass.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassGaindB = (int)(10.0*m_MicInBass.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassGaindB = m_MicInBass.gaindB;
 
         wxGetApp().appConfiguration.filterConfiguration.micInChannel.trebleFreqHz = (int)m_MicInTreble.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.micInChannel.trebleGaindB = (int)(10.0*m_MicInTreble.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.trebleGaindB = m_MicInTreble.gaindB;
 
         wxGetApp().appConfiguration.filterConfiguration.micInChannel.midFreqHz = (int)m_MicInMid.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.micInChannel.midGainDB = (int)(10.0*m_MicInMid.gaindB);
-        wxGetApp().appConfiguration.filterConfiguration.micInChannel.midQ = (int)(100.0*m_MicInMid.Q);
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.midGainDB = m_MicInMid.gaindB;
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.midQ = m_MicInMid.Q;
 
-        wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB = (int)(10.0*m_MicInVol.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB = m_MicInVol.gaindB;
         
         // Spk Out Equaliser
 
         wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassFreqHz = (int)m_SpkOutBass.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassGaindB = (int)(10.0*m_SpkOutBass.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassGaindB = m_SpkOutBass.gaindB;
 
         wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleFreqHz = (int)m_SpkOutTreble.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleGaindB = (int)(10.0*m_SpkOutTreble.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleGaindB = m_SpkOutTreble.gaindB;
 
         wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midFreqHz = (int)m_SpkOutMid.freqHz;
-        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midGainDB = (int)(10.0*m_SpkOutMid.gaindB);
-        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midQ = (int)(100.0*m_SpkOutMid.Q);
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midGainDB = m_SpkOutMid.gaindB;
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midQ = m_SpkOutMid.Q;
 
-        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB = (int)(10.0*m_SpkOutVol.gaindB);
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB = m_SpkOutVol.gaindB;
 
         wxGetApp().appConfiguration.save(pConfig);
     }


### PR DESCRIPTION
Resolves several bugs caused by #457 or noticed during implementing the fix:

1. Keep incorrectly typed filter-related keys as-is and migrate data to new, correctly-typed keys. *Note: a one time error message will likely still appear if one is going from the most recent test build to v1.8.12 stable. Going from earlier releases (or first time setup) should produce no errors.*
2. Remove unneeded x10 multiplication during filter config save. This was causing gain/Q values to inappropriately be maxed out regardless of what they were being set to.
3. Update config default values for filters to match the behavior if the "Default" button is pushed.