### PR TITLE
Allow users to configure PTT port separately from CAT if Hamlib is enabled.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -897,9 +897,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix various screen reader accessibility issues. (PR #481)
     * Use separate maximums for each slider type on the Filter dialog. (PR #485)
     * Fix minor UI issues with the Easy Setup dialog. (PR #484)
-2. Build system:
+2. Enhancements:
+    * Allow users to configure PTT port separately from CAT if Hamlib is enabled. (PR #488)
+3. Build system:
     * Update Codec2 to v1.2.0. (PR #483)
-3. Cleanup:
+4. Cleanup:
     * Remove 2400B mode from the UI. (PR #479)
 
 ## V1.8.12 July 2023

--- a/src/config/RigControlConfiguration.cpp
+++ b/src/config/RigControlConfiguration.cpp
@@ -30,6 +30,7 @@ RigControlConfiguration::RigControlConfiguration()
     , hamlibPTTType("/Hamlib/PttType", 0)
     , hamlibSerialRate("/Hamlib/SerialRate", 0)
     , hamlibSerialPort("/Hamlib/SerialPort", "")
+    , hamlibPttSerialPort("/Hamlib/PttSerialPort", "")
         
     , useSerialPTT("/Rig/UseSerialPTT", false)
     , serialPTTPort("/Rig/Port", "")
@@ -58,6 +59,12 @@ void RigControlConfiguration::load(wxConfigBase* config)
     load_(config, hamlibSerialRate);
     load_(config, hamlibSerialPort);
     
+    // By default, the PTT serial port should be the same as the 
+    // regular serial port.
+    auto tmp = hamlibSerialPort.getWithoutProcessing();
+    hamlibPttSerialPort.setDefaultVal(tmp);
+    load_(config, hamlibPttSerialPort);
+    
     load_(config, useSerialPTT);
     load_(config, serialPTTPort);
     load_(config, serialPTTUseRTS);
@@ -82,6 +89,7 @@ void RigControlConfiguration::save(wxConfigBase* config)
     save_(config, hamlibPTTType);
     save_(config, hamlibSerialRate);
     save_(config, hamlibSerialPort);
+    save_(config, hamlibPttSerialPort);
     
     save_(config, useSerialPTT);
     save_(config, serialPTTPort);

--- a/src/config/RigControlConfiguration.h
+++ b/src/config/RigControlConfiguration.h
@@ -39,6 +39,7 @@ public:
     ConfigurationDataElement<unsigned int> hamlibPTTType;
     ConfigurationDataElement<unsigned int> hamlibSerialRate;
     ConfigurationDataElement<wxString> hamlibSerialPort;
+    ConfigurationDataElement<wxString> hamlibPttSerialPort;
     
     ConfigurationDataElement<bool> useSerialPTT;
     ConfigurationDataElement<wxString> serialPTTPort;

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -555,6 +555,7 @@ void EasySetupDialog::ExchangePttDeviceData(int inout)
             wxGetApp().m_intHamlibRig = m_cbRigName->GetSelection();
             wxGetApp().appConfiguration.rigControlConfiguration.hamlibRigName = hamlib->rigIndexToName(wxGetApp().m_intHamlibRig);
             wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialPort = m_cbSerialPort->GetValue();
+            wxGetApp().appConfiguration.rigControlConfiguration.hamlibPttSerialPort = m_cbSerialPort->GetValue();
             
             wxString s = m_tcIcomCIVHex->GetValue();
             long hexAddress = 0;

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -589,7 +589,7 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
             Hamlib *hamlib = wxGetApp().m_hamlib; 
             bool status = hamlib->connect(
                 rig, port.mb_str(wxConvUTF8), serial_rate, hexAddress, pttType,
-                (pttType != Hamlib::PTT_VIA_CAT) ? pttPort.mb_str(wxConvUTF8) : nullptr );
+                (pttType == Hamlib::PTT_VIA_CAT) ? port.mb_str(wxConvUTF8) : pttPort.mb_str(wxConvUTF8) );
             if (status == false) {
                 wxMessageBox("Couldn't connect to Radio with Hamlib.  Make sure the Hamlib serial Device, Rate, and Params match your radio", 
                 wxT("Error"), wxOK | wxICON_ERROR, this);

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -59,7 +59,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
 
     wxStaticBox* hamlibBox = new wxStaticBox(panel, wxID_ANY, _("Hamlib Settings"));
     wxStaticBoxSizer* staticBoxSizer18 = new wxStaticBoxSizer( hamlibBox, wxHORIZONTAL);
-    wxGridSizer* gridSizerhl = new wxGridSizer(7, 2, 0, 0);
+    wxGridSizer* gridSizerhl = new wxGridSizer(8, 2, 0, 0);
     staticBoxSizer18->Add(gridSizerhl, 1, wxEXPAND|wxALIGN_LEFT, 5);
 
     /* Use Hamlib for PTT checkbox. */
@@ -108,6 +108,14 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbPttMethod = new wxComboBox(hamlibBox, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_DROPDOWN | wxCB_READONLY);
     m_cbPttMethod->SetSize(wxSize(140, -1));
     gridSizerhl->Add(m_cbPttMethod, 0, wxALIGN_CENTER_VERTICAL, 0);
+    
+    /* Hamlib PTT serial port combobox */
+    
+    gridSizerhl->Add(new wxStaticText(hamlibBox, wxID_ANY, _("PTT Serial Device:"), wxDefaultPosition, wxDefaultSize, 0), 
+                      0, wxALIGN_CENTER_VERTICAL |  wxALIGN_RIGHT, 20);
+    m_cbPttSerialPort = new wxComboBox(hamlibBox, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_DROPDOWN);
+    m_cbPttSerialPort->SetMinSize(wxSize(140, -1));
+    gridSizerhl->Add(m_cbPttSerialPort, 0, wxEXPAND, 0);
     
     // Add valid PTT options to combo box.
     m_cbPttMethod->Append(wxT("CAT"));
@@ -244,6 +252,9 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_buttonCancel->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnCancel), NULL, this);
     m_buttonApply->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnApply), NULL, this);
     m_buttonTest->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnTest), NULL, this);
