### PR TITLE
Fix rounding error when changing reporting frequency.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -921,6 +921,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Clarify behavior of "On Top" menu option. (PR #549)
     * Work around Xcode issue preventing FreeDV from starting on macOS < 12. (PR #553)
     * Fix issue preventing selection of FreeDV Reporter users during band tracking. (PR #555)
+    * Fix rounding error when changing reporting frequency. (PR #562)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -748,7 +748,7 @@ void MainFrame::OnChangeReportFrequency( wxCommandEvent& event )
     wxString freqStr = m_cboReportFrequency->GetValue();
     if (freqStr.Length() > 0)
     {
-        wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = atof(freqStr.ToUTF8()) * 1000 * 1000;
+        wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = round(atof(freqStr.ToUTF8()) * 1000 * 1000);
         if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0)
         {
             m_cboReportFrequency->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));


### PR DESCRIPTION
Reported by Mike WA2TOP -- when setting the Reporting Frequency to "14.2357 MHz", the radio switches to 14.235699 MHz instead. This PR should resolve that issue.