### PR TITLE
Fix bug preventing proper Options window sizing on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.8.12)
+set(PROJECT_VERSION 1.8.13)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -42,7 +42,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -886,6 +886,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.8.13 TBD 2023
+
+1. Bugfixes:
+    * Fix bug preventing proper Options window sizing on Windows. (PR #478)
+
 ## V1.8.12 July 2023
 
 1. Bugfixes:

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -46,7 +46,7 @@ cd src && sox ../../wav/wia.wav -t raw -r 16000 - | ./lpcnet_enc -s | ./lpcnet_d
 # Build codec2 with LPCNet and test FreeDV 2020 support
 cd $FREEDVGUIDIR
 if [ ! -d codec2 ]; then
-    git clone https://github.com/drowe67/codec2.git
+    git clone https://github.com/drowe67/codec2-new.git codec2
 fi
 cd codec2 && git checkout v1.1.1 && git pull && git checkout $CODEC2_BRANCH
 mkdir -p build_osx && cd build_osx && rm -Rf * && cmake -DLPCNET_BUILD_DIR=$LPCNETDIR/build_osx -DBUILD_OSX_UNIVERSAL=1 .. && make VERBOSE=1 -j4

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -187,8 +187,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     wxGridBagSizer* gridSizer = new wxGridBagSizer(5, 5);
     
     m_freqList = new wxListBox(m_rigControlTab, wxID_ANY, wxDefaultPosition, wxSize(350,150), 0, NULL, wxLB_SINGLE | wxLB_NEEDED_SB);
-    //m_freqList->SetMinSize(wxSize(250, -1));
-    //m_freqList->SetMaxSize(wxSize(-1, 350));
     gridSizer->Add(m_freqList, wxGBPosition(0, 0), wxGBSpan(5, 2), wxEXPAND);
 
     const int FREQ_LIST_BUTTON_WIDTH = 100; 

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -186,24 +186,27 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     wxGridBagSizer* gridSizer = new wxGridBagSizer(5, 5);
     
-    m_freqList = new wxListBox(m_rigControlTab, wxID_ANY);
-    m_freqList->SetMinSize(wxSize(250, -1));
-    gridSizer->Add(m_freqList, wxGBPosition(0, 0), wxGBSpan(4, 2), wxEXPAND);
-        
-    m_freqListAdd = new wxButton(m_rigControlTab, wxID_ANY, _("Add"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_freqList = new wxListBox(m_rigControlTab, wxID_ANY, wxDefaultPosition, wxSize(350,150), 0, NULL, wxLB_SINGLE | wxLB_NEEDED_SB);
+    //m_freqList->SetMinSize(wxSize(250, -1));
+    //m_freqList->SetMaxSize(wxSize(-1, 350));
+    gridSizer->Add(m_freqList, wxGBPosition(0, 0), wxGBSpan(5, 2), wxEXPAND);
+
+    const int FREQ_LIST_BUTTON_WIDTH = 100; 
+    const int FREQ_LIST_BUTTON_HEIGHT = -1;
+    m_freqListAdd = new wxButton(m_rigControlTab, wxID_ANY, _("Add"), wxDefaultPosition, wxSize(FREQ_LIST_BUTTON_WIDTH,FREQ_LIST_BUTTON_HEIGHT), 0);
     gridSizer->Add(m_freqListAdd, wxGBPosition(0, 2), wxDefaultSpan, wxEXPAND);
-    m_freqListRemove = new wxButton(m_rigControlTab, wxID_ANY, _("Remove"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_freqListRemove = new wxButton(m_rigControlTab, wxID_ANY, _("Remove"), wxDefaultPosition, wxSize(FREQ_LIST_BUTTON_WIDTH,FREQ_LIST_BUTTON_HEIGHT), 0);
     gridSizer->Add(m_freqListRemove, wxGBPosition(1, 2), wxDefaultSpan, wxEXPAND);
-    m_freqListMoveUp = new wxButton(m_rigControlTab, wxID_ANY, _("Move Up"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_freqListMoveUp = new wxButton(m_rigControlTab, wxID_ANY, _("Move Up"), wxDefaultPosition, wxSize(FREQ_LIST_BUTTON_WIDTH,FREQ_LIST_BUTTON_HEIGHT), 0);
     gridSizer->Add(m_freqListMoveUp, wxGBPosition(2, 2), wxDefaultSpan, wxEXPAND);
-    m_freqListMoveDown = new wxButton(m_rigControlTab, wxID_ANY, _("Move Down"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_freqListMoveDown = new wxButton(m_rigControlTab, wxID_ANY, _("Move Down"), wxDefaultPosition, wxSize(FREQ_LIST_BUTTON_WIDTH,FREQ_LIST_BUTTON_HEIGHT), 0);
     gridSizer->Add(m_freqListMoveDown, wxGBPosition(3, 2), wxDefaultSpan, wxEXPAND);
     
     wxStaticText* labelEnterFreq = new wxStaticText(m_rigControlTab, wxID_ANY, wxT("Enter frequency (MHz):"), wxDefaultPosition, wxDefaultSize, 0);
-    gridSizer->Add(labelEnterFreq, wxGBPosition(4, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+    gridSizer->Add(labelEnterFreq, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
     
     m_txtCtrlNewFrequency = new wxTextCtrl(m_rigControlTab, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
-    gridSizer->Add(m_txtCtrlNewFrequency, wxGBPosition(4, 1), wxGBSpan(1, 2), wxEXPAND);
+    gridSizer->Add(m_txtCtrlNewFrequency, wxGBPosition(5, 1), wxGBSpan(1, 2), wxEXPAND);
     
     sbSizer_freqList->Add(gridSizer, 0, wxALL, 5);
     
@@ -537,7 +540,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     this->SetSizerAndFit(winSizer);
     this->Layout();
     this->Centre(wxBOTH);
- 
+
     //-------------------
     // Tab ordering for accessibility
     //-------------------

--- a/src/dlg_options.h
+++ b/src/dlg_options.h
@@ -35,7 +35,7 @@ class OptionsDlg : public wxDialog
                 wxWindowID id = wxID_ANY, const wxString& title = _("Options"), 
                 const wxPoint& pos = wxDefaultPosition, 
                 const wxSize& size = wxDefaultSize, 
-                long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxTAB_TRAVERSAL );
+                long style = wxDEFAULT_DIALOG_STYLE|wxTAB_TRAVERSAL );
         ~OptionsDlg();
 
         void    ExchangeData(int inout, bool storePersistent);


### PR DESCRIPTION
Reported by several people from the digitalvoice mailing list, it appears that the OK/Cancel/Apply buttons are now hidden on 1.8.12 in Windows unless the window is resized. Additionally, I've noticed some oddities with the frequency list control sizing when the Options window's resized on Linux (tested on Ubuntu 22.04 LTS). This PR does the following:

1. Disables resizing of the Options window. Since the other controls on that dialog don't resize, there's not much point in allowing users to do so.
2. Forces sizing of the various frequency list related controls to prevent them from being resized when data is loaded from the user's configuration.