### PR TITLE
Clean up compiler warnings on Windows builds.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -916,6 +916,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add RF bandwidth information to user manual. (PR #444)
 5. Cleanup:
     * Refactor configuration handling in the codebase. (PR #457)
+    * Clean up compiler warnings on Windows builds. (PR #475)
 6. Miscellaneous:
     * Set default FreeDV Reporter hostname to qso.freedv.org. (PR #448)
 

--- a/cross-compile/freedv-mingw-llvm-aarch64.cmake
+++ b/cross-compile/freedv-mingw-llvm-aarch64.cmake
@@ -13,7 +13,7 @@ set(CMAKE_RC_COMPILER ${triple}-windres)
 
 set(CMAKE_C_FLAGS -gcodeview)
 set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-aarch64.cmake
+++ b/cross-compile/freedv-mingw-llvm-aarch64.cmake
@@ -11,9 +11,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS -gcodeview)
-set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
+set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-armv7.cmake
+++ b/cross-compile/freedv-mingw-llvm-armv7.cmake
@@ -12,9 +12,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS -gcodeview)
-set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
+set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-armv7.cmake
+++ b/cross-compile/freedv-mingw-llvm-armv7.cmake
@@ -14,7 +14,7 @@ set(CMAKE_RC_COMPILER ${triple}-windres)
 
 set(CMAKE_C_FLAGS -gcodeview)
 set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-i686.cmake
+++ b/cross-compile/freedv-mingw-llvm-i686.cmake
@@ -12,9 +12,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS -gcodeview)
-set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
+set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-i686.cmake
+++ b/cross-compile/freedv-mingw-llvm-i686.cmake
@@ -14,7 +14,7 @@ set(CMAKE_RC_COMPILER ${triple}-windres)
 
 set(CMAKE_C_FLAGS -gcodeview)
 set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-x86_64.cmake
+++ b/cross-compile/freedv-mingw-llvm-x86_64.cmake
@@ -12,9 +12,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS -gcodeview)
-set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
+set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-x86_64.cmake
+++ b/cross-compile/freedv-mingw-llvm-x86_64.cmake
@@ -14,7 +14,7 @@ set(CMAKE_RC_COMPILER ${triple}-windres)
 
 set(CMAKE_C_FLAGS -gcodeview)
 set(CMAKE_CXX_FLAGS -gcodeview)
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_EXE_LINKER_FLAGS -Wno-unused-command-line-argument -Wl,--pdb=)
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/src/reporting/pskreporter.cpp
+++ b/src/reporting/pskreporter.cpp
@@ -32,7 +32,11 @@
 #include <unistd.h>
 #include <time.h>
 #if defined(WIN32) || defined(__MINGW32__)
+
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
+#endif // !_WIN32_WINNT
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <ws2def.h>

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <string>
 #include <unistd.h>
 #include "serialport.h"
 
@@ -131,12 +132,12 @@ error:
         {
 #ifdef UNICODE
             std::vector<char> buffer;
-            std::string errFn = "[Unknown Function]"
-            int size = WideCharToMultiByte(CP_UTF8, 0, text, -1, NULL, 0, NULL, NULL);
+            std::string errFn = "[Unknown Function]";
+            int size = WideCharToMultiByte(CP_UTF8, 0, lpszFunction, -1, NULL, 0, NULL, NULL);
             if (size > 0) 
             {
                 buffer.resize(size);
-                WideCharToMultiByte(CP_UTF8, 0, text, -1, static_cast<BYTE*>(&buffer[0]), buffer.size(), NULL, NULL);
+                WideCharToMultiByte(CP_UTF8, 0, lpszFunction, -1, static_cast<LPSTR>(&buffer[0]), buffer.size(), NULL, NULL);
                 errFn = std::string(&buffer[0]);
             }
             else 

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -127,7 +127,27 @@ bool Serialport::openport(const char name[], bool useRTS, bool RTSPos, bool useD
 	    return true;
 	
 error:
-	    if (g_verbose) fprintf(stderr, "%s failed\n", lpszFunction);
+	    if (g_verbose)
+        {
+#ifdef UNICODE
+            std::vector<char> buffer;
+            std::string errFn = "[Unknown Function]"
+            int size = WideCharToMultiByte(CP_UTF8, 0, text, -1, NULL, 0, NULL, NULL);
+            if (size > 0) 
+            {
+                buffer.resize(size);
+                WideCharToMultiByte(CP_UTF8, 0, text, -1, static_cast<BYTE*>(&buffer[0]), buffer.size(), NULL, NULL);
+                errFn = std::string(&buffer[0]);
+            }
+            else 
+            {
+                // Error handling, probably shouldn't reach here
+            }
+            fprintf(stderr, "%s failed\n", errFn.c_str());
+#else
+            fprintf(stderr, "%s failed\n", lpszFunction);
+#endif // UNICODE
+        }
 	
         // Retrieve the system error message for the last-error code
 


### PR DESCRIPTION
As the title of the PR suggests. This also fixes some logic errors as a result (such as incorrectly treating wide chars as regular ones).