### PR TITLE
Fix bug preventing 60 meter frequencies from using USB with DIGU/DIGL disabled

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -913,6 +913,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Fix bug preventing frequency updates from being properly suppressed when frequency control is in focus. (PR #585)
+    * Fix bug preventing 60 meter frequencies from using USB with DIGU/DIGL disabled. (PR #589)
 
 ## V1.9.4 October 2023
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -837,36 +837,25 @@ void MainFrame::togglePTT(void) {
 
 HamlibRigController::Mode MainFrame::getCurrentMode_()
 {
+    // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
+    bool is60MeterBand = 
+        wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency >= 5250000 && 
+        wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency <= 5450000;
+    
     bool useAnalog = 
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseAnalogModes || g_analog;
+    HamlibRigController::Mode lsbMode = useAnalog ? HamlibRigController::LSB : HamlibRigController::DIGL;
+    HamlibRigController::Mode usbMode = useAnalog ? HamlibRigController::USB : HamlibRigController::DIGU;
+    
     HamlibRigController::Mode newMode;
-    if (useAnalog)
+    if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency < 10000000 &&
+        !is60MeterBand)
     {
-        if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency < 10000000)
-        {
-            newMode = HamlibRigController::LSB;
-        }
-        else
-        {
-            newMode = HamlibRigController::USB;
-        }
+        newMode = lsbMode;
     }
     else
     {
-        // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
-        bool is60MeterBand = 
-            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency >= 5250000 && 
-            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency <= 5450000;
-
-        if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency < 10000000 &&
-            !is60MeterBand)
-        {
-            newMode = HamlibRigController::DIGL;
-        }
-        else
-        {
-            newMode = HamlibRigController::DIGU;
-        }
+        newMode = usbMode;
     }
 
     return newMode;


### PR DESCRIPTION
This PR fixes a bug reported on the digitalvoice list where when "Use USB/LSB instead of DIGU/DIGL" is checked, the specific check to force USB for 60 meters is missing. This results in the radio improperly switching to LSB when a 60 meter frequency is selected or entered.