+    
+    m_cbSerialPort->Connect(wxEVT_TEXT, wxCommandEventHandler(ComPortsDlg::OnHamlibSerialPortChanged), NULL, this);
+    m_cbPttMethod->Connect(wxEVT_TEXT, wxCommandEventHandler(ComPortsDlg::OnHamlibPttMethodChanged), NULL, this);
 }
 
 //-------------------------------------------------------------------------
@@ -261,6 +272,8 @@ ComPortsDlg::~ComPortsDlg()
     m_buttonCancel->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnCancel), NULL, this);
     m_buttonApply->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnApply), NULL, this);
     m_buttonTest->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ComPortsDlg::OnTest), NULL, this);
+    m_cbSerialPort->Disconnect(wxEVT_TEXT, wxCommandEventHandler(ComPortsDlg::OnHamlibSerialPortChanged), NULL, this);
+    m_cbPttMethod->Disconnect(wxEVT_TEXT, wxCommandEventHandler(ComPortsDlg::OnHamlibPttMethodChanged), NULL, this);
 }
 
 //-------------------------------------------------------------------------
@@ -421,6 +434,7 @@ void ComPortsDlg::populatePortList()
     {
         m_cbCtlDevicePath->Append(port);
         m_cbSerialPort->Append(port);
+        m_cbPttSerialPort->Append(port);
         m_cbCtlDevicePathPttIn->Append(port);
     }
 }
@@ -441,6 +455,7 @@ void ComPortsDlg::ExchangeData(int inout)
         m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
         resetIcomCIVStatus();
         m_cbSerialPort->SetValue(wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialPort);
