### PR TITLE
Improve validation of frequencies in Options dialog.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -916,6 +916,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Use double precision instead of float for loading frequency list. (PR #627)
+    * Improve validation of frequencies in Options dialog. (PR #628)
 
 ## V1.9.6 December 2023
 

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -20,6 +20,7 @@
 //==========================================================================
 
 #include <wx/gbsizer.h>
+#include <wx/numformatter.h>
 #include "dlg_options.h"
 
 extern FreeDVInterface freedvInterface;
@@ -937,6 +938,9 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         updateToneState();
         updateMultipleRxState();
         updateRigControlState();
+
+        wxCommandEvent tmpEvent;
+        OnReportingFreqTextChange(tmpEvent);
     }
 
     if(inout == EXCHANGE_DATA_OUT)
@@ -1420,7 +1424,9 @@ void OptionsDlg::OnReportingFreqSelectionChange(wxCommandEvent& event)
 
 void OptionsDlg::OnReportingFreqTextChange(wxCommandEvent& event)
 {
-    wxRegEx rgx("[0-9]+(\\.[0-9]+)?");
+    double tmpValue = 0.0;
+    bool validNumber = wxNumberFormatter::FromString(m_txtCtrlNewFrequency->GetValue(), &tmpValue);
+
     auto idx = m_freqList->FindString(m_txtCtrlNewFrequency->GetValue());
     if (idx != wxNOT_FOUND)
     {
@@ -1443,7 +1449,7 @@ void OptionsDlg::OnReportingFreqTextChange(wxCommandEvent& event)
             m_freqListMoveDown->Enable(true);
         }
     }
-    else if (rgx.Matches(m_txtCtrlNewFrequency->GetValue()))
+    else if (validNumber && tmpValue > 0)
     {
         m_freqListAdd->Enable(true);
         m_freqListRemove->Enable(false);


### PR DESCRIPTION
This PR improves validation of frequencies in the Options dialog by doing the following:

1. Add code to refresh the state of the frequency list controls on opening of the Options dialog. (Fixes bug causing none of the frequency change buttons to be disabled.)
2. Add logic to use wxNumberFormatter to parse the frequency when checking what buttons should be disabled/enabled for the frequency list UI. (This allows better handling with certain locales that use commas for decimal separator.)
3. Add logic to not allow 0 MHz as a valid frequency.