### PR TITLE
Remove 2400B mode from the UI.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -886,6 +886,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.8.13 TBD 2023
+
+1. Cleanup:
+    * Remove 2400B mode from the UI, (PR #479)
+
 ## V1.8.12 July 2023
 
 1. Bugfixes:

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -48,8 +48,6 @@ static const char* GetCurrentModeStrImpl_(int mode)
 #endif // FREEDV_MODE_2020B
         case FREEDV_MODE_800XA:
             return "800XA";
-        case FREEDV_MODE_2400B:
-            return "2400B";
         default:
             return "unk";
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1820,7 +1820,7 @@ void MainFrame::performFreeDVOn_()
             freedvInterface.setTextVaricodeNum(1);
 
         // scatter plot (PSK) or Eye (FSK) mode
-        if ((g_mode == FREEDV_MODE_800XA) || (g_mode == FREEDV_MODE_2400A)) {
+        if (g_mode == FREEDV_MODE_800XA) {
             m_panelScatter->setEyeScatter(PLOT_SCATTER_MODE_EYE);
         }
         else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -442,8 +442,7 @@ setDefaultMode:
         m_rb700e->SetValue(1);
     if (mode == 6)
         m_rb800xa->SetValue(1);
-    if (mode == 7)
-        m_rb2400b->SetValue(1);
+    // mode 7 was the former 2400B mode, now removed.
     if ((mode == 9) && wxGetApp().appConfiguration.freedv2020Allowed)
         m_rb2020->SetValue(1);
     else if (mode == 9)
@@ -824,8 +823,6 @@ MainFrame::~MainFrame()
         mode = 5;
     if (m_rb800xa->GetValue())
         mode = 6;
-    if (m_rb2400b->GetValue())
-        mode = 7;
     if (m_rb2020->GetValue())
         mode = 9;
 #if defined(FREEDV_MODE_2020B)
@@ -965,7 +962,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             }
             wxGetApp().m_prevMode = currentMode;
         
-            if ((currentMode == FREEDV_MODE_800XA) || (currentMode == FREEDV_MODE_2400B) ) {
+            if (currentMode == FREEDV_MODE_800XA) {
 
                 /* FSK Mode - eye diagram ---------------------------------------------------------*/
 
@@ -1579,7 +1576,6 @@ void MainFrame::OnChangeTxMode( wxCommandEvent& event )
         m_rb700e,
         m_rb800xa,
         m_rb1600,
-        m_rb2400b,
         m_rb2020,
 #if defined(FREEDV_MODE_2020B)
         m_rb2020b,
@@ -1623,10 +1619,6 @@ void MainFrame::OnChangeTxMode( wxCommandEvent& event )
     else if (eventObject == m_rb800xa || (eventObject == nullptr && m_rb800xa->GetValue())) 
     {
         g_mode = FREEDV_MODE_800XA;
-    }
-    else if (eventObject == m_rb2400b || (eventObject == nullptr && m_rb2400b->GetValue())) 
-    {
-        g_mode = FREEDV_MODE_2400B;
     }
     else if (eventObject == m_rb2020 || (eventObject == nullptr && m_rb2020->GetValue())) 
     {
@@ -1715,7 +1707,7 @@ void MainFrame::performFreeDVOn_()
         wxCommandEvent tmpEvent;
         OnChangeTxMode(tmpEvent);
 
-        if (g_mode == FREEDV_MODE_2400B || g_mode == FREEDV_MODE_800XA || 
+        if (g_mode == FREEDV_MODE_800XA || 
             !wxGetApp().appConfiguration.multipleReceiveEnabled)
         {
             m_rb1600->Disable();
@@ -1723,7 +1715,6 @@ void MainFrame::performFreeDVOn_()
             m_rb700d->Disable();
             m_rb700e->Disable();
             m_rb800xa->Disable();
-            m_rb2400b->Disable();
             m_rb2020->Disable();
     #if defined(FREEDV_MODE_2020B)
             m_rb2020b->Disable();
@@ -1749,7 +1740,6 @@ void MainFrame::performFreeDVOn_()
                 // These modes require more CPU than typical (and will drive at least one core to 100% if
                 // used with the other five above), so we're excluding them from multi-RX. They also aren't
                 // selectable during a session when multi-RX is enabled.
-                //FREEDV_MODE_2400B,
                 //FREEDV_MODE_800XA
             };
             for (auto& mode : rxModes)
@@ -1758,7 +1748,6 @@ void MainFrame::performFreeDVOn_()
             }
         
             m_rb800xa->Disable();
-            m_rb2400b->Disable();
             
             // If we're receive-only, it doesn't make sense to be able to change TX mode.
             if (g_nSoundCards <= 1)
@@ -1831,7 +1820,7 @@ void MainFrame::performFreeDVOn_()
             freedvInterface.setTextVaricodeNum(1);
 
         // scatter plot (PSK) or Eye (FSK) mode
-        if ((g_mode == FREEDV_MODE_800XA) || (g_mode == FREEDV_MODE_2400A) || (g_mode == FREEDV_MODE_2400B)) {
+        if ((g_mode == FREEDV_MODE_800XA) || (g_mode == FREEDV_MODE_2400A)) {
             m_panelScatter->setEyeScatter(PLOT_SCATTER_MODE_EYE);
         }
         else {
@@ -2114,7 +2103,6 @@ void MainFrame::performFreeDVOff_()
         m_rb700d->Enable();
         m_rb700e->Enable();
         m_rb800xa->Enable();
-        m_rb2400b->Enable();
         if(wxGetApp().appConfiguration.freedv2020Allowed)
         {
             m_rb2020->Enable();

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -267,7 +267,7 @@ bool MainFrame::OpenHamlibRig() {
                 m_txtModeStatus, 
                 wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled &&
                     wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting ? nullptr : m_cboReportFrequency, 
-                g_mode == FREEDV_MODE_2400B);
+                false);
         }
     
         return status;

--- a/src/pipeline/FreeDVTransmitStep.cpp
+++ b/src/pipeline/FreeDVTransmitStep.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<short> FreeDVTransmitStep::execute(std::shared_ptr<short> inputS
             
             codec2_fifo_read(inputSampleFifo_, codecInput, samplesUsedForFifo);
             
-            if (mode == FREEDV_MODE_800XA || mode == FREEDV_MODE_2400B) 
+            if (mode == FREEDV_MODE_800XA) 
             {
                 /* 800XA doesn't support complex output just yet */
                 freedv_tx(dv_, tmpOutput, codecInput);
@@ -143,7 +143,7 @@ std::shared_ptr<short> FreeDVTransmitStep::execute(std::shared_ptr<short> inputS
             {
                 codec2_fifo_read(inputSampleFifo_, codecInput, samplesUsedForFifo);
                 
-                if (mode == FREEDV_MODE_800XA || mode == FREEDV_MODE_2400B) 
+                if (mode == FREEDV_MODE_800XA) 
                 {
                     /* 800XA doesn't support complex output just yet */
                     freedv_tx(dv_, tmpOutput, codecInput);

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -481,8 +481,7 @@ void TxRxThread::txProcessing_()
     // Buffers re-used by tx and rx processing.  We take samples from
     // the sound card, and resample them for the freedv modem input
     // sample rate.  Typically the sound card is running at 48 or 44.1
-    // kHz, and the modem at 8kHz, however some modems such as FreeDV
-    // 2400A/B run at 48 kHz.
+    // kHz, and the modem at 8kHz
 
     // allocate enough room for 20ms processing buffers at maximum
     // sample rate of 48 kHz.  Note these buffer are used by rx and tx
@@ -582,8 +581,7 @@ void TxRxThread::rxProcessing_()
     // Buffers re-used by tx and rx processing.  We take samples from
     // the sound card, and resample them for the freedv modem input
     // sample rate.  Typically the sound card is running at 48 or 44.1
-    // kHz, and the modem at 8kHz, however some modems such as FreeDV
-    // 2400A/B run at 48 kHz.
+    // kHz, and the modem at 8kHz.
 
     // allocate enough room for 20ms processing buffers at maximum
     // sample rate of 48 kHz.  Note these buffer are used by rx and tx

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -383,8 +383,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     otherModeSizer->Add(m_rb700c, 1, wxALIGN_LEFT|wxALL|wxEXPAND, 1);
     m_rb800xa = new wxRadioButton( otherModeWin, wxID_ANY, wxT("800XA"), wxDefaultPosition, wxDefaultSize, 0);
     otherModeSizer->Add(m_rb800xa, 1, wxALIGN_LEFT|wxALL|wxEXPAND, 1);
-    m_rb2400b = new wxRadioButton( otherModeWin, wxID_ANY, wxT("2400B"), wxDefaultPosition, wxDefaultSize, 0);
-    otherModeSizer->Add(m_rb2400b, 1, wxALIGN_LEFT|wxALL|wxEXPAND, 1);
     m_rb2020 = new wxRadioButton( otherModeWin, wxID_ANY, wxT("2020"), wxDefaultPosition, wxDefaultSize,  0);
     otherModeSizer->Add(m_rb2020, 1, wxALIGN_LEFT|wxALL|wxEXPAND, 1);
 #if defined(FREEDV_MODE_2020B)
@@ -488,8 +486,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_rb700e->MoveBeforeInTabOrder(m_rb1600);
     
     m_rb700c->MoveBeforeInTabOrder(m_rb800xa);
-    m_rb800xa->MoveBeforeInTabOrder(m_rb2400b);
-    m_rb2400b->MoveBeforeInTabOrder(m_rb2020);
+    m_rb800xa->MoveBeforeInTabOrder(m_rb2020);
 #if defined(FREEDV_MODE_2020B)
     m_rb2020->MoveBeforeInTabOrder(m_rb2020b);
 #endif // FREEDV_MODE_2020B
@@ -559,7 +556,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_rb700e->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb800xa->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb1600->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb2400b->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb2020->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
 #if defined(FREEDV_MODE_2020B)
     m_rb2020b->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
@@ -639,7 +635,6 @@ TopFrame::~TopFrame()
     m_rb700e->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb800xa->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb1600->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb2400b->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
     m_rb2020->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
 #if defined(FREEDV_MODE_2020B)
     m_rb2020b->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -135,7 +135,6 @@ class TopFrame : public wxFrame
         wxRadioButton *m_rb700e;
         wxRadioButton *m_rb800xa;
         wxRadioButton *m_rb1600;
-        wxRadioButton *m_rb2400b;
         wxRadioButton *m_rb2020;
 #if defined(FREEDV_MODE_2020B)
         wxRadioButton *m_rb2020b;


### PR DESCRIPTION
As part of the cleanup of the [Codec2 repository](https://github.com/drowe67/codec2-new/pull/3), this PR removes the rarely-used 2400B mode from the application UI. Note that this was approved by the FreeDV PLT in its latest meeting on July 14th, 2023.