+        m_cbPttSerialPort->SetValue(wxGetApp().appConfiguration.rigControlConfiguration.hamlibPttSerialPort);
 
         if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialRate == 0) {
             m_cbSerialRate->SetSelection(0);
@@ -482,6 +497,7 @@ void ComPortsDlg::ExchangeData(int inout)
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibRigName = hamlib->rigIndexToName(wxGetApp().m_intHamlibRig);
         
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialPort = m_cbSerialPort->GetValue();
+        wxGetApp().appConfiguration.rigControlConfiguration.hamlibPttSerialPort = m_cbPttSerialPort->GetValue();
         
         wxString s = m_tcIcomCIVHex->GetValue();
         long hexAddress = 0;
@@ -546,6 +562,7 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
 
         int rig = m_cbRigName->GetSelection();
         wxString port = m_cbSerialPort->GetValue();
+        wxString pttPort = m_cbPttSerialPort->GetValue();
         wxString s = m_cbSerialRate->GetValue();
         int serial_rate;
         if (s == "default") {
@@ -570,7 +587,9 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
         {
             // try to open rig
             Hamlib *hamlib = wxGetApp().m_hamlib; 
-            bool status = hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate, hexAddress, pttType);
+            bool status = hamlib->connect(
+                rig, port.mb_str(wxConvUTF8), serial_rate, hexAddress, pttType,
+                (pttType != Hamlib::PTT_VIA_CAT) ? pttPort.mb_str(wxConvUTF8) : nullptr );
             if (status == false) {
                 wxMessageBox("Couldn't connect to Radio with Hamlib.  Make sure the Hamlib serial Device, Rate, and Params match your radio", 
                 wxT("Error"), wxOK | wxICON_ERROR, this);
@@ -728,6 +747,7 @@ void ComPortsDlg::updateControlState()
     m_cbSerialRate->Enable(m_ckUseHamlibPTT->GetValue());
     m_tcIcomCIVHex->Enable(m_ckUseHamlibPTT->GetValue());
     m_cbPttMethod->Enable(m_ckUseHamlibPTT->GetValue());
+    m_cbPttSerialPort->Enable(m_ckUseHamlibPTT->GetValue());
 
     m_cbCtlDevicePath->Enable(m_ckUseSerialPTT->GetValue());
     m_rbUseDTR->Enable(m_ckUseSerialPTT->GetValue());
@@ -739,4 +759,23 @@ void ComPortsDlg::updateControlState()
     m_ckCTSPos->Enable(m_ckUsePTTInput->GetValue());
     
     m_buttonTest->Enable(m_ckUseHamlibPTT->GetValue() || m_ckUseSerialPTT->GetValue());    
+    
+    if (m_cbPttMethod->GetValue() == _("CAT"))
+    {
+        m_cbPttSerialPort->Enable(false);
+    }
+}
+
+void ComPortsDlg::OnHamlibSerialPortChanged(wxCommandEvent& event)
+{
+    if (m_cbPttMethod->GetValue() == _("CAT"))
+    {
+        // Make sure PTT serial port matches CAT port
+        m_cbPttSerialPort->SetValue(m_cbSerialPort->GetValue());
+    }
+}
+
+void ComPortsDlg::OnHamlibPttMethodChanged(wxCommandEvent& event)
+{
+    updateControlState();
 }

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -57,6 +57,7 @@ class ComPortsDlg : public wxDialog
         wxCheckBox *m_ckUseHamlibPTT;
         wxComboBox *m_cbRigName;
         wxComboBox *m_cbSerialPort;
+        wxComboBox *m_cbPttSerialPort;
         wxComboBox *m_cbSerialRate;
         wxStaticText  *m_cbSerialParams;
         wxStaticText *m_stIcomCIVHex;
@@ -95,6 +96,8 @@ protected:
         void PTTUseSerialClicked(wxCommandEvent& event);
         void PTTUseSerialInputClicked(wxCommandEvent& event);
         void HamlibRigNameChanged(wxCommandEvent& event);
+        void OnHamlibSerialPortChanged(wxCommandEvent& event);
+        void OnHamlibPttMethodChanged(wxCommandEvent& event);
         void resetIcomCIVStatus();
         bool savePttSettings();
         

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -141,7 +141,7 @@ void Hamlib::suppressFrequencyModeUpdates(bool suppress)
     updatesSuppressed_ = suppress;
 }
 
-bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex, const PttType pttType) {
+bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex, const PttType pttType, const char *pttSerialPort) {
     m_origFreq = 0;
     m_origMode = RIG_MODE_USB;
 
@@ -189,6 +189,11 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
 
     rig_set_conf(m_rig, rig_token_lookup(m_rig, "rig_pathname"), serial_port);
 
+    if (pttSerialPort != nullptr)
+    {
+        rig_set_conf(m_rig, rig_token_lookup(m_rig, "ptt_pathname"), pttSerialPort);
+    }
+    
     if (serial_rate) {
         if (g_verbose) fprintf(stderr, "hamlib: setting serial rate: %d\n", serial_rate);
         std::stringstream ss;

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -30,7 +30,7 @@ class Hamlib {
         std::string rigIndexToName(unsigned int rigIndex);
         
         void populateComboBox(wxComboBox *cb);
-        bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex = 0, const PttType pttType = PTT_VIA_CAT);
+        bool connect(unsigned int rig_index, const char *serial_port, const int serial_rate, const int civ_hex = 0, const PttType pttType = PTT_VIA_CAT, const char *pttSerialPort = nullptr);
         bool ptt(bool press, wxString &hamlibError);
         void enable_mode_detection(wxStaticText* statusBox, wxComboBox* freqBox, bool vhfUhfMode);
         void disable_mode_detection();

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -245,10 +245,16 @@ bool MainFrame::OpenHamlibRig() {
 
     int rig = wxGetApp().m_intHamlibRig;
     wxString port = wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialPort;
+    wxString pttPort = wxGetApp().appConfiguration.rigControlConfiguration.hamlibPttSerialPort;
+    auto pttType = (Hamlib::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get();
+    
     int serial_rate = wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialRate;
-    if (wxGetApp().CanAccessSerialPort((const char*)port.ToUTF8()))
+    if (wxGetApp().CanAccessSerialPort((const char*)port.ToUTF8()) && (
+        pttType == Hamlib::PTT_VIA_CAT || wxGetApp().CanAccessSerialPort((const char*)pttPort.ToUTF8())))
     {
-        bool status = wxGetApp().m_hamlib->connect(rig, port.mb_str(wxConvUTF8), serial_rate, wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress, (Hamlib::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get());
+        bool status = wxGetApp().m_hamlib->connect(
+            rig, port.mb_str(wxConvUTF8), serial_rate, wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress, 
+            pttType, pttType == Hamlib::PTT_VIA_CAT ? nullptr : pttPort.mb_str(wxConvUTF8));
         if (status == false)
         {
             wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -254,7 +254,7 @@ bool MainFrame::OpenHamlibRig() {
     {
         bool status = wxGetApp().m_hamlib->connect(
             rig, port.mb_str(wxConvUTF8), serial_rate, wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress, 
-            pttType, pttType == Hamlib::PTT_VIA_CAT ? nullptr : pttPort.mb_str(wxConvUTF8));
+            pttType, pttType == Hamlib::PTT_VIA_CAT ? port.mb_str(wxConvUTF8) : pttPort.mb_str(wxConvUTF8));
         if (status == false)
         {
             wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);


### PR DESCRIPTION
Resolves #477 by adding a separate PTT serial device drop-down for Hamlib (advanced PTT setup only, not on Easy Setup). This allows some radios that do not properly handle PTT over CAT to work with FreeDV.