### PR TITLE
Fix issue causing multiple macOS microphone permissions popups to appear.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -924,6 +924,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue preventing selection of FreeDV Reporter users during band tracking. (PR #555)
     * Work around issue preventing consistent switchover to 'From Mic' tab on voice keyer TX. (PR #563)
     * Fix rounding error when changing reporting frequency. (PR #562)
+    * Fix issue causing multiple macOS microphone permissions popups to appear. (PR #566)
 2. Enhancements:
     * Add configuration for background/foreground colors in FreeDV Reporter. (PR #545)
     * Always connect to FreeDV Reporter (in view only mode if necessary), regardless of valid configuration. (PR #542, #547)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,6 @@ set(FREEDV_SOURCES
     hamlib.h
     topFrame.h
     version.h
-    osx_interface.h
     util.cpp
     eq.cpp
     voicekeyer.cpp
@@ -39,10 +38,6 @@ set(FREEDV_SOURCES
     ongui.cpp
     freedv_interface.cpp
     freedv_interface.h        
-)
-
-set(FREEDV_SOURCES_OSX
-    osx_interface.mm
 )
 
 set(FREEDV_LINK_LIBS_OSX
@@ -53,6 +48,7 @@ set(FREEDV_LINK_LIBS_OSX
 add_subdirectory(audio)
 add_subdirectory(config)
 add_subdirectory(gui)
+add_subdirectory(os)
 add_subdirectory(pipeline)
 add_subdirectory(reporting)
 add_subdirectory(sox)
@@ -62,7 +58,7 @@ add_subdirectory(sox)
 if(APPLE)
     set(RES_FILES freedv.icns)
     set_source_files_properties(freedv.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
-    add_executable(FreeDV MACOSX_BUNDLE ${FREEDV_SOURCES} ${RES_FILES} ${FREEDV_SOURCES_OSX})
+    add_executable(FreeDV MACOSX_BUNDLE ${FREEDV_SOURCES} ${RES_FILES})
     set_target_properties(FreeDV PROPERTIES
         BUNDLE True
         MACOSX_BUNDLE_GUI_IDENTIFIER org.freedv.freedv
@@ -80,9 +76,9 @@ endif(APPLE)
 
 # Link imported or build tree targets.
 if(APPLE)
-target_link_libraries(FreeDV fdv_audio fdv_audio_pipeline fdv_config fdv_gui_util fdv_reporting fdv_sox lpcnetfreedv codec2)
+target_link_libraries(FreeDV fdv_audio fdv_audio_pipeline fdv_config fdv_gui_util fdv_os_wrapper fdv_reporting fdv_sox lpcnetfreedv codec2)
 else(APPLE)
-target_link_libraries(freedv fdv_audio fdv_audio_pipeline fdv_config fdv_gui_util fdv_reporting fdv_sox lpcnetfreedv codec2)
+target_link_libraries(freedv fdv_audio fdv_audio_pipeline fdv_config fdv_gui_util fdv_os_wrapper fdv_reporting fdv_sox lpcnetfreedv codec2)
 endif(APPLE)
 
 # Add build dependencies for internally built external libraries.

--- a/src/info.plist.in
+++ b/src/info.plist.in
@@ -33,7 +33,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.5</string>
+	<string>10.11</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@
 #include <wx/cmdline.h>
 #include "version.h"
 #include "main.h"
-#include "osx_interface.h"
+#include "os/os_interface.h"
 #include "freedv_interface.h"
 #include "audio/AudioEngineFactory.h"
 #include "codec2_fdmdv.h"
@@ -1945,15 +1945,18 @@ void MainFrame::performFreeDVOn_()
     });
     
     // attempt to start sound cards and tx/rx processing
-    bool micPermissionsSuccessful = false;
-    executeOnUiThreadAndWait_([&]() 
-    {
-        // Note: this executes on the UI thread as macOS may need to display popups
-        // to process this request.
-        micPermissionsSuccessful = VerifyMicrophonePermissions();
+    std::promise<bool> tmpPromise;
+    std::future<bool> tmpFuture = tmpPromise.get_future();
+
+    // Note: this executes on the UI thread as macOS may need to display popups
+    // to process this request.
+    CallAfter([&]() {
+        VerifyMicrophonePermissions(tmpPromise);
     });
+
+    tmpFuture.wait();
     
-    if (micPermissionsSuccessful)
+    if (tmpFuture.get())
     {
         bool soundCardSetupValid = false;
         executeOnUiThreadAndWait_([&]() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1943,9 +1943,17 @@ void MainFrame::performFreeDVOn_()
         m_textLevel->SetLabel(wxT(""));
         m_gaugeLevel->SetValue(0);
     });
-
+    
     // attempt to start sound cards and tx/rx processing
-    if (VerifyMicrophonePermissions())
+    bool micPermissionsSuccessful = false;
+    executeOnUiThreadAndWait_([&]() 
+    {
+        // Note: this executes on the UI thread as macOS may need to display popups
+        // to process this request.
+        micPermissionsSuccessful = VerifyMicrophonePermissions();
+    });
+    
+    if (micPermissionsSuccessful)
     {
         bool soundCardSetupValid = false;
         executeOnUiThreadAndWait_([&]() {

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -1,0 +1,11 @@
+if(APPLE)
+    set(OS_WRAP_FILES osx_interface.mm)
+else(APPLE)
+    set(OS_WRAP_FILES osx_stubs.cpp)
+endif(APPLE)
+
+add_library(fdv_os_wrapper STATIC
+    ${OS_WRAP_FILES}
+)
+
+target_include_directories(fdv_os_wrapper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/..)

--- a/src/os/os_interface.h
+++ b/src/os/os_interface.h
@@ -1,5 +1,5 @@
 //==========================================================================
-// Name:            osx_interface.h
+// Name:            os_interface.h
 //
 // Purpose:         Provides C wrapper to needed Objective-C calls.
 // Created:         Nov. 23, 2019
@@ -19,20 +19,16 @@
 //  along with this program; if not, see <http://www.gnu.org/licenses/>.
 //
 //==========================================================================
-#ifndef __OSX_INTERFACE__
-#define __OSX_INTERFACE__
+#ifndef __OS_INTERFACE__
+#define __OS_INTERFACE__
+
+#include <future>
 
 // Checks whether FreeDV has permissions to access the microphone on OSX Catalina
 // and above. If the user doesn't grant permissions (returns FALSE), the GUI 
 // should be able to properly handle the situation.
-#ifdef __APPLE__
-extern "C" bool VerifyMicrophonePermissions();
-#else
-// Stub for non-Apple platforms
-#define VerifyMicrophonePermissions() (true)
-#endif // __APPLE__
+void VerifyMicrophonePermissions(std::promise<bool>& promise);
 
-#ifdef __APPLE__
 // macOS does color space conversions in the background when rendering PlotWaterfall.
 // This causes FreeDV to use ~30-50% more CPU that it otherwise would (despite wxWidgets
 // using sRGB internally). Because of this, we reset the main window's color space to 
@@ -41,9 +37,5 @@ extern "C" bool VerifyMicrophonePermissions();
 // See https://github.com/OpenTTD/OpenTTD/issues/7644 and https://trac.wxwidgets.org/ticket/18516
 // for more details.
 extern "C" void ResetMainWindowColorSpace();
-#else
-// Stub for non-Apple platforms
-#define ResetMainWindowColorSpace() 
-#endif // __APPLE__
 
-#endif // __OSX_INTERFACE__
+#endif // __OS_INTERFACE__

--- a/src/os/osx_stubs.cpp
+++ b/src/os/osx_stubs.cpp
@@ -1,0 +1,33 @@
+//==========================================================================
+// Name:            osx_stubs.cpp
+//
+// Purpose:         Provides stubs for unimplemented Objective-C calls.
+// Created:         October 11, 2023
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#include "os_interface.h"
+
+void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
+{
+    micPromise.set_value(true);
+}
+
+void ResetMainWindowColorSpace()
+{
+    // empty
+}

--- a/src/plot_waterfall.cpp
+++ b/src/plot_waterfall.cpp
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include "wx/wx.h"
 #include "main.h"
-#include "osx_interface.h"
+#include "os/os_interface.h"
 
 // Tweak accordingly
 #define Y_PER_SECOND (30) 


### PR DESCRIPTION
In some instances, the popup from macOS can display two or more times after pushing Start for the first time, despite having pushed Allow. This PR updates the logic that triggers the popup such that the popup is triggered on the UI thread, eliminating the duplicate popups.

EDIT: this doesn't seem to fix it on Sonoma but might on earlier versions. Will monitor and see if future Sonoma updates resolve this or if an additional PR is required.