### PR TITLE
Revert BETA back to prior 1.9.0 value.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.0)
+set(PROJECT_VERSION 1.9.1)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -42,7 +42,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.1 TBD 2023
+
+1. Bugfixes:
+    * Revert BETA back to prior 1.9.0 value for waterfall. (PR #503)
+
 ## V1.9.0 August 2023
 
 1. Bugfixes:

--- a/src/defines.h
+++ b/src/defines.h
@@ -30,7 +30,7 @@
 #define MIN_MAG_DB        -40.0     // min of spectrogram/waterfall magnitude axis
 #define MAX_MAG_DB          0.0     // max of spectrogram/waterfall magnitude axis
 #define STEP_MAG_DB         5.0     // magnitude axis step
-#define BETA                0.75    // constant for time averaging spectrum data
+#define BETA                0.95    // constant for time averaging spectrum data
 #define MIN_F_HZ            0       // min freq on Waterfall and Spectrum
 #define MAX_F_HZ            3000    // max freq on Waterfall and Spectrum
 #define STEP_F_HZ           500     // major (e.g. text legend) freq step on Waterfall and Spectrum graticule


### PR DESCRIPTION
As part of #487, BETA was set to 0.75 to improve fast fading visualization. This PR reverts that change based on user feedback of version 1.9.0. All other waterfall changes from that PR seem okay (so far).