### PR TITLE
Add None as a valid PTT method and make it report RX Only.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -921,6 +921,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)
+    * Add None as a valid PTT method and make it report RX Only. (PR #556)
 3. Documentation:
     * Add information about multiple audio devices and macOS. (PR #554)
 

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -165,7 +165,7 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     m_cbPttMethod->Append(wxT("CAT"));
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
-    m_cbPttMethod->Append(wxT("None"));
+    m_cbPttMethod->Append(wxT("None (RX Only)"));
     m_cbPttMethod->SetSelection(0);
 
     /* Serial port box */

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -165,6 +165,7 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     m_cbPttMethod->Append(wxT("CAT"));
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
+    m_cbPttMethod->Append(wxT("None"));
     m_cbPttMethod->SetSelection(0);
 
     /* Serial port box */

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -121,6 +121,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbPttMethod->Append(wxT("CAT"));
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
+    m_cbPttMethod->Append(wxT("None"));
     
     gridSizerhl->Add(new wxStaticText(hamlibBox, wxID_ANY, _("Serial Params:"), wxDefaultPosition, wxDefaultSize, 0), 
                       0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 20);

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -121,7 +121,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbPttMethod->Append(wxT("CAT"));
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
-    m_cbPttMethod->Append(wxT("None"));
+    m_cbPttMethod->Append(wxT("None (RX Only)"));
     
     gridSizerhl->Add(new wxStaticText(hamlibBox, wxID_ANY, _("Serial Params:"), wxDefaultPosition, wxDefaultSize, 0), 
                       0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 20);

--- a/src/hamlib.cpp
+++ b/src/hamlib.cpp
@@ -213,6 +213,9 @@ bool Hamlib::connect(unsigned int rig_index, const char *serial_port, const int 
         case PTT_VIA_DTR:
             rig_set_conf(m_rig, rig_token_lookup(m_rig, "ptt_type"), "DTR");
             break;
+        case PTT_VIA_NONE:
+            rig_set_conf(m_rig, rig_token_lookup(m_rig, "ptt_type"), "NONE");
+            break;
         case PTT_VIA_CAT:
         default:
             break;

--- a/src/hamlib.h
+++ b/src/hamlib.h
@@ -19,7 +19,8 @@ class Hamlib {
         {
             PTT_VIA_CAT = 0,
             PTT_VIA_RTS,
-            PTT_VIA_DTR
+            PTT_VIA_DTR,
+            PTT_VIA_NONE,
         };
         
         Hamlib();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1657,7 +1657,6 @@ void MainFrame::OnExit(wxCommandEvent& event)
         stopRxStream();
     }
     m_togBtnAnalog->Disable();
-    //m_btnTogPTT->Disable();
 
     auto engine = AudioEngineFactory::GetAudioEngine();
     engine->stop();
@@ -2192,8 +2191,8 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent& event)
             // On/Off actions complete, re-enable button.
             executeOnUiThreadAndWait_([&]() {
                 m_togBtnAnalog->Enable(m_RxRunning);
-                m_togBtnVoiceKeyer->Enable(m_RxRunning && (g_nSoundCards == 2));
-                m_btnTogPTT->Enable(m_RxRunning && (g_nSoundCards == 2));
+                m_togBtnVoiceKeyer->Enable(m_RxRunning && (g_nSoundCards == 2) && ((Hamlib::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get() != Hamlib::PTT_VIA_NONE));
+                m_btnTogPTT->Enable(m_RxRunning && (g_nSoundCards == 2) && ((Hamlib::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get() != Hamlib::PTT_VIA_NONE));
                 optionsDlg->setSessionActive(m_RxRunning);
 
                 if (m_RxRunning)
@@ -2983,7 +2982,7 @@ void MainFrame::initializeFreeDVReporter_()
             wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
             wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
             std::string("FreeDV ") + FREEDV_VERSION,
-            g_nSoundCards <= 1 ? true : false);
+            g_nSoundCards <= 1 || (Hamlib::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get() == Hamlib::PTT_VIA_NONE ? true : false);
     assert(wxGetApp().m_sharedReporterObject);
     
     // Make built in FreeDV Reporter client available.

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -232,7 +232,11 @@ void MainFrame::OnToolsComCfg(wxCommandEvent& event)
 
     ComPortsDlg *dlg = new ComPortsDlg(NULL);
 
-    dlg->ShowModal();
+    if (dlg->ShowModal() == wxID_OK)
+    {
+        // Reinitialize FreeDV Reporter again in case we changed PTT method.
+        initializeFreeDVReporter_();
+    }
 
     delete dlg;
 }
@@ -309,11 +313,11 @@ bool MainFrame::OpenHamlibRig() {
     
     int serial_rate = wxGetApp().appConfiguration.rigControlConfiguration.hamlibSerialRate;
     if (wxGetApp().CanAccessSerialPort((const char*)port.ToUTF8()) && (
-        pttType == Hamlib::PTT_VIA_CAT || wxGetApp().CanAccessSerialPort((const char*)pttPort.ToUTF8())))
+        pttType == Hamlib::PTT_VIA_CAT || pttType == Hamlib::PTT_VIA_NONE || wxGetApp().CanAccessSerialPort((const char*)pttPort.ToUTF8())))
     {
         bool status = wxGetApp().m_hamlib->connect(
             rig, port.mb_str(wxConvUTF8), serial_rate, wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress, 
-            pttType, pttType == Hamlib::PTT_VIA_CAT ? port.mb_str(wxConvUTF8) : pttPort.mb_str(wxConvUTF8));
+            pttType, pttType == Hamlib::PTT_VIA_CAT || pttType == Hamlib::PTT_VIA_NONE ? port.mb_str(wxConvUTF8) : pttPort.mb_str(wxConvUTF8));
         if (status == false)
         {
             wxMessageBox("Couldn't connect to Radio with hamlib", wxT("Error"), wxOK | wxICON_ERROR, this);


### PR DESCRIPTION
Additional request from #550. This PR adds "None" as a PTT option for Hamlib and additionally makes it behave as though TX sound devices haven't been specified for the purpose of reporting.