### PR TITLE
Report OS usage to FreeDV Reporter.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -926,6 +926,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add ability to double-click FreeDV Reporter entries to change the radio's frequency. (PR #592)
     * FreeDV Reporter: Add ability to force RX Only reporting in Tools->Options. (PR #599)
     * Add new 160m/80m/40m calling frequencies for IARU R2. (PR #601)
+3. Other:
+    * Report OS usage to FreeDV Reporter. (PR #606)
 
 ## V1.9.4 October 2023
 

--- a/src/os/os_interface.h
+++ b/src/os/os_interface.h
@@ -23,6 +23,7 @@
 #define __OS_INTERFACE__
 
 #include <future>
+#include <string>
 
 // Checks whether FreeDV has permissions to access the microphone on OSX Catalina
 // and above. If the user doesn't grant permissions (returns FALSE), the GUI 
@@ -37,5 +38,9 @@ void VerifyMicrophonePermissions(std::promise<bool>& promise);
 // See https://github.com/OpenTTD/OpenTTD/issues/7644 and https://trac.wxwidgets.org/ticket/18516
 // for more details.
 extern "C" void ResetMainWindowColorSpace();
+
+// Retrieves a string representing the operating system that FreeDV is running on.
+// This can be either "windows", "linux", "macos" or "other".
+std::string GetOperatingSystemString();
 
 #endif // __OS_INTERFACE__

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -75,3 +75,8 @@ void ResetMainWindowColorSpace()
     assert(cs != nullptr);
     CGColorSpaceRelease(cs);
 }
+
+std::string GetOperatingSystemString()
+{
+    return "macos";
+}

--- a/src/os/osx_stubs.cpp
+++ b/src/os/osx_stubs.cpp
@@ -31,3 +31,14 @@ void ResetMainWindowColorSpace()
 {
     // empty
 }
+
+std::string GetOperatingSystemString()
+{
+#ifdef __linux__
+    return "linux";
+#elif _WIN32
+    return "windows";
+#else
+    return "other";
+#endif // __linux__ || _WIN32
+}

--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -231,7 +231,7 @@ void FreeDVReporter::connect_()
         auth->insert("grid_square", gridSquare_);
         auth->insert("version", software_);
         auth->insert("rx_only", sio::bool_message::create(rxOnly_));
-        auth->insert("os", GetOperatingSystemString() );
+        auth->insert("os", GetOperatingSystemString());
     }
 
     // Reconnect listener should re-report frequency so that "unknown"

--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -22,6 +22,7 @@
 
 #include "FreeDVReporter.h"
 #include "sio_client.h"
+#include "../os/os_interface.h"
 
 using namespace std::chrono_literals;
 
@@ -230,6 +231,7 @@ void FreeDVReporter::connect_()
         auth->insert("grid_square", gridSquare_);
         auth->insert("version", software_);
         auth->insert("rx_only", sio::bool_message::create(rxOnly_));
+        auth->insert("os", GetOperatingSystemString() );
     }
 
     // Reconnect listener should re-report frequency so that "unknown"


### PR DESCRIPTION
FreeDV Reporter is now able to collect statistics on OS usage. This PR updates freedv-gui to provide this information so that the project can determine the platforms most commonly used by FreeDV users.