### PR TITLE
Add 800XA to multi-receive mode list.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -389,12 +389,11 @@ FreeDV can simultaneously decode the following modes when selected prior to push
 * 2020/2020B
 * 700C/D/E
 * 1600
+* 800XA
 
 In addition, FreeDV can allow the user to switch between the above modes for transmit without having to push "Stop" first. 
 These features can be enabled by going to Tools->Options->Modem and checking the "Simultaneously Decode All HF Modes" option. Note that
-this may consume significant additional CPU resources, which can cause decode problems. In addition, these features are automatically
-disabled if 800XA or 2400B are selected before pushing "Start" due to the significant additional CPU resources required to decode these
-modes.
+this may consume significant additional CPU resources, which can cause decode problems. 
 
 By default, FreeDV will use as many threads/cores in parallel as required to decode all supported HF modes. On some slower systems, it may be
 necessary to enable the "Use single thread for multiple RX operation" option as well. This results in FreeDV decoding each mode in series
@@ -918,6 +917,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Use SetSize/GetSize instead of SetClientSize/GetClientSize to work around startup sizing issue. (PR #611)
     * Check for RIGCAPS_NOT_CONST in Hamlib 4.6. (PR #615)
     * Make main screen gauges horizontal to work around sizing/layout issues. (PR #613)
+2. Enhancements:
+    * Add 800XA to multi-RX list. (PR #617)
 
 ## V1.9.5 November 2023
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -107,6 +107,8 @@ float FreeDVInterface::GetMinimumSNR_(int mode)
             return 4.0f;
         case FREEDV_MODE_2020:
             return 2.0f;
+        case FREEDV_MODE_800XA:
+            return 2.0f;
         default:
             return 0.0f;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1831,8 +1831,7 @@ void MainFrame::performFreeDVOn_()
         wxCommandEvent tmpEvent;
         OnChangeTxMode(tmpEvent);
 
-        if (g_mode == FREEDV_MODE_800XA || 
-            !wxGetApp().appConfiguration.multipleReceiveEnabled)
+        if (!wxGetApp().appConfiguration.multipleReceiveEnabled)
         {
             m_rb1600->Disable();
             m_rb700c->Disable();
@@ -1860,19 +1859,14 @@ void MainFrame::performFreeDVOn_()
                 FREEDV_MODE_700E,
                 FREEDV_MODE_700C,
                 FREEDV_MODE_700D,
-            
-                // These modes require more CPU than typical (and will drive at least one core to 100% if
-                // used with the other five above), so we're excluding them from multi-RX. They also aren't
-                // selectable during a session when multi-RX is enabled.
-                //FREEDV_MODE_800XA
+                FREEDV_MODE_800XA
             };
+
             for (auto& mode : rxModes)
             {
                 freedvInterface.addRxMode(mode);
             }
         
-            m_rb800xa->Disable();
-            
             // If we're receive-only, it doesn't make sense to be able to change TX mode.
             if (g_nSoundCards <= 1)
             {


### PR DESCRIPTION
During testing this morning, we determined that the previous issue with 800XA and CPU consumption doesn't exist. This PR adds 800XA mode to the multi-receive list to improve usability (i.e. by making things in the UI more consistent).