### PR TITLE
Add FreeDV Reporter option to have the band filter track the current frequency

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -935,6 +935,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
         * *NOTE: Requires 'Enable Experimental Features' to be turned on, see below.*
     * Adds configuration item allowing optional use of experimental features. (PR #497)
         * This option is called "Enable Experimental Features" in Tools->Options->Debugging.
+    * Add FreeDV Reporter option to have the band filter track the current frequency. (PR #534)
 3. Build system:
     * Upgrade wxWidgets on binary builds to 3.2.2.1. (PR #531)
     * Fix issue preventing proper generation of unsigned Windows installers. (PR #528)

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -41,6 +41,7 @@ ReportingConfiguration::ReportingConfiguration()
     , freedvReporterHostname("/Reporting/FreeDV/Hostname", wxT(FREEDV_REPORTER_DEFAULT_HOSTNAME))
     , freedvReporterBandFilter("/Reporting/FreeDV/CurrentBandFilter", 0)
     , useMetricDistances("/Reporting/FreeDV/UseMetricDistances", true)
+    , freedvReporterBandFilterTracksFrequency("/Reporting/FreeDV/BandFilterTracksFrequency", false)
         
     , useUTCForReporting("/CallsignList/UseUTCTime", false)
         
@@ -88,6 +89,7 @@ void ReportingConfiguration::load(wxConfigBase* config)
     load_(config, freedvReporterHostname);
     load_(config, freedvReporterBandFilter);
     load_(config, useMetricDistances);
+    load_(config, freedvReporterBandFilterTracksFrequency);
     
     load_(config, useUTCForReporting);
     
@@ -114,6 +116,7 @@ void ReportingConfiguration::save(wxConfigBase* config)
     save_(config, freedvReporterHostname);
     save_(config, freedvReporterBandFilter);
     save_(config, useMetricDistances);
+    save_(config, freedvReporterBandFilterTracksFrequency);
     
     save_(config, useUTCForReporting);
     

--- a/src/config/ReportingConfiguration.h
+++ b/src/config/ReportingConfiguration.h
@@ -50,6 +50,7 @@ public:
     ConfigurationDataElement<wxString> freedvReporterHostname;
     ConfigurationDataElement<int> freedvReporterBandFilter;
     ConfigurationDataElement<bool> useMetricDistances;
+    ConfigurationDataElement<bool> freedvReporterBandFilterTracksFrequency;
     
     ConfigurationDataElement<bool> useUTCForReporting;
     

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -84,6 +84,7 @@ class FreeDVReporterDialog : public wxDialog
         void OnItemDeselected(wxListEvent& event);
         void OnSortColumn(wxListEvent& event);
         void OnTimer(wxTimerEvent& event);
+        void OnFilterTrackingEnable(wxCommandEvent& event);
         
         // Main list box that shows spots
         wxListView*   m_listSpots;
@@ -96,6 +97,7 @@ class FreeDVReporterDialog : public wxDialog
         
         // Band filter
         wxComboBox* m_bandFilter;
+        wxCheckBox* m_trackFrequency;
         
         // Step 4: test/save/cancel setup
         wxButton* m_buttonOK;
@@ -148,6 +150,7 @@ class FreeDVReporterDialog : public wxDialog
          wxString makeValidTime_(std::string timeStr, wxDateTime& timeObj);
          
          void addOrUpdateListIfNotFiltered_(ReporterData* data);
+         FilterFrequency getFilterForFrequency_(uint64_t freq);
          bool isFiltered_(uint64_t freq);
          
          bool setColumnForRow_(int row, int col, wxString val);


### PR DESCRIPTION
Resolves #530 by adding a new checkbox in the FreeDV Reporter window to allow the band filter to track the "Report Frequency" field on the main window. Example usage:

<img width="1293" alt="Screenshot 2023-09-11 at 11 35 40 PM" src="https://github.com/drowe67/freedv-gui/assets/449242/bad547ba-ee13-4388-87a7-346db7db42f1">
