### PR TITLE
Preserve averaging setting across restarts.

### DIFF
--- a/src/config/FreeDVConfiguration.cpp
+++ b/src/config/FreeDVConfiguration.cpp
@@ -96,6 +96,8 @@ FreeDVConfiguration::FreeDVConfiguration()
     , statsResetTimeSecs("/Stats/ResetTime", 10)
         
     , currentFreeDVMode("/Audio/mode", 4)
+        
+    , currentSpectrumAveraging("/Plot/Spectrum/CurrentAveraging", 0)
 {
     // empty
 }
@@ -168,6 +170,8 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     
     load_(config, statsResetTimeSecs);
     load_(config, currentFreeDVMode);
+    
+    load_(config, currentSpectrumAveraging);
     
     auto wxStandardPathObj = wxStandardPaths::Get();
     auto documentsDir = wxStandardPathObj.GetDocumentsDir();
@@ -245,6 +249,8 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     
     save_(config, statsResetTimeSecs);
     save_(config, currentFreeDVMode);
+    
+    save_(config, currentSpectrumAveraging);
     
     config->Flush();
 }

--- a/src/config/FreeDVConfiguration.h
+++ b/src/config/FreeDVConfiguration.h
@@ -105,6 +105,8 @@ public:
     
     ConfigurationDataElement<int> currentFreeDVMode;
     
+    ConfigurationDataElement<int> currentSpectrumAveraging;
+    
     virtual void load(wxConfigBase* config) override;
     virtual void save(wxConfigBase* config) override;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,8 +610,10 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
         "3"
     };
     m_cbxNumSpectrumAveraging = new wxComboBox(spectrumPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 3, samplingChoices, wxCB_DROPDOWN | wxCB_READONLY);
-    m_cbxNumSpectrumAveraging->SetSelection(0);
+    m_cbxNumSpectrumAveraging->SetSelection(wxGetApp().appConfiguration.currentSpectrumAveraging);
     spectrumPanelControlSizer->Add(m_cbxNumSpectrumAveraging, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    m_cbxNumSpectrumAveraging->Connect(wxEVT_TEXT, wxCommandEventHandler(MainFrame::OnAveragingChange), NULL, this);
     
     wxStaticText* labelSamples = new wxStaticText(spectrumPanel, wxID_ANY, wxT("sample(s)"), wxDefaultPosition, wxDefaultSize, 0);
     spectrumPanelControlSizer->Add(labelSamples, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
@@ -859,6 +861,7 @@ MainFrame::~MainFrame()
     wxGetApp().appConfiguration.currentFreeDVMode = mode;
     wxGetApp().appConfiguration.save(pConfig);
 
+    m_cbxNumSpectrumAveraging->Disconnect(wxEVT_TEXT, wxCommandEventHandler(MainFrame::OnAveragingChange), NULL, this);
     m_togBtnOnOff->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnOnOffUI), NULL, this);
     m_togBtnAnalog->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnAnalogClickUI), NULL, this);
 
@@ -925,6 +928,10 @@ void MainFrame::OnIdle(wxIdleEvent &evt) {
 }
 #endif
 
+void MainFrame::OnAveragingChange(wxCommandEvent& event)
+{
+    wxGetApp().appConfiguration.currentSpectrumAveraging = m_cbxNumSpectrumAveraging->GetSelection();
+}
 
 #ifdef _USE_TIMER
 //----------------------------------------------------------------

--- a/src/main.h
+++ b/src/main.h
@@ -340,6 +340,8 @@ class MainFrame : public TopFrame
         virtual void topFrame_OnSize( wxSizeEvent& event ) override;
         virtual void OnCloseFrame(wxCloseEvent& event);
         void OnExitClick(wxCommandEvent& event);
+        
+        void OnAveragingChange(wxCommandEvent& event);
 
         void startTxStream();
         void startRxStream();


### PR DESCRIPTION
An additional setting for spectrum plot averaging was added to #487 but didn't preserve this across restarts. This PR adds the necessary configuration option to enable this.