### PR TITLE
Work around issue preventing consistent switchover to 'From Mic' tab on voice keyer TX.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -921,6 +921,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Clarify behavior of "On Top" menu option. (PR #549)
     * Work around Xcode issue preventing FreeDV from starting on macOS < 12. (PR #553)
     * Fix issue preventing selection of FreeDV Reporter users during band tracking. (PR #555)
+    * Work around issue preventing consistent switchover to 'From Mic' tab on voice keyer TX. (PR #563)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -581,7 +581,19 @@ void MainFrame::togglePTT(void) {
     {
         // rx-> tx transition, swap to Mic In page to monitor speech
         wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
-        m_auiNbookCtrl->ChangeSelection(m_auiNbookCtrl->GetPageIndex((wxWindow *)m_panelSpeechIn));
+        
+        // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
+        // the current page ourselves is a better bet.
+        size_t index = 0;
+        for (; index < m_auiNbookCtrl->GetPageCount(); index++)
+        {
+            auto page = m_auiNbookCtrl->GetPage(index);
+            if (page == (wxWindow *)m_panelSpeechIn)
+            {
+                m_auiNbookCtrl->ChangeSelection(index);
+                break;
+            }
+        }
 
         // disable sync text
 


### PR DESCRIPTION
Observed an issue on macOS where FreeDV occasionally switches to the Spectrum tab instead of the From Mic tab when the voice keyer transmits. This PR seems to work around this issue (in local testing at least) by manually searching for the correct tab instead of using wxAuiNotebook's search methods.