### PR TITLE
Adjust length of vertical frequency ticks to prevent overlap with text.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -911,6 +911,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue with Voice Keyer file changes via Tools->Options not taking effect until restart. (PR #511)
     * Eliminate mutex errors during Visual Studio debugging. (PR #512)
     * Add timeout during deletion of FreeDVReporter object. (PR #515)
+    * Adjust vertical tick lengths on waterfall to prevent text overlap. (PR #518)
+    * Adjust coloring of text and ticks on spectrum plot to improve visibility when in dark mode. (PR #518)
 2. Enhancements:
     * Add tooltip to Record button to claify its behavior. (PR #511)
 

--- a/src/plot_spectrum.cpp
+++ b/src/plot_spectrum.cpp
@@ -195,10 +195,11 @@ void PlotSpectrum::drawGraticule(wxGraphicsContext* ctx)
     float    f, mag, freq_hz_to_px, mag_dB_to_py;
 
     wxBrush ltGraphBkgBrush;
+    wxColour foregroundColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
     ltGraphBkgBrush.SetStyle(wxBRUSHSTYLE_TRANSPARENT);
-    ltGraphBkgBrush.SetColour(*wxBLACK);
+    ltGraphBkgBrush.SetColour(foregroundColor);
     ctx->SetBrush(ltGraphBkgBrush);
-    ctx->SetPen(wxPen(BLACK_COLOR, 1));
+    ctx->SetPen(wxPen(foregroundColor, 1));
     
     wxGraphicsFont tmpFont = ctx->CreateFont(GetFont(), GetForegroundColour());
     ctx->SetFont(tmpFont);
@@ -228,7 +229,7 @@ void PlotSpectrum::drawGraticule(wxGraphicsContext* ctx)
 
         ctx->SetPen(m_penShortDash);
         ctx->StrokeLine(x, m_rGrid.GetHeight() + PLOT_BORDER, x, PLOT_BORDER);
-        ctx->SetPen(wxPen(BLACK_COLOR, 1));
+        ctx->SetPen(wxPen(foregroundColor, 1));
         ctx->StrokeLine(x, m_rGrid.GetHeight() + PLOT_BORDER, x, m_rGrid.GetHeight() + PLOT_BORDER + YBOTTOM_TEXT_OFFSET);
 
         snprintf(buf, STR_LENGTH, "%4.0fHz", f);
@@ -237,7 +238,7 @@ void PlotSpectrum::drawGraticule(wxGraphicsContext* ctx)
             ctx->DrawText(buf, x - text_w/2, m_rGrid.GetHeight() + PLOT_BORDER + YBOTTOM_TEXT_OFFSET);
     }
 
-    ctx->SetPen(wxPen(BLACK_COLOR, 1));
+    ctx->SetPen(wxPen(foregroundColor, 1));
     for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ) 
     {
         x = f*freq_hz_to_px;

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -275,7 +275,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         if (m_graticule)
             ctx->StrokeLine(x, m_imgHeight + PLOT_BORDER, x, PLOT_BORDER);
         else
-            ctx->StrokeLine(x, PLOT_BORDER + 5, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+            ctx->StrokeLine(x, PLOT_BORDER + 8, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
             
         snprintf(buf, STR_LENGTH, "%4.0fHz", f);
         GetTextExtent(buf, &text_w, &text_h);
@@ -287,7 +287,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + XLEFT_OFFSET;
-        ctx->StrokeLine(x, PLOT_BORDER + 10, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+        ctx->StrokeLine(x, PLOT_BORDER + 13, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
     }
     
     // Horizontal gridlines

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -275,19 +275,19 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         if (m_graticule)
             ctx->StrokeLine(x, m_imgHeight + PLOT_BORDER, x, PLOT_BORDER);
         else
-            ctx->StrokeLine(x, PLOT_BORDER, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+            ctx->StrokeLine(x, PLOT_BORDER + 5, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
             
         snprintf(buf, STR_LENGTH, "%4.0fHz", f);
         GetTextExtent(buf, &text_w, &text_h);
         if (!overlappedText)
-            ctx->DrawText(buf, x - text_w/2, (YBOTTOM_TEXT_OFFSET/2));
+            ctx->DrawText(buf, x - text_w/2, (YBOTTOM_TEXT_OFFSET/2) - 5);
     }
 
     for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ) 
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + XLEFT_OFFSET;
-        ctx->StrokeLine(x, PLOT_BORDER + 5, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+        ctx->StrokeLine(x, PLOT_BORDER + 10, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
     }
     
     // Horizontal gridlines


### PR DESCRIPTION
Fixes #517 by adjusting the size of the major and minor vertical frequency ticks on the waterfall plot. This brings the waterfall more in line with the spectrum plot in terms of (lack of) overlapping text.

Additionally, this PR also fixes an issue with the coloring of the tick marks on the spectrum plot when in dark mode.