### PR TITLE
Initialize locale so we don't end up using the C one by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.1)
+set(PROJECT_VERSION 1.9.2)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -42,7 +42,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -903,6 +903,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.2 TBD 2023
+
+1. Bugfixes:
+    * Initialize locale so that times appear correctly. (PR #509)
+
 ## V1.9.1 August 2023
 
 1. Bugfixes:

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -550,7 +550,7 @@ wxString FreeDVReporterDialog::makeValidTime_(std::string timeStr)
         {
             timeZone = wxDateTime::TimeZone(wxDateTime::TZ::Local);
         }
-        return tmpDate.Format(wxDefaultDateTimeFormat, timeZone);
+        return tmpDate.Format(_("%x %X"), timeZone);
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,6 +208,9 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
 //-------------------------------------------------------------------------
 bool MainApp::OnInit()
 {
+    // Initialize locale.
+    m_locale.Init();
+
     for (auto& obj : m_reporters)
     {
         delete obj;

--- a/src/main.h
+++ b/src/main.h
@@ -220,6 +220,7 @@ class MainApp : public wxApp
         
         std::shared_ptr<LinkStep> linkStep;
 
+        wxLocale m_locale;
     protected:
 };
 


### PR DESCRIPTION
Turns out that wxLocale needs to be initialized for times in the FreeDV Reporter window appear properly (i.e. using the user's locale instead of the default date/time format). This only seems to be necessary on Linux for some reason. /shrug