### PR TITLE
Fix bug preventing frequency updates from being properly suppressed on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.4)
+set(PROJECT_VERSION 1.9.5)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -46,7 +46,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -909,6 +909,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.5 TBD 2023
+
+1. Bugfixes:
+    * Fix bug preventing frequency updates from being properly suppressed when frequency control is in focus. (PR #585)
+
 ## V1.9.4 October 2023
 
 1. Bugfixes:

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -400,9 +400,6 @@ bool MainFrame::OpenHamlibRig() {
                     m_txtModeStatus->SetForegroundColour(wxColor(*wxRED));
                 }
 
-                // Suppress updates if the Report Frequency box has focus.
-                //suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
-
                 // Update frequency box
                 if (!suppressFreqModeUpdates_ && (
                     !wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -401,7 +401,7 @@ bool MainFrame::OpenHamlibRig() {
                 }
 
                 // Suppress updates if the Report Frequency box has focus.
-                suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
+                //suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
 
                 // Update frequency box
                 if (!suppressFreqModeUpdates_ && (

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -335,7 +335,7 @@ bool MainFrame::OpenHamlibRig() {
         };
 
         wxGetApp().rigFrequencyController->onRigConnected += [&](IRigController*) {
-            if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+            if (wxGetApp().rigFrequencyController && wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
             {
                 wxGetApp().rigFrequencyController->setFrequency(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
                 wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
@@ -400,16 +400,17 @@ bool MainFrame::OpenHamlibRig() {
                     m_txtModeStatus->SetForegroundColour(wxColor(*wxRED));
                 }
 
+                // Suppress updates if the Report Frequency box has focus.
+                suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
+
                 // Update frequency box
-                if (!wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||
-                    !wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting)
+                if (!suppressFreqModeUpdates_ && (
+                    !wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||
+                    !wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting))
                 {
                     m_cboReportFrequency->SetValue(wxString::Format("%.4f", freq/1000.0/1000.0));
                 }
                 m_txtModeStatus->Refresh();
-
-                // Suppress updates if the Report Frequency box has focus.
-                suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
             });
         };
 


### PR DESCRIPTION
Resolves #584 by explicitly checking for the suppression state (and additionally resetting it based on the current focus status on every frequency update) prior to actually updating the frequency. This appears necessary since GTK doesn't seem to trigger the various focus events, unlike other platforms.