### PR TITLE
Fix compiler issue with certain versions of MinGW.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -918,6 +918,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Use SetSize/GetSize instead of SetClientSize/GetClientSize to work around startup sizing issue. (PR #611)
     * Check for RIGCAPS_NOT_CONST in Hamlib 4.6. (PR #615)
     * Make main screen gauges horizontal to work around sizing/layout issues. (PR #613)
+    * Fix compiler issue with certain versions of MinGW. (PR #622)
 2. Enhancements:
     * Allow serial PTT to be enabled along with OmniRig. (PR #619)
     * Add 800XA to multi-RX list. (PR #617)

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -165,7 +165,7 @@ class FreeDVReporterDialog : public wxDialog
          double calculateDistance_(wxString gridSquare1, wxString gridSquare2);
          void calculateLatLonFromGridSquare_(wxString gridSquare, double& lat, double& lon);
 
-         static int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData) wxCALLBACK;
+         static wxCALLBACK int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
          static double DegreesToRadians_(double degrees);
 };
 


### PR DESCRIPTION
Reported in https://github.com/drowe67/freedv-gui/commit/243260d38141c20db7b8e653e073496e64fb2431. This issue appears to happen in certain versions of MinGW as well as Visual Studio (hence may be failing for users using a standards-compliant build environment).