### PR TITLE
Add additional error checking when configuring FreeDV Reporter.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -930,7 +930,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add highlighting for RX rows in FreeDV Reporter (to match web version). (PR #519)
     * Add Distance column in FreeDV Reporter window. (PR #519)
     * Add support for sorting columns in FreeDV Reporter window. (PR #519)
-    * Allow use of FreeDV Reporter without having a session running. (PR #529)
+    * Allow use of FreeDV Reporter without having a session running. (PR #529, #535)
     * Adds support for saving and restoring tab state. (PR #497)
         * *NOTE: Requires 'Enable Experimental Features' to be turned on, see below.*
     * Adds configuration item allowing optional use of experimental features. (PR #497)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2977,7 +2977,11 @@ bool MainFrame::validateSoundCardSetup()
 
 void MainFrame::initializeFreeDVReporter_()
 {
-    if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled && wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() != "")
+    if (wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled &&
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled &&
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() != "" &&
+        wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString() != "" &&
+        wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString() != "")
     {
         wxGetApp().m_sharedReporterObject =
             std::make_shared<FreeDVReporter>(
@@ -3048,9 +3052,18 @@ void MainFrame::initializeFreeDVReporter_()
             m_reporterDialog = nullptr;
         }
         
-        if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
+        if (wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled &&
+            wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
         {
-            wxMessageBox("FreeDV Reporter requires a valid hostname. Reporting to FreeDV Reporter will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
+            if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() == "")
+            {
+                wxMessageBox("FreeDV Reporter requires a valid hostname. Reporting to FreeDV Reporter will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
+            }
+            else if (wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString() == "" ||
+                     wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString() == "")
+            {
+                wxMessageBox("FreeDV Reporter requires a valid callsign and grid square in Tools->Options. Reporting to FreeDV Reporter will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
+            }
         }
     }
 }


### PR DESCRIPTION
During testing, I found some instances where FreeDV Reporter was connecting even though the general reporting enable checkbox wasn't checked. This PR fixes those and adds some additional error checking for callsign and locator/grid square.