### PR TITLE
Use hide/show actions instead of disconnect/reconnect for analog switching.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -918,7 +918,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Fix regression preventing proper display of "RX Only" stations. (PR #542)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
-    * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542)
+    * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)
 
 ## V1.9.2 September 2023
 

--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -94,24 +94,14 @@ void FreeDVReporter::inAnalogMode(bool inAnalog)
 {
     if (isValidForReporting())
     {
-        std::unique_lock<std::mutex> lk(fnQueueMutex_);
-        fnQueue_.push_back([&, inAnalog]() {
-            if (inAnalog)
-            {
-                // Workaround for race condition in sioclient
-                while (isConnecting_)
-                {
-                    std::this_thread::sleep_for(20ms);
-                }
-                
-                sioClient_->sync_close();
-            }
-            else
-            {
-                connect_();
-            }
-        });
-        fnQueueConditionVariable_.notify_one();
+        if (inAnalog)
+        {
+            hideFromView();
+        }
+        else
+        {
+            showOurselves();
+        }
     }
 }
 


### PR DESCRIPTION
This PR reduces FreeDV Reporter overhead during analog/digital switching by using the hide/show actions introduced in previous PRs instead of disconnecting and reconnecting. By doing so, we can also continue monitoring FreeDV Reporter even when in analog mode.