### PR TITLE
Connect to FreeDV Reporter even when no session is running

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -921,6 +921,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add highlighting for RX rows in FreeDV Reporter (to match web version). (PR #519)
     * Add Distance column in FreeDV Reporter window. (PR #519)
     * Add support for sorting columns in FreeDV Reporter window. (PR #519)
+    * Allow use of FreeDV Reporter without having a session running. (PR #529)
 3. Cleanup:
     * Remove unneeded 2400B and 2020B sample files. (PR #521)
 

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -207,9 +207,9 @@ void FreeDVReporterDialog::refreshDistanceColumn()
     m_listSpots->SetColumn(2, item);
 }
 
-void FreeDVReporterDialog::setReporter(FreeDVReporter* reporter)
+void FreeDVReporterDialog::setReporter(std::shared_ptr<FreeDVReporter> reporter)
 {
-    if (reporter_ != nullptr)
+    if (reporter_)
     {
         reporter_->setOnReporterConnectFn(FreeDVReporter::ReporterConnectionFn());
         reporter_->setOnReporterDisconnectFn(FreeDVReporter::ReporterConnectionFn());
@@ -223,7 +223,7 @@ void FreeDVReporterDialog::setReporter(FreeDVReporter* reporter)
     
     reporter_ = reporter;
     
-    if (reporter_ != nullptr)
+    if (reporter_)
     {
         reporter_->setOnReporterConnectFn(std::bind(&FreeDVReporterDialog::onReporterConnect_, this));
         reporter_->setOnReporterDisconnectFn(std::bind(&FreeDVReporterDialog::onReporterDisconnect_, this));

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -23,6 +23,10 @@
 #include <wx/datetime.h>
 #include "freedv_reporter.h"
 
+#include "freedv_interface.h"
+
+extern FreeDVInterface freedvInterface;
+
 #define UNKNOWN_STR "--"
 #define NUM_COLS (12)
 
@@ -365,7 +369,8 @@ void FreeDVReporterDialog::refreshQSYButtonState()
         auto selectedCallsign = m_listSpots->GetItemText(selectedIndex);
     
         if (selectedCallsign != wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign && 
-            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0)
+            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0 &&
+            freedvInterface.isRunning())
         {
             wxString theirFreqString = m_listSpots->GetItemText(selectedIndex, 3);
             wxRegEx mhzRegex(" MHz$");

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -61,7 +61,7 @@ class FreeDVReporterDialog : public wxDialog
                 long style = wxDEFAULT_DIALOG_STYLE | wxTAB_TRAVERSAL | wxMINIMIZE_BOX | wxRESIZE_BORDER);
         ~FreeDVReporterDialog();
         
-        void setReporter(FreeDVReporter* reporter);
+        void setReporter(std::shared_ptr<FreeDVReporter> reporter);
         void refreshQSYButtonState();
         void refreshDistanceColumn();
         
@@ -129,7 +129,7 @@ class FreeDVReporterDialog : public wxDialog
              wxDateTime lastUpdateDate;
          };
          
-         FreeDVReporter* reporter_;
+         std::shared_ptr<FreeDVReporter> reporter_;
          std::map<int, int> columnLengths_;
          std::map<std::string, ReporterData*> allReporterData_;
          FilterFrequency currentBandFilter_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1994,6 +1994,15 @@ void MainFrame::performFreeDVOn_()
                         m_pskReporterTimer.Start(5 * 60 * 1000);
                     });
 
+                    // Make sure QSY button becomes enabled after start.
+                    executeOnUiThreadAndWait_([&]() 
+                    {
+                        if (m_reporterDialog != nullptr)
+                        {
+                            m_reporterDialog->refreshQSYButtonState();
+                        }
+                    });
+                    
                     // Immediately transmit selected TX mode and frequency to avoid UI glitches.
                     for (auto& obj : wxGetApp().m_reporters)
                     {
@@ -2128,6 +2137,12 @@ void MainFrame::performFreeDVOff_()
     #if defined(FREEDV_MODE_2020B)
             m_rb2020b->Enable();
     #endif // FREEDV_MODE_2020B
+        }
+        
+        // Make sure QSY button becomes disabled after stop.
+        if (m_reporterDialog != nullptr)
+        {
+            m_reporterDialog->refreshQSYButtonState();
         }
     });
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,10 +210,6 @@ bool MainApp::OnInit()
     // Initialize locale.
     m_locale.Init();
 
-    for (auto& obj : m_reporters)
-    {
-        delete obj;
-    }
     m_reporters.clear();
     
     if(!wxApp::OnInit())
@@ -539,6 +535,9 @@ setDefaultMode:
     auto currentSizer = m_panel->GetSizer();
     m_panel->SetSizerAndFit(currentSizer, false);
     m_panel->Layout();
+    
+    // Initialize FreeDV Reporter as required
+    initializeFreeDVReporter_();
     
     // If the FreeDV Reporter window was open on last execution, reopen it now.
     CallAfter([&]() {
@@ -978,14 +977,7 @@ MainFrame::~MainFrame()
         wxGetApp().m_hamlib = nullptr;
     }
     
-    if (wxGetApp().m_reporters.size() > 0)
-    {
-        for (auto& obj : wxGetApp().m_reporters)
-        {
-            delete obj;
-        }
-        wxGetApp().m_reporters.clear();
-    }
+    wxGetApp().m_reporters.clear();
 }
 
 
@@ -1631,14 +1623,7 @@ void MainFrame::OnExit(wxCommandEvent& event)
         wxGetApp().m_hamlib = nullptr;
     }
 
