### PR TITLE
Resolve bug preventing certain radios' serial ports from being listed on macOS

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -899,6 +899,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix minor UI issues with the Easy Setup dialog. (PR #484)
     * Adjust waterfall settings to better visualize 2 Hz fading. (PR #487)
     * Fix issue causing the waterfall to not scroll at the expected rate. (PR #487)
+    * Resolve bug preventing certain radios' serial ports from being listed on macOS. (PR #496)
 2. Enhancements
     * Allow users to configure PTT port separately from CAT if Hamlib is enabled. (PR #488)
     * Add ability to average spectrum plot across 1-3 samples. (PR #487, 492)

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -1007,7 +1007,8 @@ void EasySetupDialog::updateHamlibDevices_()
         for(unsigned int i=0; i<gl.gl_pathc; i++) {
             if(gl.gl_pathv[i][strlen(gl.gl_pathv[i])-1]=='/')
                 continue;
-                
+
+#if defined(__FreeBSD__)
             /* Exclude pseudo TTYs */
             if(gl.gl_pathv[i][8] >= 'l' && gl.gl_pathv[i][8] <= 's')
                 continue;
@@ -1017,6 +1018,10 @@ void EasySetupDialog::updateHamlibDevices_()
             /* Exclude virtual TTYs */
             if(gl.gl_pathv[i][8] == 'v')
                 continue;
+#else
+            if (!strcmp("/dev/cu.wlan-debug", gl.gl_pathv[i]))
+                continue;
+#endif // defined(__FreeBSD__)
 
             /* Exclude initial-state and lock-state devices */
 #ifndef __WXOSX__

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -353,7 +353,8 @@ void ComPortsDlg::populatePortList()
         for(unsigned int i=0; i<gl.gl_pathc; i++) {
             if(gl.gl_pathv[i][strlen(gl.gl_pathv[i])-1]=='/')
                 continue;
-                
+
+#if defined(__FreeBSD__)                 
             /* Exclude pseudo TTYs */
             if(gl.gl_pathv[i][8] >= 'l' && gl.gl_pathv[i][8] <= 's')
                 continue;
@@ -363,6 +364,10 @@ void ComPortsDlg::populatePortList()
             /* Exclude virtual TTYs */
             if(gl.gl_pathv[i][8] == 'v')
                 continue;
+#else
+            if (!strcmp("/dev/cu.wlan-debug", gl.gl_pathv[i]))
+                continue;
+#endif // defined(__FreeBSD__) 
 
             /* Exclude initial-state and lock-state devices */
 #ifndef __WXOSX__


### PR DESCRIPTION
Reported on Discord. Basically, we were using the FreeBSD rules for filtering out serial ports from the PTT/Easy Setup dialogs, which meant that certain ports that are actually valid on macOS (i.e. `/dev/cu.SLAB*`) weren't being listed. This PR removes the unneeded port filtering for macOS and adds an additional macOS specific filter to remove `/dev/cu.wlan-debug`.