### PR TITLE
Fix bug preventing proper restore of selected tabs.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -917,6 +917,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * FreeDV Reporter: Fix regression preventing proper display of "RX Only" stations. (PR #542)
     * Default to the audio from the current TX mode if no modes decode (works around Codec2 bug with 1600 mode). (PR #544)
+    * Fix bug preventing proper restore of selected tabs. (PR #548)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -265,6 +265,7 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 
        // Get list of tab id's and move them to pane
        wxString tab_list = tab_part.AfterFirst(wxT('='));
+       size_t activePage = -1;
        while(1) {
           wxString tab = tab_list.BeforeFirst(wxT(','));
           if (tab.empty()) break;
@@ -284,9 +285,10 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
           const size_t newpage_idx = dest_tabs->GetPageCount();
           dest_tabs->InsertPage(page.window, page, newpage_idx);
 
-          if (c == wxT('+')) dest_tabs->SetActivePage(newpage_idx);
+          if (c == wxT('+')) activePage = newpage_idx;
           else if ( c == wxT('*')) sel_page = tab_idx;
        }
+       if (activePage >= 0) dest_tabs->SetActivePage(activePage);
        dest_tabs->DoShowHide();
 
        tabs = tabs.AfterFirst(wxT('|'));


### PR DESCRIPTION
Reported on the digitalvoice list (https://groups.google.com/g/digitalvoice/c/sWHBDKbov5g). Seems to be something wxWidgets related but am able to work around the issue by waiting to select the saved active tab until after all the tabs for a pane are loaded.