### PR TITLE
Fix Windows-specific issue preventing entry of very high frequencies

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -920,6 +920,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Make main screen gauges horizontal to work around sizing/layout issues. (PR #613)
     * Fix compiler issue with certain versions of MinGW. (PR #622)
     * Suppress use of space bar when in RX Only mode. (PR #623)
+    * Fix Windows-specific issue preventing entry of very high frequencies. (PR #624)
 2. Enhancements:
     * Allow serial PTT to be enabled along with OmniRig. (PR #619)
     * Add 800XA to multi-RX list. (PR #617)

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -98,10 +98,10 @@ ReportingConfiguration::ReportingConfiguration()
                 fraction += wxString('0', 6 - fraction.Length());
             }
 
-            long hz = 0;
-            long mhz = 0;
-            wholeNumber.ToLong(&mhz);
-            fraction.ToLong(&hz);
+            long long hz = 0;
+            long long mhz = 0;
+            wholeNumber.ToLongLong(&mhz);
+            fraction.ToLongLong(&hz);
             uint64_t freq = mhz * 1000000 + hz;
 
             if (reportingFrequencyAsKhz)


### PR DESCRIPTION
Reported via private email. Apparently LLVM MinGW uses a different data type for `long` on Windows, causing very high frequencies to be corrupted when loaded from the saved configuration.