### PR TITLE
Eliminate mutex errors during Visual Studio debugging.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -909,6 +909,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Initialize locale so that times appear correctly. (PR #509)
     * Fix issue with Voice Keyer button turning blue even if file doesn't exist. (PR #511)
     * Fix issue with Voice Keyer file changes via Tools->Options not taking effect until restart. (PR #511)
+    * Eliminate mutex errors during Visual Studio debugging. (PR #512)
 2. Enhancements:
     * Add tooltip to Record button to claify its behavior. (PR #511)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ float               g_TxFreqOffsetHz;
 // TODO: review code and see if we need this any more, as fifos should
 // now be thread safe
 
-wxMutex g_mutexProtectingCallbackData;
+wxMutex g_mutexProtectingCallbackData(wxMUTEX_RECURSIVE);
 
 // TX mode change mutex
 wxMutex txModeChangeMutex;


### PR DESCRIPTION
While I was attempting to debug an issue with FreeDV hanging on pushing the Stop button, I noticed a bunch of wxMutex errors displaying in Visual Studio. While this PR probably doesn't change any external behavior, it's still good to not attempt to unlock mutexes that were already locked :x