### PR TITLE
Add files to allow generation of Flatpak packages.

### DIFF
--- a/flatpak/LPCNet-flatpak-support.patch
+++ b/flatpak/LPCNet-flatpak-support.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1600871..613cb09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,10 +169,10 @@ set(LPCNET_ROOT http://rowetel.com/downloads/deep/)
+ set(LPCNET_FILE lpcnet_191005_v1.0.tgz)
+ set(LPCNET_URL ${LPCNET_ROOT}${LPCNET_FILE})
+ 
+-if(EXISTS ${CMAKE_BINARY_DIR}/${LPCNET_FILE})
++if(EXISTS ${CMAKE_SOURCE_DIR}/${LPCNET_FILE})
+     set(lpcnet_SOURCE_DIR ${CMAKE_BINARY_DIR}/src)
+     file(MAKE_DIRECTORY ${lpcnet_SOURCE_DIR})
+-    execute_process(COMMAND tar -xzf ${CMAKE_BINARY_DIR}/${LPCNET_FILE} -C ${CMAKE_BINARY_DIR}/src)
++    execute_process(COMMAND tar -xzf ${CMAKE_SOURCE_DIR}/${LPCNET_FILE} -C ${CMAKE_BINARY_DIR}/src)
+ 
+ # Work around not having the FetchContent module.
+ elseif(CMAKE_VERSION VERSION_LESS 3.11.4)

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,37 @@
+# Flatpak packaging
+
+This folder contains the files necessary to generate a Flatpak package for FreeDV. Flatpak
+is a container-based packaging scheme available on most common Linux distros that enables
+the generation of a single package that works on multiple systems with no modifications
+required.
+
+## Setting up a Flatpak build environment
+
+Execute the following command (Debian/Ubuntu):
+
+```
+$ git config --global protocol.file.allow always
+$ sudo apt install flatpak flatpak-builder gnome-software-plugin-flatpak
+$ flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+$ flatpak install flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08 
+```
+
+On other distros, the packages should be similar.
+
+## Generating a Flatpak package
+
+```
+$ flatpak-builder flatpak-build org.freedv.freedv.yml
+```
+
+## Installing and testing the generated package
+
+```
+$ flatpak-builder --user --install --force-clean flatpak-build org.freedv.freedv.yml
+$ flatpak run org.freedv.freedv
+```
+
+## Additional notes
+
+The Flatpak build container has no network access, so any new dependencies added to FreeDV will
+need to be downloaded and built as a separate module to ensure that the package can still be built.

--- a/flatpak/org.freedv.freedv.yml
+++ b/flatpak/org.freedv.freedv.yml
@@ -1,0 +1,71 @@
+app-id: org.freedv.freedv
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: freedv
+finish-args:
+    - --share=network
+    - --socket=wayland
+    - --share=ipc
+    - --socket=fallback-x11
+    - --socket=pulseaudio
+    - --filesystem=home
+modules:
+    - name: wxWidgets
+      buildsystem: cmake
+      builddir: true
+      sources:
+          - type: git
+            url: https://github.com/wxWidgets/wxWidgets
+            tag: v3.2.3
+    - name: LPCNet
+      buildsystem: cmake
+      builddir: true
+      sources:
+          - type: git
+            url: https://github.com/drowe67/LPCNet.git
+            tag: v0.5
+          - type: file
+            url: http://rowetel.com/downloads/deep/lpcnet_191005_v1.0.tgz
+            sha256: 509440924751fdd87ffaa5683ee3dddd937af5c833b9104ccce65d51614926c8
+          - type: patch
+            path: LPCNet-flatpak-support.patch
+    - name: codec2
+      buildsystem: cmake
+      builddir: true
+      modules:
+          - LPCNet
+      sources:
+          - type: git
+            url: https://github.com/drowe67/codec2.git
+            tag: 1.2.0
+      config-opts:
+          - -DLPCNET=ON
+    - name: hamlib
+      buildsystem: autotools
+      sources:
+          - type: git
+            url: https://github.com/Hamlib/Hamlib.git
+            tag: 4.5.5
+    - name: socketio-cpp
+      buildsystem: cmake
+      sources:
+          - type: git
+            url: https://github.com/socketio/socket.io-client-cpp.git
+            tag: master
+      config-opts:
+          - -DBUILD_TESTING=OFF
+    - name: freedv
+      buildsystem: cmake
+      builddir: true
+      modules:
+          - wxWidgets
+          - LPCNet
+          - codec2
+          - hamlib
+          - socketio-cpp
+      sources:
+          - type: git
+            url: https://github.com/drowe67/freedv-gui.git
+            tag: v1.9.4
+

--- a/flatpak/org.freedv.freedv.yml
+++ b/flatpak/org.freedv.freedv.yml
@@ -10,6 +10,7 @@ finish-args:
     - --socket=fallback-x11
     - --socket=pulseaudio
     - --filesystem=home
+    - --device=all
 modules:
     - name: wxWidgets
       buildsystem: cmake


### PR DESCRIPTION
This PR adds a new `flatpak` folder in the source tree to enable generation of Flatpak packages for FreeDV. By doing so, this should hopefully allow users who prefer to run the newest versions of FreeDV to do so. It's presumed that distro-specific packages will still be maintained and available (albeit slightly older than the Flatpak one) for those who don't want to take on the additional overhead.

(More information about Flatpak at https://flatpak.org/.)

Remaining tasks:

- [ ] Have others test the instructions in this PR to ensure that packages can be generated and that FreeDV executes normally inside the Flatpak container.
- [ ] Customize anything additional with the generated packages as needed (i.e. application icon)