### PR TITLE
Fix bug preventing reload of manually entered frequency on start.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -920,6 +920,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Additional fix for PR #561 to parse/format frequencies using current locale. (PR #595)
     * Add entitlements to work around macOS Sonoma permissions bug. (PR #598)
     * Fix bug preventing FreeDV Reporter window from closing after resetting configuration to defaults. (PR #593)
+    * Fix bug preventing reload of manually entered frequency on start. (PR #608)
 2. Enhancements:
     * FreeDV Reporter: Add support for filtering the exact frequency. (PR #596)
     * Add confirmation dialog box before actually resetting configuration to defaults. (PR #593)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,8 @@
 
 #include <inttypes.h>
 #include <time.h>
+#include <sstream>
+#include <iomanip>
 #include <vector>
 #include <deque>
 #include <random>
@@ -432,8 +434,21 @@ void MainFrame::loadConfiguration_()
     wxGetApp().m_tone_amplitude = 500;
     
     // General reporting parameters
-    m_cboReportFrequency->SetValue(wxString::Format("%.4f", ((double)wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency)/1000.0/1000.0));
-    
+
+    // wxString::Format() doesn't respect locale but C++ iomanip should. Use the latter instead.
+    if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0)
+    {
+        double freq =  ((double)wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency)/1000.0/1000.0;
+
+        std::stringstream ss;
+        std::locale loc("");
+        ss.imbue(loc);
+        ss << std::fixed << std::setprecision(4) << freq;
+        std::string sVal = ss.str();
+
+        m_cboReportFrequency->SetValue(sVal);
+    }
+
     int defaultMode = wxGetApp().appConfiguration.currentFreeDVMode.getDefaultVal();
     int mode = wxGetApp().appConfiguration.currentFreeDVMode;
 setDefaultMode:

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1093,7 +1093,15 @@ void MainFrame::OnSystemColorChanged(wxSysColourChangedEvent& event)
 void MainFrame::updateReportingFreqList_()
 {
     uint64_t prevFreqInt = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
-    auto prevSelected = wxString::Format(_("%.04f"), (double)prevFreqInt / (double)1000.0 / (double)1000.0);
+
+    double freq =  ((double)prevFreqInt)/1000.0/1000.0;
+
+    std::stringstream ss;
+    std::locale loc("");
+    ss.imbue(loc);
+    ss << std::fixed << std::setprecision(4) << freq;
+    std::string prevSelected = ss.str();
+
     m_cboReportFrequency->Clear();
     
     for (auto& item : wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyList.get())
@@ -1105,6 +1113,6 @@ void MainFrame::updateReportingFreqList_()
     if (idx >= 0)
     {
         m_cboReportFrequency->SetSelection(idx);
-        m_cboReportFrequency->SetValue(prevSelected);
     }
+    m_cboReportFrequency->SetValue(prevSelected);
 }


### PR DESCRIPTION
Reported by @barjac. This PR fixes an issue causing manually entered frequencies to be overwritten on start.