### PR TITLE
Add configuration for background/foreground colors in FreeDV Reporter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.2)
+set(PROJECT_VERSION 1.9.3)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -42,7 +42,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -912,6 +912,13 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.3 TBD 2023
+
+1. Bugfixes:
+    * TBD
+2. Enhancements:
+    * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
+
 ## V1.9.2 September 2023
 
 1. Bugfixes:

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -62,6 +62,10 @@ ReportingConfiguration::ReportingConfiguration()
         _("28.7200"),
         _("10489.6400"),
     })
+    , freedvReporterTxRowBackgroundColor("/Reporting/FreeDV/TxRowBackgroundColor", "#fc4500")
+    , freedvReporterTxRowForegroundColor("/Reporting/FreeDV/TxRowForegroundColor", "#000000")
+    , freedvReporterRxRowBackgroundColor("/Reporting/FreeDV/RxRowBackgroundColor", "#379baf")
+    , freedvReporterRxRowForegroundColor("/Reporting/FreeDV/RxRowForegroundColor", "#000000")
 {
     // empty
 }
@@ -96,6 +100,11 @@ void ReportingConfiguration::load(wxConfigBase* config)
     load_(config, reportingFrequencyList);
     
     load_(config, manualFrequencyReporting);
+
+    load_(config, freedvReporterTxRowBackgroundColor);
+    load_(config, freedvReporterTxRowForegroundColor);
+    load_(config, freedvReporterRxRowBackgroundColor);
+    load_(config, freedvReporterRxRowForegroundColor);
     
     // Special load handling for reporting below.
     wxString freqStr = config->Read(reportingFrequency.getElementName(), oldFreqStr);
@@ -123,6 +132,11 @@ void ReportingConfiguration::save(wxConfigBase* config)
     save_(config, reportingFrequencyList);
     
     save_(config, manualFrequencyReporting);
+
+    save_(config, freedvReporterTxRowBackgroundColor);
+    save_(config, freedvReporterTxRowForegroundColor);
+    save_(config, freedvReporterRxRowBackgroundColor);
+    save_(config, freedvReporterRxRowForegroundColor);
     
     // Special save handling for reporting below.
     wxString tempFreqStr = wxString::Format(wxT("%" PRIu64), reportingFrequency.getWithoutProcessing());

--- a/src/config/ReportingConfiguration.h
+++ b/src/config/ReportingConfiguration.h
@@ -55,6 +55,11 @@ public:
     ConfigurationDataElement<bool> useUTCForReporting;
     
     ConfigurationDataElement<std::vector<wxString> > reportingFrequencyList;
