### PR TITLE
Fix #610 by using SetSize instead of SetClientSize.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.5)
+set(PROJECT_VERSION 1.9.6)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -46,7 +46,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -912,6 +912,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.6 TBD 2023
+
+1. Bugfixes:
+    * Use SetSize/GetSize instead of SetClientSize/GetClientSize to work around startup sizing issue. (PR #611)
+
 ## V1.9.5 November 2023
 
 1. Bugfixes:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -395,9 +395,9 @@ void MainFrame::loadConfiguration_()
 
     if (w < size.GetWidth()) w = size.GetWidth();
     if (h < size.GetHeight()) h = size.GetHeight();
-    SetClientSize(w, h);
+    SetSize(w, h);
     SetSizeHints(size);
-        
+    
     g_txLevel = wxGetApp().appConfiguration.transmitLevel;
     char fmt[15];
     m_sliderTxLevel->SetValue(g_txLevel);
@@ -906,7 +906,7 @@ MainFrame::~MainFrame()
     wxGetApp().m_pttInSerialPort = nullptr;
     
     if (!IsIconized()) {
-        GetClientSize(&w, &h);
+        GetSize(&w, &h);
         GetPosition(&x, &y);
         
         wxGetApp().appConfiguration.mainWindowLeft = x;


### PR DESCRIPTION
`SetClientSize()` as was used in previous releases to restore window size doesn't seem to work well with the new Get Help button. This PR switches to using `SetSize()` instead (and subsequently also uses `GetSize()` to save the size of the window).