### PR TITLE
Suppress use of space bar when in RX Only mode.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -919,6 +919,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Check for RIGCAPS_NOT_CONST in Hamlib 4.6. (PR #615)
     * Make main screen gauges horizontal to work around sizing/layout issues. (PR #613)
     * Fix compiler issue with certain versions of MinGW. (PR #622)
+    * Suppress use of space bar when in RX Only mode. (PR #623)
 2. Enhancements:
     * Allow serial PTT to be enabled along with OmniRig. (PR #619)
     * Add 800XA to multi-RX list. (PR #617)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3036,12 +3036,7 @@ bool MainFrame::validateSoundCardSetup()
 
 void MainFrame::initializeFreeDVReporter_()
 {
-    bool hamlibDisabledForRigControl = 
-        (wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT &&
-         (HamlibRigController::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get() == HamlibRigController::PTT_VIA_NONE);
-    bool receiveOnly = 
-        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterForceReceiveOnly || 
-        g_nSoundCards <= 1 || hamlibDisabledForRigControl;
+    bool receiveOnly = isReceiveOnly();
     
     auto oldReporterObject = wxGetApp().m_sharedReporterObject;
     wxGetApp().m_sharedReporterObject =

--- a/src/main.h
+++ b/src/main.h
@@ -344,6 +344,8 @@ class MainFrame : public TopFrame
         void StopPlaybackFileFromRadio();
         void StopRecFileFromRadio();
         
+        bool isReceiveOnly();
+        
     protected:
 
         void setsnrBeta(bool snrSlow);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -751,7 +751,7 @@ int MainApp::FilterEvent(wxEvent& event)
         (((wxKeyEvent&)event).GetKeyCode() == WXK_SPACE))
         {
             // only use space to toggle PTT if we are running and no modal dialogs (like options) up
-            if (frame->m_RxRunning && frame->IsActive() && wxGetApp().appConfiguration.enableSpaceBarForPTT) {
+            if (frame->m_RxRunning && frame->IsActive() && wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
 
                 // space bar controls rx/rx if keyer not running
                 if (frame->vk_state == VK_IDLE) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -113,6 +113,20 @@ bool MainApp::CanAccessSerialPort(std::string portName)
 }
 
 //----------------------------------------------------------------
+// isReceiveOnly()
+//----------------------------------------------------------------
+
+bool MainFrame::isReceiveOnly()
+{
+    bool hamlibDisabledForRigControl = 
+        (wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT &&
+         (HamlibRigController::PttType)wxGetApp().appConfiguration.rigControlConfiguration.hamlibPTTType.get() == HamlibRigController::PTT_VIA_NONE);
+    return 
+        wxGetApp().appConfiguration.reportingConfiguration.freedvReporterForceReceiveOnly || 
+        g_nSoundCards <= 1 || hamlibDisabledForRigControl;
+}
+
+//----------------------------------------------------------------
 // OpenSerialPort()
 //----------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes an issue reported on the digitalvoice mailing list whereby if TX is disabled, PTT can still be toggled by use of the space bar.