### PR TITLE
Fix issue causing a hang when testing serial port PTT.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.3)
+set(PROJECT_VERSION 1.9.4)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -46,7 +46,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -909,6 +909,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.4 TBD 2023
+
+1. Bugfixes:
+    * Fix issue causing hanging while testing serial port PTT. (PR #577)
+
 ## V1.9.3 October 2023
 
 1. Bugfixes:

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -731,12 +731,12 @@ void EasySetupDialog::OnTest(wxCommandEvent& event)
                 txTestAudioDevice_ = nullptr;
             }
         
-            if (hamlibTestObject_->isConnected())
+            if (hamlibTestObject_ != nullptr && hamlibTestObject_->isConnected())
             {
                 hamlibTestObject_->ptt(false);
                 hamlibTestObject_->disconnect();
             }
-            else if (serialPortTestObject_->isConnected())
+            else if (serialPortTestObject_ != nullptr && serialPortTestObject_->isConnected())
             {
                 serialPortTestObject_->ptt(false);
                 serialPortTestObject_->disconnect();
@@ -825,10 +825,15 @@ void EasySetupDialog::OnTest(wxCommandEvent& event)
             }
             else if (m_ckUseSerialPTT->GetValue())
             {
-                wxString serialPort = m_cbSerialPort->GetValue();
+                wxString serialPort = m_cbCtlDevicePath->GetValue();
 
                 if (!wxGetApp().CanAccessSerialPort((const char*)serialPort.ToUTF8()))
                 {
+                    CallAfter([&]() {
+                        wxMessageBox(
+                            "Couldn't connect to Radio.  Make sure the serial Device and Params match your radio", 
+                            wxT("Error"), wxOK | wxICON_ERROR, this);
+                    });
                     return;
                 }
                 

--- a/src/dlg_easy_setup.cpp
+++ b/src/dlg_easy_setup.cpp
@@ -853,7 +853,8 @@ void EasySetupDialog::OnTest(wxCommandEvent& event)
                 };
                 serialPortTestObject_->onRigConnected += [&](IRigController*) {
                     serialPortTestObject_->ptt(true);
-                };                
+                };          
+                serialPortTestObject_->connect();      
             }
         
             // Start playing a sine wave through the radio's device

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -62,7 +62,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
 
     wxStaticBox* hamlibBox = new wxStaticBox(panel, wxID_ANY, _("Hamlib Settings"));
     wxStaticBoxSizer* staticBoxSizer18 = new wxStaticBoxSizer( hamlibBox, wxHORIZONTAL);
-    wxGridSizer* gridSizerhl = new wxGridSizer(8, 2, 0, 0);
+    wxGridSizer* gridSizerhl = new wxGridSizer(7, 2, 0, 0);
     staticBoxSizer18->Add(gridSizerhl, 1, wxEXPAND|wxALIGN_LEFT, 5);
 
     /* Use Hamlib for PTT checkbox. */
@@ -131,11 +131,6 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbPttMethod->Append(wxT("DTR"));
     m_cbPttMethod->Append(wxT("None (RX Only)"));
     
-    gridSizerhl->Add(new wxStaticText(hamlibBox, wxID_ANY, _("Serial Params:"), wxDefaultPosition, wxDefaultSize, 0), 
-                      0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 20);
-    m_cbSerialParams = new wxStaticText(hamlibBox, wxID_ANY, _(""), wxDefaultPosition, wxDefaultSize, 0);
-    gridSizerhl->Add(m_cbSerialParams, 0, wxALIGN_CENTER_VERTICAL, 0);
-
     mainSizer->Add(staticBoxSizer18, 0, wxEXPAND, 5);
 
     //----------------------------------------------------------------------

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -632,6 +632,8 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
                 }
             };
 
+            hamlib->connect();
+            
             std::unique_lock<std::mutex> lk(mtx);
             cv.wait(lk);
             

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -675,6 +675,8 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
                 cv.notify_one();
             };
 
+            serialPort->connect();
+            
             std::unique_lock<std::mutex> lk(mtx);
             cv.wait(lk);
 

--- a/src/dlg_ptt.h
+++ b/src/dlg_ptt.h
@@ -59,7 +59,6 @@ class ComPortsDlg : public wxDialog
         wxComboBox *m_cbSerialPort;
         wxComboBox *m_cbPttSerialPort;
         wxComboBox *m_cbSerialRate;
-        wxStaticText  *m_cbSerialParams;
         wxStaticText *m_stIcomCIVHex;
         wxTextCtrl *m_tcIcomCIVHex;
         wxComboBox *m_cbPttMethod;


### PR DESCRIPTION
Reported on the digitalvoice list on October 22nd. This is due to some missed code to open the serial port during the testing process, causing a permanent hang until the process is killed.