### PR TITLE
Confirm reset before actually doing so.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -914,6 +914,9 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Fix bug preventing frequency updates from being properly suppressed when frequency control is in focus. (PR #585)
     * Fix bug preventing 60 meter frequencies from using USB with DIGU/DIGL disabled. (PR #589)
+    * Fix bug preventing FreeDV Reporter window from closing after resetting configuration to defaults. (PR #593)
+2. Enhancements:
+    * Add confirmation dialog box before actually resetting configuration to defaults. (PR #593)
 
 ## V1.9.4 October 2023
 


### PR DESCRIPTION
Per email request, adds a confirmation popup before resetting configuration to defaults. Reset-related bugs (i.e. with FreeDV Reporter) discovered during testing are also fixed as part of this PR.