### PR TITLE
Add decimal separator force to "." dot for frequencies translation on…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,6 +210,14 @@ bool MainApp::OnInit()
     // Initialize locale.
     m_locale.Init();
 
+    // Check System language to force dot "." as decimal separator
+    int sys_lang = wxLocale::GetSystemLanguage();
+    if( sys_lang != wxLANGUAGE_DEFAULT )
+    {
+        // Restore "C" numeric locale
+        setlocale(LC_NUMERIC, "C");
+    }
+
     m_reporters.clear();
     
     if(!wxApp::OnInit())


### PR DESCRIPTION
On French Computer, locale use the comma as decimal separator. This make rig exchange translate frequencies without the decimal part { 14,236 -> 14.000) } by using wxWidget::Format when using Frequency reporter

I add a small check and force locale for numeric decimal separator to dot "." to avoid 