-    if (wxGetApp().m_reporters.size() > 0)
-    {
-        for (auto& obj : wxGetApp().m_reporters)
-        {
-            delete obj;
-        }
-        wxGetApp().m_reporters.clear();
-    }
+    wxGetApp().m_reporters.clear();
     
     //fprintf(stderr, "MainFrame::OnExit\n");
     wxUnusedVar(event);
@@ -1959,10 +1944,6 @@ void MainFrame::performFreeDVOn_()
         
         if (soundCardSetupValid)
         {
-            for (auto& obj : wxGetApp().m_reporters)
-            {
-                delete obj;
-            }
             wxGetApp().m_reporters.clear();
             
             startRxStream();
@@ -1993,7 +1974,7 @@ void MainFrame::performFreeDVOn_()
                     if (wxGetApp().appConfiguration.reportingConfiguration.pskReporterEnabled)
                     {
                         auto pskReporter = 
-                            new PskReporter(
+                            std::make_shared<PskReporter>(
                                 wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
                                 wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
                                 std::string("FreeDV ") + FREEDV_VERSION);
@@ -2001,67 +1982,10 @@ void MainFrame::performFreeDVOn_()
                         wxGetApp().m_reporters.push_back(pskReporter);
                     }
                     
-                    if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled && wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() != "")
+                    if (wxGetApp().m_sharedReporterObject)
                     {
-                        auto freedvReporter =
-                            new FreeDVReporter(
-                                wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString(),
-                                wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
-                                wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
-                                std::string("FreeDV ") + FREEDV_VERSION,
-                                g_nSoundCards <= 1 ? true : false);
-                        assert(freedvReporter);
-                        wxGetApp().m_reporters.push_back(freedvReporter);
-                        
-                        // Make built in FreeDV Reporter client available.
-                        executeOnUiThreadAndWait_([&]() {
-                            if (m_reporterDialog == nullptr)
-                            {
-                                m_reporterDialog = new FreeDVReporterDialog(this);
-                            }
-                            
-                            m_reporterDialog->setReporter(freedvReporter);
-                            m_reporterDialog->refreshDistanceColumn();
-                        });
-                        
-                        // Set up QSY request handler
-                        // TBD: automatically change frequency via hamlib if enabled.
-                        freedvReporter->setOnQSYRequestFn([&](std::string callsign, uint64_t freqHz, std::string message) {
-                            double frequencyMHz = freqHz / 1000000.0;
-                            wxString fullMessage = wxString::Format(_("%s has requested that you QSY to %.04f MHz."), callsign, frequencyMHz);
-                            int dialogStyle = wxOK | wxICON_INFORMATION | wxCENTRE;
-                            
-                            if (wxGetApp().m_hamlib != nullptr && wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
-                            {
-                                fullMessage = wxString::Format(_("%s has requested that you QSY to %.04f MHz. Would you like to change to that frequency now?"), callsign, frequencyMHz);
-                                dialogStyle = wxYES_NO | wxICON_QUESTION | wxCENTRE;
-                            }
-                            
-                            CallAfter([&, fullMessage, dialogStyle, frequencyMHz]() {
-                                wxMessageDialog messageDialog(this, fullMessage, wxT("FreeDV Reporter"), dialogStyle);
-
-                                if (dialogStyle & wxYES_NO)
-                                {
-                                    messageDialog.SetYesNoLabels(_("Change Frequency"), _("Cancel"));
-                                }
-
-                                auto answer = messageDialog.ShowModal();
-                                if (answer == wxID_YES)
-                                {
-                                    // This will implicitly cause Hamlib to change the frequecy and mode.
-                                    m_cboReportFrequency->SetValue(wxString::Format("%.4f", frequencyMHz));
-                                }
-                            });
-                        });
-                        
-                        freedvReporter->connect();
-                    }
-                    else if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
-                    {
-                        executeOnUiThreadAndWait_([&]() 
-                        {
-                            wxMessageBox("FreeDV Reporter requires a valid hostname. Reporting to FreeDV Reporter will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
-                        });
+                        wxGetApp().m_reporters.push_back(wxGetApp().m_sharedReporterObject);
+                        wxGetApp().m_sharedReporterObject->showOurselves();
                     }
                     
                     // Enable FreeDV Reporter timer (every 5 minutes).
@@ -2080,10 +2004,6 @@ void MainFrame::performFreeDVOn_()
             }
             else
             {
-                for (auto& obj : wxGetApp().m_reporters)
-                {
-                    delete obj;
-                }
                 wxGetApp().m_reporters.clear();
             }
 
@@ -2128,12 +2048,6 @@ void MainFrame::performFreeDVOff_()
 #ifdef _USE_TIMER
     executeOnUiThreadAndWait_([&]() 
     {
-        if (m_reporterDialog != nullptr)
-        {
-            // Destroy only on exit.
-            m_reporterDialog->setReporter(nullptr);
-        }
-        
         m_plotTimer.Stop();
         m_pskReporterTimer.Stop();
         m_updFreqStatusTimer.Stop(); // [UP]
@@ -2180,14 +2094,11 @@ void MainFrame::performFreeDVOff_()
     });
     
     stopRxStream();
-
-    if (wxGetApp().m_reporters.size() > 0)
-    {            
-        for (auto& obj : wxGetApp().m_reporters)
-        {
-            delete obj;
-        }
-        wxGetApp().m_reporters.clear();
+         
+    wxGetApp().m_reporters.clear();
+    if (wxGetApp().m_sharedReporterObject)
+    {
+        wxGetApp().m_sharedReporterObject->hideFromView();
     }
     
     // FreeDV clean up
@@ -3036,4 +2947,84 @@ bool MainFrame::validateSoundCardSetup()
     engine->setOnEngineError(nullptr, nullptr);
     
     return canRun;
+}
+
+void MainFrame::initializeFreeDVReporter_()
+{
+    if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled && wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() != "")
+    {
+        wxGetApp().m_sharedReporterObject =
+            std::make_shared<FreeDVReporter>(
+                wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString(),
+                wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
+                wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
+                std::string("FreeDV ") + FREEDV_VERSION,
+                g_nSoundCards <= 1 ? true : false);
+        assert(wxGetApp().m_sharedReporterObject);
+        
+        // Make built in FreeDV Reporter client available.
+        if (m_reporterDialog == nullptr)
+        {
+            m_reporterDialog = new FreeDVReporterDialog(this);
+        }
+            
+        m_reporterDialog->setReporter(wxGetApp().m_sharedReporterObject);
+        m_reporterDialog->refreshDistanceColumn();
+        
+        // Set up QSY request handler
+        // TBD: automatically change frequency via hamlib if enabled.
+        wxGetApp().m_sharedReporterObject->setOnQSYRequestFn([&](std::string callsign, uint64_t freqHz, std::string message) {
+            double frequencyMHz = freqHz / 1000000.0;
+            wxString fullMessage = wxString::Format(_("%s has requested that you QSY to %.04f MHz."), callsign, frequencyMHz);
+            int dialogStyle = wxOK | wxICON_INFORMATION | wxCENTRE;
+            
+            if (wxGetApp().m_hamlib != nullptr && wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+            {
+                fullMessage = wxString::Format(_("%s has requested that you QSY to %.04f MHz. Would you like to change to that frequency now?"), callsign, frequencyMHz);
+                dialogStyle = wxYES_NO | wxICON_QUESTION | wxCENTRE;
+            }
+            
+            CallAfter([&, fullMessage, dialogStyle, frequencyMHz]() {
+                wxMessageDialog messageDialog(this, fullMessage, wxT("FreeDV Reporter"), dialogStyle);
+
+                if (dialogStyle & wxYES_NO)
+                {
+                    messageDialog.SetYesNoLabels(_("Change Frequency"), _("Cancel"));
+                }
+
+                auto answer = messageDialog.ShowModal();
+                if (answer == wxID_YES)
+                {
+                    // This will implicitly cause Hamlib to change the frequecy and mode.
+                    m_cboReportFrequency->SetValue(wxString::Format("%.4f", frequencyMHz));
+                }
+            });
+        });
+        
+        wxGetApp().m_sharedReporterObject->connect();
+        wxGetApp().m_sharedReporterObject->hideFromView();
+    }
+    else
+    {
+        wxGetApp().m_sharedReporterObject = nullptr;
+        
+        if (m_reporterDialog != nullptr)
+        {
+            // wxWidgets doesn't fire wxEVT_MOVE events on Linux for some
+            // reason, so we need to grab and save the current position again.
+            auto pos = m_reporterDialog->GetPosition();
+            wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
+            wxGetApp().appConfiguration.reporterWindowTop = pos.y;
+
+            m_reporterDialog->setReporter(nullptr);
+            m_reporterDialog->Close();
+            m_reporterDialog->Destroy();
+            m_reporterDialog = nullptr;
+        }
+        
+        if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
+        {
+            wxMessageBox("FreeDV Reporter requires a valid hostname. Reporting to FreeDV Reporter will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
+        }
+    }
 }

--- a/src/main.h
+++ b/src/main.h
@@ -90,6 +90,7 @@
 #include "hamlib.h"
 #include "serialport.h" 
 #include "reporting/IReporter.h"
+#include "reporting/FreeDVReporter.h"
 #include "freedv_interface.h"
 #include "audio/AudioEngineFactory.h"
 #include "audio/IAudioDevice.h"
@@ -184,7 +185,12 @@ class MainApp : public wxApp
 
         wxRect              m_rTopWindow;
 
-        std::vector<IReporter*> m_reporters;
+        // To support viewing FreeDV Reporter data outside of a session, we need to have
+        // a running connection and know when to appropriately kill it. A shared_ptr
+        // allows us to do so.
+        std::shared_ptr<FreeDVReporter> m_sharedReporterObject;
+        
+        std::vector<std::shared_ptr<IReporter> > m_reporters;
         
         bool                loadConfig();
         bool                saveConfig();
@@ -487,6 +493,8 @@ class MainFrame : public TopFrame
         void executeOnUiThreadAndWait_(std::function<void()> fn);
         
         void updateReportingFreqList_();
+        
+        void initializeFreeDVReporter_();
 };
 
 void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -74,6 +74,9 @@ void MainFrame::OnToolsEasySetup(wxCommandEvent& event)
             m_txtCtrlCallSign->Show();
         }
 
+        // Initialize FreeDV Reporter if required.
+        initializeFreeDVReporter_();
+        
         // Relayout window so that the changes can take effect.
         m_panel->Layout();
     }
