### PR TITLE
Fix compiler error with 32 bit Windows during 1.9.2 release build.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -929,7 +929,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add tooltip to Record button to claify its behavior. (PR #511)
     * Add highlighting for RX rows in FreeDV Reporter (to match web version). (PR #519)
     * Add Distance column in FreeDV Reporter window. (PR #519)
-    * Add support for sorting columns in FreeDV Reporter window. (PR #519)
+    * Add support for sorting columns in FreeDV Reporter window. (PR #519, #537)
     * Allow use of FreeDV Reporter without having a session running. (PR #529, #535)
     * Adds support for saving and restoring tab state. (PR #497)
         * *NOTE: Requires 'Enable Experimental Features' to be turned on, see below.*

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -161,7 +161,7 @@ class FreeDVReporterDialog : public wxDialog
          double calculateDistance_(wxString gridSquare1, wxString gridSquare2);
          void calculateLatLonFromGridSquare_(wxString gridSquare, double& lat, double& lon);
 
-         static int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
+         static int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData) wxCALLBACK;
          static double DegreesToRadians_(double degrees);
 };
 


### PR DESCRIPTION
While building 1.9.2, the 32 bit x86 build of FreeDV failed. This was due to PR #519 as apparently stdcall is required for the callback. The definition for the needed callback now has wxCALLBACK appended to it to fix the problem.