### PR TITLE
Work around Xcode issue preventing FreeDV from starting on macOS < 12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ if(APPLE)
         HOMEPAGE_URL ${PROJECT_HOMEPAGE_URL}
         LANGUAGES C CXX OBJCXX
     )
+
+    # Workaround for Xcode 15 bug preventing FreeDV binaries from starting
+    # on older versions of macOS. See https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking.
+    add_link_options("-Wl,-ld_classic")
 else(APPLE)
     project(
         ${PROJECT_NAME}

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -920,6 +920,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix bug preventing proper restore of selected tabs. (PR #548)
     * Improve labeling of PTT/CAT control options. (PR #550)
     * Clarify behavior of "On Top" menu option. (PR #549)
+    * Work around Xcode issue preventing FreeDV from starting on macOS < 12. (PR #553)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)


### PR DESCRIPTION
Discovered during investigation of another issue. More info at https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking.