### PR TITLE
Fix issues found through code inspection.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -917,6 +917,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Use double precision instead of float for loading frequency list. (PR #627)
     * Improve validation of frequencies in Options dialog. (PR #628)
+    * Fix typo resulting in TX device sample rate being used for filter initialization. (PR #630)
+    * Fix intermittent crash resulting from object thread starting before object is fully initialized. (PR #630)
 
 ## V1.9.6 December 2023
 

--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -80,7 +80,7 @@ void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSam
         cb->sbqSpkOutBass   = designAnEQFilter("bass", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassGaindB, rxSampleRate);
         cb->sbqSpkOutTreble = designAnEQFilter("treble", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleGaindB, rxSampleRate);
         cb->sbqSpkOutMid    = designAnEQFilter("equalizer", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midGainDB, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midQ, rxSampleRate);
-        cb->sbqSpkOutVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, 0, txSampleRate);
+        cb->sbqSpkOutVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, 0, rxSampleRate);
         
         // Note: vol can be a no-op!
         assert(cb->sbqSpkOutBass != nullptr && cb->sbqSpkOutTreble != nullptr && cb->sbqSpkOutMid != nullptr);

--- a/src/util/ThreadedObject.cpp
+++ b/src/util/ThreadedObject.cpp
@@ -23,10 +23,11 @@
 #include "ThreadedObject.h"
 
 ThreadedObject::ThreadedObject()
-    : isDestroying_(false),
-      objectThread_(std::bind(&ThreadedObject::eventLoop_, this))
+    : isDestroying_(false)
 {
-    // empty
+    // Instantiate thread here rather than the initializer since otherwise
+    // we might not be able to guarantee that the mutex is initialized first.
+    objectThread_ = std::thread(std::bind(&ThreadedObject::eventLoop_, this));
 }
 
 ThreadedObject::~ThreadedObject()


### PR DESCRIPTION
This PR fixes the following typos and mistakes found through code inspection:

1. Swapped TX and RX sample rates during filter creation.
2. ThreadedObject's thread needs to be created after mutex is initialized. (Existing code does this most of the time, but there's an extremely intermittent crash on startup possibly due to the thread starting before the object is fully initialized.)