### PR TITLE
Fix various voice keyer and UI issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.1)
+set(PROJECT_VERSION 1.9.2)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -42,7 +42,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -903,6 +903,14 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.2 TBD 2023
+
+1. Bugfixes:
+    * Fix issue with Voice Keyer button turning blue even if file doesn't exist. (PR #511)
+    * Fix issue with Voice Keyer file changes via Tools->Options not taking effect until restart. (PR #511)
+2. Enhancements:
+    * Add tooltip to Record button to claify its behavior. (PR #511)
+
 ## V1.9.1 August 2023
 
 1. Bugfixes:

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -161,6 +161,13 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
             m_cboLastReportedCallsigns->Hide();
             m_txtCtrlCallSign->Show();
         }
+        
+        // 
+        auto newVkFile = wxGetApp().appConfiguration.voiceKeyerWaveFile->mb_str();
+        if (vkFileName_ != newVkFile)
+        {
+            vkFileName_ = newVkFile;
+        }
 
         // Relayout window so that the changes can take effect.
         m_panel->Layout();

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -204,6 +204,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     wxStaticBoxSizer* sbSizerAudioRecordPlay = new wxStaticBoxSizer(audioBox, wxVERTICAL);
     
     m_audioRecord = new wxToggleButton(audioBox, wxID_ANY, _("Record"), wxDefaultPosition, wxDefaultSize, 0);
+    m_audioRecord->SetToolTip(_("Records incoming over the air signals as well as anything transmitted."));
     sbSizerAudioRecordPlay->Add(m_audioRecord, 0, wxALL | wxALIGN_CENTER_HORIZONTAL, 1);
     
     leftSizer->Add(sbSizerAudioRecordPlay, 0, wxALL|wxEXPAND, 3);

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -32,19 +32,13 @@ void MainFrame::OnTogBtnVoiceKeyerClick (wxCommandEvent& event)
     }
     else
     {
-        bool enableVK = false;
-        
         if (vk_state == VK_IDLE)
         {
             m_togBtnVoiceKeyer->SetValue(true);
             VoiceKeyerProcessEvent(VK_START);
-            enableVK = true;
         }
         else
             VoiceKeyerProcessEvent(VK_SPACE_BAR);
-        
-        wxColour vkBackgroundColor(55, 155, 175);
-        m_togBtnVoiceKeyer->SetBackgroundColour(enableVK ? vkBackgroundColor : wxNullColour);
     }
 
     event.Skip();
@@ -185,6 +179,9 @@ int MainFrame::VoiceKeyerStartTx(void)
 
         m_btnTogPTT->SetValue(true); togglePTT();
         next_state = VK_TX;
+        
+        wxColour vkBackgroundColor(55, 155, 175);
+        m_togBtnVoiceKeyer->SetBackgroundColour(vkBackgroundColor);
 
         if (wxGetApp().appConfiguration.monitorVoiceKeyerAudio)
         {


### PR DESCRIPTION
As reported on the digitalvoice mailing list, this PR resolves the following issues:

1. Fixes a bug where if the VK file doesn't exist, it still lights blue anyway when attempting to transmit it.
2. Fixes another issue where if the VK file is changed via Tools->Options, it doesn't take effect until the application is restarted.
3. Adds a tooltip for the Record button to make it more clear what it does.