### PR TITLE
Use double precision instead of float for loading frequency list.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.6)
+set(PROJECT_VERSION 1.9.7)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -46,7 +46,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -912,6 +912,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.7 TBD 2024
+
+1. Bugfixes:
+    * Use double precision instead of float for loading frequency list. (PR #627)
+
 ## V1.9.6 December 2023
 
 1. Bugfixes:

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -110,13 +110,13 @@ ReportingConfiguration::ReportingConfiguration()
 
             if (reportingFrequencyAsKhz)
             {
-                float khzFloat = freq / 1000.0;
-                newList.push_back(wxString::Format("%.01f", khzFloat));
+                double khzFloat = freq / 1000.0;
+                newList.push_back(wxString::Format("%.01lf", khzFloat));
             }
             else
             {
-                float mhzFloat = freq / 1000000.0;
-                newList.push_back(wxString::Format("%.04f", mhzFloat));
+                double mhzFloat = freq / 1000000.0;
+                newList.push_back(wxString::Format("%.04lf", mhzFloat));
             }
         }
 


### PR DESCRIPTION
This PR is an additional followup to #624 to use double instead of float for loading the frequency list. By doing this, users can add exact frequencies for e.g. QO-100.