### PR TITLE
UX improvements for "On Top" menu option

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -918,6 +918,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Fix regression preventing proper display of "RX Only" stations. (PR #542)
     * Default to the audio from the current TX mode if no modes decode (works around Codec2 bug with 1600 mode). (PR #544)
     * Fix bug preventing proper restore of selected tabs. (PR #548)
+    * Clarify behavior of "On Top" menu option. (PR #549)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -358,7 +358,7 @@ void MainFrame::OnCloseFrame(wxCloseEvent& event)
 //-------------------------------------------------------------------------
 void MainFrame::OnTop(wxCommandEvent& event)
 {
-    int style = GetWindowStyle();
+    auto style = GetWindowStyle();
 
     if (style & wxSTAY_ON_TOP)
     {
@@ -368,6 +368,7 @@ void MainFrame::OnTop(wxCommandEvent& event)
     {
         style |= wxSTAY_ON_TOP;
     }
+
     SetWindowStyle(style);
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -360,11 +360,11 @@ void MainFrame::OnTop(wxCommandEvent& event)
 {
     auto style = GetWindowStyle();
 
-    if (style & wxSTAY_ON_TOP)
-    {
-        style &= ~wxSTAY_ON_TOP;
-    }
-    else
+    // Clear wxSTAY_ON_TOP first if it's already set.
+    style &= ~wxSTAY_ON_TOP;
+    
+    // (Re)set wxSTAY_ON_TOP depending on whether the menu option is checked.
+    if (event.IsChecked())
     {
         style |= wxSTAY_ON_TOP;
     }

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -332,9 +332,13 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_menubarMain = new wxMenuBar(wxMB_DOCKABLE);
     file = new wxMenu();
 
+#if !defined(__WXGTK__)
+    /* "On Top" isn't reliable on Linux, so there's no point in having it visible. */
     wxMenuItem* m_menuItemOnTop;
-    m_menuItemOnTop = new wxMenuItem(file, wxID_ANY, wxString(_("&On Top")) , _("Always Top Window"), wxITEM_NORMAL);
+    m_menuItemOnTop = new wxMenuItem(file, wxID_ANY, wxString(_("Keep &On Top")) , _("Always keeps FreeDV above other windows"), wxITEM_CHECK);
     file->Append(m_menuItemOnTop);
+    this->Connect(m_menuItemOnTop->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnTop));
+#endif // !defined(__WXGTK__)
 
     wxMenuItem* m_menuItemExit;
     m_menuItemExit = new wxMenuItem(file, ID_EXIT, wxString(_("E&xit")) , _("Exit Program"), wxITEM_NORMAL);
@@ -789,7 +793,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     this->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(TopFrame::topFrame_OnUpdateUI));
     this->Connect(wxEVT_SYS_COLOUR_CHANGED, wxSysColourChangedEventHandler(TopFrame::OnSystemColorChanged));
     this->Connect(m_menuItemExit->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnExit));
-    this->Connect(m_menuItemOnTop->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnTop));
 
     this->Connect(m_menuItemEasySetup->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnToolsEasySetup));
     this->Connect(m_menuItemEasySetup->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(TopFrame::OnToolsEasySetupUI));


### PR DESCRIPTION
Resolves #546 by doing the following:

1. On Linux (or any other platform using GTK), hide the "On Top" menu option as it's not reliable (note: [support was even removed entirely in GTK4](https://discourse.gnome.org/t/gtk-4-how-to-replace-gtk-window-set-keep-above-and-gtk-window-set-keep-below/3550) for this reason).
2. For other platforms, rename "On Top" to "Keep On Top" and indicate whether it's enabled via a checkmark next to the menu item. Example below:

<img width="322" alt="Screenshot 2023-09-20 at 10 09 39 PM" src="https://github.com/drowe67/freedv-gui/assets/449242/88bd8bd5-58b8-43c5-a61b-d216b4d39301">
