### PR TITLE
60 meters should be 5250-5450 KHz.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -903,7 +903,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Allow users to configure PTT port separately from CAT if Hamlib is enabled. (PR #488)
     * Add ability to average spectrum plot across 1-3 samples. (PR #487, 492)
     * Adjust sizing of main page tabs for better readability. (PR #487)
-    * Add band filtering in the FreeDV Reporter dialog. (PR #490)
+    * Add band filtering in the FreeDV Reporter dialog. (PR #490, #494)
 3. Build system:
     * Update Codec2 to v1.2.0. (PR #483)
     * Deprecate PortAudio support on Linux. (PR #489, #491)

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -675,7 +675,7 @@ bool FreeDVReporterDialog::isFiltered_(uint64_t freq)
     {
         bandForFreq = FilterFrequency::BAND_80M;
     }
-    else if (freq >= 5351500 && freq <= 5366500)
+    else if (freq >= 5250000 && freq <= 5450000)
     {
         bandForFreq = FilterFrequency::BAND_60M;
     }


### PR DESCRIPTION
Widens 60 meter band filter to 5250-5450 KHz per comments in the previous pull request (#490).