### PR TITLE
Fix issue preventing Start button from reenabling itself on audio device errors.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -919,6 +919,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Improve validation of frequencies in Options dialog. (PR #628)
     * Fix typo resulting in TX device sample rate being used for filter initialization. (PR #630)
     * Fix intermittent crash resulting from object thread starting before object is fully initialized. (PR #630)
+    * Fix issue preventing Start button from reenabling itself on audio device errors. (PR #636)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/audio/IAudioDevice.h
+++ b/src/audio/IAudioDevice.h
@@ -43,6 +43,8 @@ public:
     virtual void start() = 0;
     virtual void stop() = 0;
 
+    virtual bool isRunning() = 0;
+
     // Sets user friendly description of device. Not used by all engines.
     void setDescription(std::string desc);
     

--- a/src/audio/PortAudioDevice.cpp
+++ b/src/audio/PortAudioDevice.cpp
@@ -57,6 +57,11 @@ PortAudioDevice::~PortAudioDevice()
     }
 }
 
+bool PortAudioDevice::isRunning()
+{
+    return deviceStream_ != nullptr;
+}
+
 void PortAudioDevice::start()
 {
     PaStreamParameters streamParameters;

--- a/src/audio/PortAudioDevice.h
+++ b/src/audio/PortAudioDevice.h
@@ -32,11 +32,13 @@ class PortAudioDevice : public IAudioDevice
 public:
     virtual ~PortAudioDevice();
     
-    virtual int getNumChannels() { return numChannels_; }
-    virtual int getSampleRate() const { return sampleRate_; }
+    virtual int getNumChannels() override { return numChannels_; }
+    virtual int getSampleRate() const override { return sampleRate_; }
     
-    virtual void start();
-    virtual void stop();
+    virtual void start() override;
+    virtual void stop() override;
+
+    virtual bool isRunning() override;
     
 protected:
     // PortAudioDevice cannot be created directly, only via PortAudioEngine.

--- a/src/audio/PulseAudioDevice.cpp
+++ b/src/audio/PulseAudioDevice.cpp
@@ -55,6 +55,11 @@ PulseAudioDevice::~PulseAudioDevice()
     }
 }
 
+bool PulseAudioDevice::isRunning()
+{
+    return stream_ != nullptr;
+}
+
 void PulseAudioDevice::start()
 {
     pa_sample_spec sample_specification;

--- a/src/audio/PulseAudioDevice.h
+++ b/src/audio/PulseAudioDevice.h
@@ -36,11 +36,13 @@ class PulseAudioDevice : public IAudioDevice
 public:
     virtual ~PulseAudioDevice();
     
-    virtual int getNumChannels() { return numChannels_; }
-    virtual int getSampleRate() const { return sampleRate_; }
+    virtual int getNumChannels() override { return numChannels_; }
+    virtual int getSampleRate() const override { return sampleRate_; }
     
-    virtual void start();
-    virtual void stop();
+    virtual void start() override;
+    virtual void stop() override;
+
+    virtual bool isRunning() override;
     
 protected:
     // PulseAudioDevice cannot be created directly, only via PulseAudioEngine.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2655,10 +2655,6 @@ void MainFrame::startRxStream()
         {
             CallAfter([&, error]() {
                 wxMessageBox(wxString::Format("Error encountered while processing audio: %s", error), wxT("Error"), wxOK);
-
-                // Force shutdown of connection
-                wxCommandEvent tmpEvent;
-                OnTogBtnOnOff(tmpEvent);
             });
         };
 
@@ -2888,6 +2884,16 @@ void MainFrame::startRxStream()
         }
 
         if (g_verbose) fprintf(stderr, "starting tx/rx processing thread\n");
+
+        // Work around an issue where the buttons stay disabled even if there
+        // is an error opening one or more audio device(s).
+        bool txDevicesRunning = 
+            (!txInSoundDevice || txInSoundDevice->isRunning()) &&
+            (!txOutSoundDevice || txOutSoundDevice->isRunning());
+        bool rxDevicesRunning = 
+            (rxInSoundDevice && rxInSoundDevice->isRunning()) &&
+            (rxOutSoundDevice && rxOutSoundDevice->isRunning());
+        m_RxRunning = txDevicesRunning && rxDevicesRunning;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2655,11 +2655,11 @@ void MainFrame::startRxStream()
         {
             CallAfter([&, error]() {
                 wxMessageBox(wxString::Format("Error encountered while processing audio: %s", error), wxT("Error"), wxOK);
-            });
 
-            // Force shutdown of connection
-            wxCommandEvent tmpEvent;
-            OnTogBtnOnOff(tmpEvent);
+                // Force shutdown of connection
+                wxCommandEvent tmpEvent;
+                OnTogBtnOnOff(tmpEvent);
+            });
         };
 
         rxInSoundDevice->setOnAudioData([&](IAudioDevice& dev, void* data, size_t size, void* state) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2656,6 +2656,10 @@ void MainFrame::startRxStream()
             CallAfter([&, error]() {
                 wxMessageBox(wxString::Format("Error encountered while processing audio: %s", error), wxT("Error"), wxOK);
             });
+
+            // Force shutdown of connection
+            wxCommandEvent tmpEvent;
+            OnTogBtnOnOff(tmpEvent);
         };
 
         rxInSoundDevice->setOnAudioData([&](IAudioDevice& dev, void* data, size_t size, void* state) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2010,94 +2010,94 @@ void MainFrame::performFreeDVOn_()
             
             startRxStream();
 
-            // attempt to start PTT ......            
-            if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT)
+            if (m_RxRunning)
             {
-                OpenHamlibRig();
-            }
-            else if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTT) 
-            {
-                OpenSerialPort();
-            }
-            else
-            {
-                wxGetApp().rigPttController = nullptr;
-            }
-            
-#if defined(WIN32)
-            if (wxGetApp().appConfiguration.rigControlConfiguration.useOmniRig)
-            {
-                // OmniRig can be anbled along with serial port PTT.
-                // The logic below will ensure we don't overwrite the serial PTT
-                // handler.
-                OpenOmniRig();
-            }
-#endif // defined(WIN32)
-                
-            // Initialize PSK Reporter reporting.
-            if (wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled)
-            {        
-                if (wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString() == "" || wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString() == "")
+                // attempt to start PTT ......            
+                if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT)
                 {
-                    executeOnUiThreadAndWait_([&]() 
-                    {
-                        wxMessageBox("Reporting requires a valid callsign and grid square in Tools->Options. Reporting will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
-                    });
+                    OpenHamlibRig();
+                }
+                else if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTT) 
+                {
+                    OpenSerialPort();
                 }
                 else
                 {
-                    if (wxGetApp().appConfiguration.reportingConfiguration.pskReporterEnabled)
-                    {
-                        auto pskReporter = 
-                            std::make_shared<PskReporter>(
-                                wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
-                                wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
-                                std::string("FreeDV ") + FREEDV_VERSION);
-                        assert(pskReporter != nullptr);
-                        wxGetApp().m_reporters.push_back(pskReporter);
-                    }
+                    wxGetApp().rigPttController = nullptr;
+                }
+                
+    #if defined(WIN32)
+                if (wxGetApp().appConfiguration.rigControlConfiguration.useOmniRig)
+                {
+                    // OmniRig can be anbled along with serial port PTT.
+                    // The logic below will ensure we don't overwrite the serial PTT
+                    // handler.
+                    OpenOmniRig();
+                }
+    #endif // defined(WIN32)
                     
