### PR TITLE
Remove references to g_logfile as it's not being used.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -914,6 +914,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fixes bug preventing display of reporting UI if enabled on first start. (PR #520)
     * Adjust vertical tick lengths on waterfall to prevent text overlap. (PR #518)
     * Adjust coloring of text and ticks on spectrum plot to improve visibility when in dark mode. (PR #518)
+    * Fix intermittent crash on exit due to improperly closing stderr. (PR #526)
 2. Enhancements:
     * Add tooltip to Record button to claify its behavior. (PR #511)
 3. Cleanup:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,6 @@ bool endingTx;
 // Option test file to log samples
 
 FILE *ftest;
-FILE *g_logfile;
 
 // Config file management 
 wxConfigBase *pConfig = NULL;
@@ -375,7 +374,6 @@ void MainFrame::loadConfiguration_()
 
     // sanitise frame position as a first pass at Win32 registry bug
 
-    //fprintf(g_logfile, "x = %d y = %d w = %d h = %d\n", x,y,w,h);
     if (x < 0 || x > 2048) x = 20;
     if (y < 0 || y > 2048) y = 20;
     if (w < 0 || w > 2048) w = 800;
@@ -565,12 +563,6 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     m_filterDialog = nullptr;
 
     m_zoom              = 1.;
-
-    #ifdef __WXMSW__
-    g_logfile = stderr;
-    #else
-    g_logfile = stderr;
-    #endif
 
     // Init Hamlib library, but we don't start talking to any rigs yet
 
@@ -886,10 +878,6 @@ MainFrame::~MainFrame()
     //fprintf(stderr, "MainFrame::~MainFrame()\n");
     #ifdef FTEST
     fclose(ftest);
-    #endif
-
-    #ifdef __WXMSW__
-    fclose(g_logfile);
     #endif
 
     if (wxGetApp().m_serialport)


### PR DESCRIPTION
Resolves #525 by removing `g_logfile` references in the codebase. This is not being used by anything other than `fclose()`, so there should not be any behavior changes (other than eliminating the intermittent crash).