### PR TITLE
Update wxWidgets to version 3.2.3.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -929,7 +929,9 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)
     * Add None as a valid PTT method and make it report RX Only. (PR #556)
     * Increase RX coloring timeout in FreeDV Reporter to 20 seconds. (PR #558)
-3. Documentation:
+3. Build system:
+    * Upgrade wxWidgets on binary builds to 3.2.3. (PR #565)
+4. Documentation:
     * Add information about multiple audio devices and macOS. (PR #554)
 
 ## V1.9.2 September 2023

--- a/cmake/BuildWxWidgets.cmake
+++ b/cmake/BuildWxWidgets.cmake
@@ -1,4 +1,4 @@
-set(WXWIDGETS_VERSION "3.2.2.1")
+set(WXWIDGETS_VERSION "3.2.3")
 
 # Ensure that the wxWidgets library is staticly built.
 set(wxBUILD_SHARED OFF CACHE BOOL "Build wx libraries as shared libs")


### PR DESCRIPTION
As the PR title says. Applies to Windows and macOS builds of FreeDV and is intended to fix issues with macOS Sonoma.