### PR TITLE
Add new 160m, 80m and 40m calling frequencies for IARU R2.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -924,6 +924,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Add support for filtering the exact frequency. (PR #596)
     * Add confirmation dialog box before actually resetting configuration to defaults. (PR #593)
     * Add ability to double-click FreeDV Reporter entries to change the radio's frequency. (PR #592)
+    * Add new 160m/80m/40m calling frequencies for IARU R2. (PR #601)
 
 ## V1.9.4 October 2023
 

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -50,13 +50,16 @@ ReportingConfiguration::ReportingConfiguration()
     , useUTCForReporting("/CallsignList/UseUTCTime", false)
         
     , reportingFrequencyList("/Reporting/FrequencyList", {
+        _("1.9970"),
         _("3.6250"),
         _("3.6430"),
         _("3.6930"),
         _("3.6970"),
+        _("3.8500"),
         _("5.4035"),
         _("5.3665"),
         _("7.1770"),
+        _("7.1970"),
         _("14.2360"),
         _("14.2400"),
         _("18.1180"),


### PR DESCRIPTION
Resolves #580 by adding the following frequencies to the default frequency list:

* 1997 KHz (160 meters)
* 3850 KHz (80 meters)
* 7197 KHz (40 meters)

The new 40/80m frequencies are intended to be used as alternates for IARU R2 for those who can't use the existing frequencies (i.e. US General class licensees).