### PR TITLE
Fix minor issues with the Easy Setup dialog.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -891,6 +891,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Fix bug preventing proper Options window sizing on Windows. (PR #478)
     * Fix various screen reader accessibility issues. (PR #481)
+    * Fix minor UI issues with the Easy Setup dialog. (PR #484)
 2. Build system:
     * Update Codec2 to v1.2.0. (PR #483)
 3. Cleanup:

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -164,7 +164,8 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     m_cbPttMethod->Append(wxT("CAT"));
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
-    
+    m_cbPttMethod->SetSelection(0);
+
     /* Serial port box */
     m_serialBox = new wxStaticBox(setupCatControlBox, wxID_ANY, _("Serial PTT"));
     m_serialBox->Hide();
@@ -239,7 +240,7 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     m_txt_callsign = new wxTextCtrl(setupPskReporterBox, wxID_ANY,  wxEmptyString, wxDefaultPosition, wxSize(90,-1), 0, wxTextValidator(wxFILTER_ALPHANUMERIC));
     sbSizer_psk->Add(m_txt_callsign, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
     
-    wxStaticText* labelPskGridSquare = new wxStaticText(setupPskReporterBox, wxID_ANY, wxT("Grid Square: "), wxDefaultPosition, wxDefaultSize, 0);
+    wxStaticText* labelPskGridSquare = new wxStaticText(setupPskReporterBox, wxID_ANY, wxT("Grid Square/Locator: "), wxDefaultPosition, wxDefaultSize, 0);
     sbSizer_psk->Add(labelPskGridSquare, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
     
     m_txt_grid_square = new wxTextCtrl(setupPskReporterBox, wxID_ANY,  wxEmptyString, wxDefaultPosition, wxSize(80,-1), 0, wxTextValidator(wxFILTER_ALPHANUMERIC));
@@ -636,6 +637,12 @@ void EasySetupDialog::resetIcomCIVStatus_()
     {
         m_stIcomCIVHex->Show();
         m_tcIcomCIVHex->Show();
+
+        // Load existing CIV address so we can make sure we get the default.
+        if (m_tcIcomCIVHex->GetValue().length() == 0)
+        {
+            m_tcIcomCIVHex->SetValue(wxString::Format(wxT("%02X"), wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress.get()));
+        }
     }
     else
     {


### PR DESCRIPTION
Resolves #482 by doing the following:

1. Ensures that the default CI-V address is loaded when an Icom radio is selected and there's not already one in the text box.
2. Default "PTT via" to "CAT" if not already selected.
3. Change "Grid Square" label to "Grid Square/Locator" to match Tools->Options->Reporting.