-                    if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
+                // Initialize PSK Reporter reporting.
+                if (wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled)
+                {        
+                    if (wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString() == "" || wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString() == "")
                     {
-                        wxGetApp().m_reporters.push_back(wxGetApp().m_sharedReporterObject);
-                        wxGetApp().m_sharedReporterObject->showOurselves();
-                    }
-
-                    // Enable FreeDV Reporter timer (every 5 minutes).
-                    executeOnUiThreadAndWait_([&]() 
-                    {
-                        m_pskReporterTimer.Start(5 * 60 * 1000);
-                    });
-
-                    // Make sure QSY button becomes enabled after start.
-                    executeOnUiThreadAndWait_([&]() 
-                    {
-                        if (m_reporterDialog != nullptr)
+                        executeOnUiThreadAndWait_([&]() 
                         {
-                            m_reporterDialog->refreshQSYButtonState();
-                        }
-                    });
-                    
-                    // Immediately transmit selected TX mode and frequency to avoid UI glitches.
-                    for (auto& obj : wxGetApp().m_reporters)
+                            wxMessageBox("Reporting requires a valid callsign and grid square in Tools->Options. Reporting will be disabled.", wxT("Error"), wxOK | wxICON_ERROR, this);
+                        });
+                    }
+                    else
                     {
-                        obj->transmit(freedvInterface.getCurrentTxModeStr(), g_tx);
-                        obj->freqChange(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
+                        if (wxGetApp().appConfiguration.reportingConfiguration.pskReporterEnabled)
+                        {
+                            auto pskReporter = 
+                                std::make_shared<PskReporter>(
+                                    wxGetApp().appConfiguration.reportingConfiguration.reportingCallsign->ToStdString(), 
+                                    wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare->ToStdString(),
+                                    std::string("FreeDV ") + FREEDV_VERSION);
+                            assert(pskReporter != nullptr);
+                            wxGetApp().m_reporters.push_back(pskReporter);
+                        }
+                        
+                        if (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled)
+                        {
+                            wxGetApp().m_reporters.push_back(wxGetApp().m_sharedReporterObject);
+                            wxGetApp().m_sharedReporterObject->showOurselves();
+                        }
+
+                        // Enable FreeDV Reporter timer (every 5 minutes).
+                        executeOnUiThreadAndWait_([&]() 
+                        {
+                            m_pskReporterTimer.Start(5 * 60 * 1000);
+                        });
+
+                        // Make sure QSY button becomes enabled after start.
+                        executeOnUiThreadAndWait_([&]() 
+                        {
+                            if (m_reporterDialog != nullptr)
+                            {
+                                m_reporterDialog->refreshQSYButtonState();
+                            }
+                        });
+                        
+                        // Immediately transmit selected TX mode and frequency to avoid UI glitches.
+                        for (auto& obj : wxGetApp().m_reporters)
+                        {
+                            obj->transmit(freedvInterface.getCurrentTxModeStr(), g_tx);
+                            obj->freqChange(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
+                        }
                     }
                 }
-            }
-            else
-            {
-                wxGetApp().m_reporters.clear();
-            }
+                else
+                {
+                    wxGetApp().m_reporters.clear();
+                }
 