@@ -188,6 +191,9 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
         {
             vkFileName_ = newVkFile;
         }
+        
+        // Initialize FreeDV Reporter if required.
+        initializeFreeDVReporter_();
 
         // Refresh distance column label in case setting was changed.
         if (m_reporterDialog != nullptr)

--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -35,6 +35,7 @@ FreeDVReporter::FreeDVReporter(std::string hostname, std::string callsign, std::
     , lastFrequency_(0)
     , tx_(false)
     , rxOnly_(rxOnly)
+    , hidden_(false)
 {
     sioClient_ = new sio::client();
     assert(sioClient_ != nullptr);
@@ -112,6 +113,20 @@ void FreeDVReporter::transmit(std::string mode, bool tx)
 {
     std::unique_lock<std::mutex> lk(fnQueueMutex_);
     fnQueue_.push_back(std::bind(&FreeDVReporter::transmitImpl_, this, mode, tx));
+    fnQueueConditionVariable_.notify_one();
+}
+
+void FreeDVReporter::hideFromView()
+{
+    std::unique_lock<std::mutex> lk(fnQueueMutex_);
+    fnQueue_.push_back(std::bind(&FreeDVReporter::hideFromViewImpl_, this));
+    fnQueueConditionVariable_.notify_one();
+}
+
+void FreeDVReporter::showOurselves()
+{
+    std::unique_lock<std::mutex> lk(fnQueueMutex_);
+    fnQueue_.push_back(std::bind(&FreeDVReporter::showOurselvesImpl_, this));
     fnQueueConditionVariable_.notify_one();
 }
     
@@ -193,8 +208,15 @@ void FreeDVReporter::connect_()
     {
         isConnecting_ = false;
         
-        freqChangeImpl_(lastFrequency_);
-        transmitImpl_(mode_, tx_);
+        if (hidden_)
+        {
+            hideFromView();
+        }
+        else
+        {
+            freqChangeImpl_(lastFrequency_);
+            transmitImpl_(mode_, tx_);
+        }
     });
     
     sioClient_->set_reconnect_listener([&](unsigned, unsigned)
@@ -211,8 +233,15 @@ void FreeDVReporter::connect_()
             onReporterConnectFn_();
         }
         
-        freqChangeImpl_(lastFrequency_);
-        transmitImpl_(mode_, tx_);
+        if (hidden_)
+        {
+            hideFromView();
+        }
+        else
+        {
+            freqChangeImpl_(lastFrequency_);
+            transmitImpl_(mode_, tx_);
+        }
     });
     
     sioClient_->set_fail_listener([&]() {
@@ -495,4 +524,16 @@ void FreeDVReporter::transmitImpl_(std::string mode, bool tx)
     // Save last mode and TX state in case we have to reconnect.
     mode_ = mode;
     tx_ = tx;
+}
+
+void FreeDVReporter::hideFromViewImpl_()
+{
+    sioClient_->socket()->emit("hide_self");
+    hidden_ = true;
+}
+
+void FreeDVReporter::showOurselvesImpl_()
+{
+    sioClient_->socket()->emit("show_self");
+    hidden_ = false;
 }

--- a/src/reporting/FreeDVReporter.h
+++ b/src/reporting/FreeDVReporter.h
@@ -83,6 +83,9 @@ public:
     
     void setOnQSYRequestFn(QsyRequestFn fn);
     
+    void hideFromView();
+    void showOurselves();
+    
 private:
     // Required elements to implement execution thread for FreeDV Reporter.
     std::vector<std::function<void()> > fnQueue_;
@@ -101,6 +104,7 @@ private:
     std::string mode_;
     bool tx_;
     bool rxOnly_;
+    bool hidden_;
     
     ReporterConnectionFn onReporterConnectFn_;
     ReporterConnectionFn onReporterDisconnectFn_;
@@ -118,6 +122,9 @@ private:
     void threadEntryPoint_();
     void freqChangeImpl_(uint64_t frequency);
     void transmitImpl_(std::string mode, bool tx);
+    
+    void hideFromViewImpl_();
+    void showOurselvesImpl_();
 };
 
 #endif // FREEDV_REPORTER_H


### PR DESCRIPTION
Resolves #527 by implementing logic (client and server side) to enable hiding of our own connection from other users (and showing it again). Configuration changes for FreeDV Reporter also take effect immediately, but can still only be done while a session isn't running.