### PR TITLE
Update code signing documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,8 @@ if(SIGN_WINDOWS_BINARIES)
   
     # Default PKCS#11 module if not provided.
     if(NOT DEFINED PKCS11_MODULE)
-        # XXX -- we're assuming Ubuntu amd64 and YubiKey here.
-        set(PKCS11_MODULE /usr/lib/x86_64-linux-gnu/libykcs11.so)
+        # XXX -- we're assuming Ubuntu amd64 and SafeNet here.
+        set(PKCS11_MODULE /usr/lib/libeToken.so)
     endif(NOT DEFINED PKCS11_MODULE)
 
     # Default timestamping server

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -938,6 +938,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 3. Build system:
     * Upgrade wxWidgets on binary builds to 3.2.2.1. (PR #531)
     * Fix issue preventing proper generation of unsigned Windows installers. (PR #528)
+    * Update code signing documentation and defaults to use certificate provider's token instead of our own. (PR #533)
 4. Cleanup:
     * Remove unneeded 2400B and 2020B sample files. (PR #521)
 


### PR DESCRIPTION
We finally got a working EV certificate, so this PR does the following:

1. Updates the documentation to remove references to YubiKey and highly discourage the use of your own token.
2. Updates `CMakeLists.txt` to default the PKCS11 library to SafeNet's instead of YubiKey's.

Note: a test build generated with this PR worked fine with multiple Windows testers (no SmartScreen popups), unlike the previously signed releases.