### PR TITLE
Check for RIGCAPS_NOT_CONST in Hamlib and update function definition as needed

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -916,6 +916,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Use SetSize/GetSize instead of SetClientSize/GetClientSize to work around startup sizing issue. (PR #611)
+    * Check for RIGCAPS_NOT_CONST in Hamlib 4.6. (PR #615)
 
 ## V1.9.5 November 2023
 

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -35,7 +35,11 @@ extern int g_verbose;
 HamlibRigController::RigList HamlibRigController::RigList_;
 std::mutex HamlibRigController::RigListMutex_;
 
-int HamlibRigController::BuildRigList_(const struct rig_caps *rig, rig_ptr_t rigList) {
+#if RIGCAPS_NOT_CONST
+int HamlibRigController::BuildRigList_(struct rig_caps *rig, rig_ptr_t rigList) {
+#else
+int HamlibRigController::BuildRigList_(const struct rig_caps *rig, rig_ptr_t rigList) {    
+#endif // RIGCAPS_NOT_CONST
     ((HamlibRigController::RigList *)rigList)->push_back(rig); 
     return 1;
 }

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -96,9 +96,14 @@ private:
     
     static RigList RigList_;
     static std::mutex RigListMutex_;
-    
+
     static bool RigCompare_(const struct rig_caps *rig1, const struct rig_caps *rig2);
+
+#if RIGCAPS_NOT_CONST    
+    static int BuildRigList_(struct rig_caps *rig, rig_ptr_t);
+#else
     static int BuildRigList_(const struct rig_caps *rig, rig_ptr_t);
+#endif // RIGCAPS_NOT_CONST
 };
 
 #endif // HAMLIB_RIG_CONTROLLER_H


### PR DESCRIPTION
Resolves #614 by checking for new `RIGCAPS_NOT_CONST` definition in Hamlib (to differentiate between Hamlib 4.6 and older versions).