### PR TITLE
Don't delete from allReporterList unless disconnected.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -899,6 +899,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Revert BETA back to prior 1.9.0 value for waterfall. (PR #503)
+    * Optimize FreeDV Reporter window logic to reduce likelihood of waterfall stuttering. (PR #505)
+    * Fix intermittent crash during FreeDV Reporter updates. (PR #505)
 
 ## V1.9.0 August 2023
 

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -617,10 +617,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data)
     
     if (itemIndex >= 0 && filtered)
     {
-        // Remove as it has been filtered out.
-        delete allReporterData_[data->sid];
-        allReporterData_.erase(data->sid);
-        
+        // Remove as it has been filtered out.       
         delete (std::string*)m_listSpots->GetItemData(itemIndex);
         m_listSpots->DeleteItem(itemIndex);
         

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -618,26 +618,31 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data)
 
 void FreeDVReporterDialog::setColumnForRow_(int row, int col, wxString val)
 {
-    m_listSpots->SetItem(row, col, val);
+    auto oldText = m_listSpots->GetItemText(row, col);
     
-    auto itemFont = m_listSpots->GetItemFont(row);
-    int textWidth = 0;
-    int textHeight = 0; // Note: unused
+    if (oldText != val)
+    {
+        m_listSpots->SetItem(row, col, val);
     
-    // Note: if the font is invalid we should just use the default.
-    if (itemFont.IsOk())
-    {
-        GetTextExtent(val, &textWidth, &textHeight, nullptr, nullptr, &itemFont);
-    }
-    else
-    {
-        GetTextExtent(val, &textWidth, &textHeight);
-    }
+        auto itemFont = m_listSpots->GetItemFont(row);
+        int textWidth = 0;
+        int textHeight = 0; // Note: unused
     
-    if (textWidth > columnLengths_[col])
-    {
-        columnLengths_[col] = textWidth;
-        m_listSpots->SetColumnWidth(col, wxLIST_AUTOSIZE_USEHEADER);
+        // Note: if the font is invalid we should just use the default.
+        if (itemFont.IsOk())
+        {
+            GetTextExtent(val, &textWidth, &textHeight, nullptr, nullptr, &itemFont);
+        }
+        else
+        {
+            GetTextExtent(val, &textWidth, &textHeight);
+        }
+    
+        if (textWidth > columnLengths_[col])
+        {
+            columnLengths_[col] = textWidth;
+            m_listSpots->SetColumnWidth(col, wxLIST_AUTOSIZE_USEHEADER);
+        }
     }
 }
 

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -129,10 +129,10 @@ class FreeDVReporterDialog : public wxDialog
          
          wxString makeValidTime_(std::string timeStr);
          
-         void checkColumnsAndResize_();
-         
          void addOrUpdateListIfNotFiltered_(ReporterData* data);
          bool isFiltered_(uint64_t freq);
+         
+         void setColumnForRow_(int row, int col, wxString val);
 };
 
 #endif // __FREEDV_REPORTER_DIALOG__


### PR DESCRIPTION
This is a fix for #504 that removes a memory deallocation from allReporterList when an entry is filtered out (but not disconnected from FreeDV Reporter). This prevents invalid memory dereferencing when the filtered entry sends an update, thus preventing a crash.

This PR also contains optimizations to the FreeDV Reporter GUI logic to hopefully reduce the likelihood of the waterfall stuttering when the FreeDV Reporter window is open.