+
+    ConfigurationDataElement<wxString> freedvReporterTxRowBackgroundColor;
+    ConfigurationDataElement<wxString> freedvReporterTxRowForegroundColor;
+    ConfigurationDataElement<wxString> freedvReporterRxRowBackgroundColor;
+    ConfigurationDataElement<wxString> freedvReporterRxRowForegroundColor;
     
     virtual void load(wxConfigBase* config) override;
     virtual void save(wxConfigBase* config) override;

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -230,6 +230,53 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     sbSizer_waterfallColor->Add(m_waterfallColorScheme3, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
     
     sizerDisplay->Add(sbSizer_waterfallColor, 0, wxALL | wxEXPAND, 5);
+
+    //----------------------------------------------------------
+    // FreeDV Reporter colors
+    //----------------------------------------------------------
+    wxStaticBox* sb_reporterColor = new wxStaticBox(m_displayTab, wxID_ANY, _("FreeDV Reporter colors"));
+    wxStaticBoxSizer* sbSizer_reporterColor =  new wxStaticBoxSizer(sb_reporterColor, wxVERTICAL);
+
+    wxBoxSizer* reporterTxColorSizer = new wxBoxSizer(wxHORIZONTAL);
+    wxBoxSizer* reporterRxColorSizer = new wxBoxSizer(wxHORIZONTAL);
+
+    // TX colors
+    wxStaticText* labelReporterTxStation = new wxStaticText(m_displayTab, wxID_ANY, wxT("TX Stations:"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterTxColorSizer->Add(labelReporterTxStation, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    wxStaticText* labelReporterTxBackgroundColor = new wxStaticText(m_displayTab, wxID_ANY, wxT("Background"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterTxColorSizer->Add(labelReporterTxBackgroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    m_freedvReporterTxBackgroundColor = new wxColourPickerCtrl(m_displayTab, wxID_ANY);
+    reporterTxColorSizer->Add(m_freedvReporterTxBackgroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    wxStaticText* labelReporterTxForegroundColor = new wxStaticText(m_displayTab, wxID_ANY, wxT("Foreground"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterTxColorSizer->Add(labelReporterTxForegroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    m_freedvReporterTxForegroundColor = new wxColourPickerCtrl(m_displayTab, wxID_ANY);
+    reporterTxColorSizer->Add(m_freedvReporterTxForegroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    sbSizer_reporterColor->Add(reporterTxColorSizer, 0, wxALL, 5);
+
+    // RX colors
+    wxStaticText* labelReporterRxStation = new wxStaticText(m_displayTab, wxID_ANY, wxT("RX Stations:"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterRxColorSizer->Add(labelReporterRxStation, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    wxStaticText* labelReporterRxBackgroundColor = new wxStaticText(m_displayTab, wxID_ANY, wxT("Background"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterRxColorSizer->Add(labelReporterRxBackgroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    m_freedvReporterRxBackgroundColor = new wxColourPickerCtrl(m_displayTab, wxID_ANY);
+    reporterRxColorSizer->Add(m_freedvReporterRxBackgroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    wxStaticText* labelReporterRxForegroundColor = new wxStaticText(m_displayTab, wxID_ANY, wxT("Foreground"), wxDefaultPosition, wxDefaultSize, 0);
+    reporterRxColorSizer->Add(labelReporterRxForegroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    m_freedvReporterRxForegroundColor = new wxColourPickerCtrl(m_displayTab, wxID_ANY);
+    reporterRxColorSizer->Add(m_freedvReporterRxForegroundColor, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    sbSizer_reporterColor->Add(reporterRxColorSizer, 0, wxALL, 5);
+
+    sizerDisplay->Add(sbSizer_reporterColor, 0, wxALL | wxEXPAND, 5);
     
     m_displayTab->SetSizer(sizerDisplay);
     
@@ -706,6 +753,17 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
 {
     if(inout == EXCHANGE_DATA_IN)
     {
+        // Populate FreeDV Reporter color settings
+        wxColour rxBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowBackgroundColor);
+        wxColour rxForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowForegroundColor);
+        wxColour txBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor);
+        wxColour txForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor);
+
+        m_freedvReporterRxBackgroundColor->SetColour(rxBackgroundColor);
+        m_freedvReporterRxForegroundColor->SetColour(rxForegroundColor);
+        m_freedvReporterTxBackgroundColor->SetColour(txBackgroundColor);
+        m_freedvReporterTxForegroundColor->SetColour(txForegroundColor);
+
         // Populate reporting frequency list.
         for (auto& item : wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyList.get())
         {
@@ -826,6 +884,19 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
 
     if(inout == EXCHANGE_DATA_OUT)
     {
+        // Populate FreeDV Reporter color settings
+        wxColour rxBackgroundColor = m_freedvReporterRxBackgroundColor->GetColour();
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowBackgroundColor = rxBackgroundColor.GetAsString(wxC2S_HTML_SYNTAX);
+
+        wxColour rxForegroundColor = m_freedvReporterRxForegroundColor->GetColour();
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowForegroundColor = rxForegroundColor.GetAsString(wxC2S_HTML_SYNTAX);
+
+        wxColour txBackgroundColor = m_freedvReporterTxBackgroundColor->GetColour();
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor = txBackgroundColor.GetAsString(wxC2S_HTML_SYNTAX);
+
+        wxColour txForegroundColor = m_freedvReporterTxForegroundColor->GetColour();
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor = txForegroundColor.GetAsString(wxC2S_HTML_SYNTAX);
+
         // Save new reporting frequency list.
         wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyList->clear();
         for (unsigned int index = 0; index < m_freqList->GetCount(); index++)

--- a/src/dlg_options.h
+++ b/src/dlg_options.h
@@ -22,6 +22,8 @@
 #ifndef __OPTIONS_DIALOG__
 #define __OPTIONS_DIALOG__
 
+#include <wx/clrpicker.h>
+
 #include "main.h"
 #include "defines.h"
 
@@ -95,7 +97,13 @@ class OptionsDlg : public wxDialog
         wxRadioButton *m_waterfallColorScheme1; // Multicolored
         wxRadioButton *m_waterfallColorScheme2; // Black & white
         wxRadioButton *m_waterfallColorScheme3; // Blue tint?
-        
+
+        /* FreeDV Reporter colors */
+        wxColourPickerCtrl* m_freedvReporterTxBackgroundColor;
+        wxColourPickerCtrl* m_freedvReporterTxForegroundColor;
+        wxColourPickerCtrl* m_freedvReporterRxBackgroundColor;
+        wxColourPickerCtrl* m_freedvReporterRxForegroundColor;
+
         /* Voice Keyer */
 
         wxButton     *m_buttonChooseVoiceKeyerWaveFile;

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -980,15 +980,17 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data)
     
     if (data->transmitting)
     {
-        wxColour lightRed(0xfc, 0x45, 0x00);
-        m_listSpots->SetItemBackgroundColour(itemIndex, lightRed);
-        m_listSpots->SetItemTextColour(itemIndex, *wxBLACK);
+        wxColour txBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor);
+        wxColour txForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor);
+        m_listSpots->SetItemBackgroundColour(itemIndex, txBackgroundColor);
+        m_listSpots->SetItemTextColour(itemIndex, txForegroundColor);
     }
     else if (data->lastRxDate.IsValid() && data->lastRxDate.IsEqualUpTo(wxDateTime::Now(), wxTimeSpan(0, 0, 10)))
     {
-        wxColour rxForegroundColor(55, 155, 175);
+        wxColour rxBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor);
+        wxColour rxForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor);
         m_listSpots->SetItemBackgroundColour(itemIndex, rxForegroundColor);
-        m_listSpots->SetItemTextColour(itemIndex, *wxBLACK);
+        m_listSpots->SetItemTextColour(itemIndex, rxBackgroundColor);
     }
     else
     {

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -987,10 +987,10 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data)
     }
     else if (data->lastRxDate.IsValid() && data->lastRxDate.IsEqualUpTo(wxDateTime::Now(), wxTimeSpan(0, 0, 10)))
     {
-        wxColour rxBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor);
-        wxColour rxForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor);
-        m_listSpots->SetItemBackgroundColour(itemIndex, rxForegroundColor);
-        m_listSpots->SetItemTextColour(itemIndex, rxBackgroundColor);
+        wxColour rxBackgroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowBackgroundColor);
+        wxColour rxForegroundColor(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowForegroundColor);
+        m_listSpots->SetItemBackgroundColour(itemIndex, rxBackgroundColor);
+        m_listSpots->SetItemTextColour(itemIndex, rxForegroundColor);
     }
     else
     {


### PR DESCRIPTION
Resolves #541 by adding configuration options in Tools->Options->Display to control the RX/TX background and foreground colors in FreeDV Reporter.

Example UI:

![Screenshot 2023-09-17 at 6 24 33 PM](https://github.com/drowe67/freedv-gui/assets/449242/55f42ad3-130b-4e2c-b9a1-62267318defe)
