### PR TITLE
Add ability to double-click FreeDV Reporter entries to change the radio's frequency.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -63,7 +63,7 @@ you to adjust your radio sound levels (see "Sound Card Levels" below).
 ### Reporting
 
 While not required, it is recommended to enable reporting so that others
-can see who is currently receiving them. This will also allow the FreeDV
+can see who is currently receiving them. This also allows the FreeDV
 applicaton to control the radio's frequency and mode. Both sides of a contact 
 must have this enabled in order for contacts to be reported. To configure 
 reporting, simply enable the feature here and enter your callsign and current 
@@ -365,12 +365,13 @@ The following services are currently supported and can be individually enabled o
 along with the reporting feature as a whole:
 
 * [PSK Reporter](https://pskreporter.info/) (using the "FREEDV" mode)
-* [FreeDV Reporter](https://freedv-reporter.k6aq.net/)
+* [FreeDV Reporter](https://qso.freedv.org/) -- also accessible via the Tools->FreeDV Reporter menu option.
 
 The frequency that FreeDV reports is set by changing the "Report Frequency" drop down box in the main window. This 
 is in kilohertz (kHz) and will turn red if the entered value is invalid. If Hamlib support is also enabled, 
 this frequency will automatically remain in sync with the current VFO on the radio (i.e. if the frequency is changed
-in the application, the radio will also change its frequency).
+in the application, the radio will also change its frequency). Double-clicking on users in the Tools->FreeDV Reporter
+window will also cause this frequency to change to match the other user.
 
 *Note: in some setups (such as when using ALE), it is not preferred to have the reporting frequency automatically be 
 in sync with the radio. For example, in the case of ALE, the radio's frequency changes multiple times per second while
@@ -916,6 +917,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Fix bug preventing frequency updates from being properly suppressed when frequency control is in focus. (PR #585)
     * Fix bug preventing 60 meter frequencies from using USB with DIGU/DIGL disabled. (PR #589)
+2. Enhancements:
+    * Add ability to double-click FreeDV Reporter entries to change the radio's frequency. (PR #592)
 
 ## V1.9.4 October 2023
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -63,9 +63,11 @@ you to adjust your radio sound levels (see "Sound Card Levels" below).
 ### Reporting
 
 While not required, it is recommended to enable reporting so that others
-can see who is currently receiving them. Both sides of a contact must have this enabled
-in order for this feature to work. To configure reporting, simply enable
-the feature here and enter your callsign and current grid square.
+can see who is currently receiving them. This will also allow the FreeDV
+applicaton to control the radio's frequency and mode. Both sides of a contact 
+must have this enabled in order for contacts to be reported. To configure 
+reporting, simply enable the feature here and enter your callsign and current 
+grid square/locator.
 
 For more information about the reporting feature, see the "FreeDV Reporting" section below.
 

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -167,7 +167,8 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_listSpots->Connect(wxEVT_LIST_ITEM_SELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemSelected), NULL, this);
     m_listSpots->Connect(wxEVT_LIST_ITEM_DESELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemDeselected), NULL, this);
     m_listSpots->Connect(wxEVT_LIST_COL_CLICK, wxListEventHandler(FreeDVReporterDialog::OnSortColumn), NULL, this);
-
+    m_listSpots->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(FreeDVReporterDialog::OnDoubleClick), NULL, this);
+    
     m_buttonOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnOK), NULL, this);
     m_buttonSendQSY->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnSendQSY), NULL, this);
     m_buttonDisplayWebpage->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnOpenWebsite), NULL, this);
@@ -205,6 +206,7 @@ FreeDVReporterDialog::~FreeDVReporterDialog()
     m_listSpots->Disconnect(wxEVT_LIST_ITEM_SELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemSelected), NULL, this);
     m_listSpots->Disconnect(wxEVT_LIST_ITEM_DESELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemDeselected), NULL, this);
     m_listSpots->Disconnect(wxEVT_LIST_COL_CLICK, wxListEventHandler(FreeDVReporterDialog::OnSortColumn), NULL, this);
+    m_listSpots->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(FreeDVReporterDialog::OnDoubleClick), NULL, this);
     
     m_buttonOK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnOK), NULL, this);
     m_buttonSendQSY->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnSendQSY), NULL, this);
@@ -399,6 +401,18 @@ void FreeDVReporterDialog::OnFilterTrackingEnable(wxCommandEvent& event)
     }
     
     setBandFilter(freq);
+}
+
+void FreeDVReporterDialog::OnDoubleClick(wxMouseEvent& event)
+{
+    auto selectedIndex = m_listSpots->GetFirstSelected();
+    if (selectedIndex >= 0 && wxGetApp().rigFrequencyController && 
+        wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+    {
+        std::string* sidPtr = (std::string*)m_listSpots->GetItemData(selectedIndex);
+        
+        wxGetApp().rigFrequencyController->setFrequency(allReporterData_[*sidPtr]->frequency);
+    }
 }
 
 void FreeDVReporterDialog::refreshQSYButtonState()

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -86,6 +86,8 @@ class FreeDVReporterDialog : public wxDialog
         void OnTimer(wxTimerEvent& event);
         void OnFilterTrackingEnable(wxCommandEvent& event);
         
+        void OnDoubleClick(wxMouseEvent& event);
+        
         // Main list box that shows spots
         wxListView*   m_listSpots;
         wxImageList*  m_sortIcons;


### PR DESCRIPTION
Resolves #588 by allowing users to double-click on entries in the FreeDV Reporter window to change the radio's frequency and mode. Minor tweaks to the documentation have also been made to clarify that reporting will enable frequency/mode control.