### PR TITLE
Include PDB debugging file for FreeDV.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,14 @@ install(
 )    
 
 if(WIN32)
+    # Install pdb files.
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/src/freedv.pdb 
+        DESTINATION bin
+    )
+endif(WIN32)
+
+if(WIN32)
     #
     # Cpack NSIS configuration for Windows.
     #

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -922,6 +922,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)
+    * Include PDB debugging file for FreeDV. (PR #633)
 
 ## V1.9.6 December 2023
 


### PR DESCRIPTION
As the PR title suggests. This should hopefully allow Windows users to help debug problems (via attaching to the process using Visual Studio).