### PR TITLE
Increase RX coloring timeout to 20s and use UTC for time comparisons.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -925,6 +925,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)
     * Add None as a valid PTT method and make it report RX Only. (PR #556)
+    * Increase RX coloring timeout in FreeDV Reporter to 20 seconds. (PR #558)
 3. Documentation:
     * Add information about multiple audio devices and macOS. (PR #554)
 


### PR DESCRIPTION
This PR updates the RX coloring code for the internal version of FreeDV Reporter as follows:

1. Increases the time that the coloring is displayed without an additional RX report from 10 seconds to 20 seconds. 
2. Time comparisons for determining whether to hide the coloring are now done explicitly using UTC time to ensure that differing time zones don't cause the coloring to prematurely be removed.