### PR TITLE
Allow serial PTT to be enabled along with OmniRig.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -918,6 +918,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Use SetSize/GetSize instead of SetClientSize/GetClientSize to work around startup sizing issue. (PR #611)
     * Check for RIGCAPS_NOT_CONST in Hamlib 4.6. (PR #615)
     * Make main screen gauges horizontal to work around sizing/layout issues. (PR #613)
+2. Enhancements:
+    * Allow serial PTT to be enabled along with OmniRig. (PR #619)
 
 ## V1.9.5 November 2023
 

--- a/src/dlg_ptt.cpp
+++ b/src/dlg_ptt.cpp
@@ -796,12 +796,11 @@ void ComPortsDlg::OnTest(wxCommandEvent& event) {
 
 #if defined(WIN32)
 //-------------------------------------------------------------------------
-// PTTUseSerialClicked()
+// PTTUseOmniRigClicked()
 //-------------------------------------------------------------------------
 void ComPortsDlg::PTTUseOmniRigClicked(wxCommandEvent& event)
 {
     m_ckUseHamlibPTT->SetValue(false);
-    m_ckUseSerialPTT->SetValue(false);
     updateControlState();
 }
 #endif // defined(WIN32)
@@ -811,11 +810,7 @@ void ComPortsDlg::PTTUseOmniRigClicked(wxCommandEvent& event)
 //-------------------------------------------------------------------------
 void ComPortsDlg::PTTUseSerialClicked(wxCommandEvent& event)
 {
-    m_ckUseHamlibPTT->SetValue(false);
-#if defined(WIN32)
-    m_ckUseOmniRig->SetValue(false);
-#endif // defined(WIN32)
-    
+    m_ckUseHamlibPTT->SetValue(false);    
     updateControlState();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2000,9 +2000,17 @@ void MainFrame::performFreeDVOn_()
             {
                 OpenSerialPort();
             }
-#if defined(WIN32)
-            else if (wxGetApp().appConfiguration.rigControlConfiguration.useOmniRig)
+            else
             {
+                wxGetApp().rigPttController = nullptr;
+            }
+            
+#if defined(WIN32)
+            if (wxGetApp().appConfiguration.rigControlConfiguration.useOmniRig)
+            {
+                // OmniRig can be anbled along with serial port PTT.
+                // The logic below will ensure we don't overwrite the serial PTT
+                // handler.
                 OpenOmniRig();
             }
 #endif // defined(WIN32)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -461,8 +461,11 @@ void MainFrame::OpenOmniRig()
 
     // OmniRig also controls PTT.
     wxGetApp().rigFrequencyController = tmp;
-    wxGetApp().rigPttController = tmp;
-    
+    if (!wxGetApp().rigPttController)
+    {
+        wxGetApp().rigPttController = tmp;
+    }
+
     wxGetApp().rigFrequencyController->onRigError += [this](IRigController*, std::string err)
     {
         std::string fullErr = "Couldn't connect to Radio with OmniRig: " + err;


### PR DESCRIPTION
Per request from Discord, this PR allows OmniRig to be enabled along with serial port PTT. This has the effect of allowing use of OmniRig for frequency control and the serial port RTS/DTR pins for PTT control.