-            if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTTInput)
-            {
-                OpenPTTInPort();
-            }
+                if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTTInput)
+                {
+                    OpenPTTInPort();
+                }
 
-            if (m_RxRunning)
-            {
                 executeOnUiThreadAndWait_([&]() 
                 {
         #ifdef _USE_TIMER
@@ -2857,7 +2857,28 @@ void MainFrame::startRxStream()
             }
             
             txInSoundDevice->start();
+            if (!txInSoundDevice->isRunning())
+            {
+                rxInSoundDevice.reset();
+                rxOutSoundDevice.reset();
+                txInSoundDevice.reset();
+                txOutSoundDevice.reset();
+                m_RxRunning = false;
+                return;
+            }
+
             txOutSoundDevice->start();
+            if (!txOutSoundDevice->isRunning())
+            {
+                txInSoundDevice->stop();
+
+                rxInSoundDevice.reset();
+                rxOutSoundDevice.reset();
+                txInSoundDevice.reset();
+                txOutSoundDevice.reset();
+                m_RxRunning = false;
+                return;
+            }
             
             if ( m_txThread->Run() != wxTHREAD_NO_ERROR )
             {
@@ -2876,7 +2897,33 @@ void MainFrame::startRxStream()
         }
 
         rxInSoundDevice->start();
+        if (!rxInSoundDevice->isRunning())
+        {
+            if (txInSoundDevice) txInSoundDevice->stop();
+            if (txOutSoundDevice) txOutSoundDevice->stop();
+            
+            rxInSoundDevice.reset();
+            rxOutSoundDevice.reset();
+            txInSoundDevice.reset();
+            txOutSoundDevice.reset();
+            m_RxRunning = false;
+            return;
+        }
+
         rxOutSoundDevice->start();
+        if (!rxOutSoundDevice->isRunning())
+        {
+            if (txInSoundDevice) txInSoundDevice->stop();
+            if (txOutSoundDevice) txOutSoundDevice->stop();
+            rxInSoundDevice->stop();
+
+            rxInSoundDevice.reset();
+            rxOutSoundDevice.reset();
+            txInSoundDevice.reset();
+            txOutSoundDevice.reset();
+            m_RxRunning = false;
+            return;
+        }
 
         if ( m_rxThread->Run() != wxTHREAD_NO_ERROR )
         {
@@ -2884,16 +2931,6 @@ void MainFrame::startRxStream()
         }
 
         if (g_verbose) fprintf(stderr, "starting tx/rx processing thread\n");
-
-        // Work around an issue where the buttons stay disabled even if there
-        // is an error opening one or more audio device(s).
-        bool txDevicesRunning = 
-            (!txInSoundDevice || txInSoundDevice->isRunning()) &&
-            (!txOutSoundDevice || txOutSoundDevice->isRunning());
-        bool rxDevicesRunning = 
-            (rxInSoundDevice && rxInSoundDevice->isRunning()) &&
-            (rxOutSoundDevice && rxOutSoundDevice->isRunning());
-        m_RxRunning = txDevicesRunning && rxDevicesRunning;
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue discovered during unrelated testing for another issue where FreeDV will not reenable the Start button if there's an audio error. The failure to reenable the Start button means that users have to close and restart the application in order to try to use a different audio device.