### PR TITLE
Fix flicker in FreeDV Reporter window when tracking by frequency.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -921,6 +921,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix intermittent crash resulting from object thread starting before object is fully initialized. (PR #630)
     * Prevent creation of filters if not enabled. (PR #631)
     * Fix issue preventing Start button from reenabling itself on audio device errors. (PR #636)
+    * Fix flicker in FreeDV Reporter window when tracking by frequency. (PR #637)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -46,6 +46,7 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     , sortAscending_(false)
     , isConnected_(false)
     , filterSelfMessageUpdates_(false)
+    , filteredFrequency_(0)
 {
     for (int col = 0; col < NUM_COLS; col++)
     {
@@ -667,17 +668,22 @@ void FreeDVReporterDialog::refreshQSYButtonState()
 
 void FreeDVReporterDialog::setBandFilter(FilterFrequency freq)
 {
-    currentBandFilter_ = freq;
-    
-    // Update displayed list based on new filter criteria.
-    clearAllEntries_(false);
-
-    std::map<int, int> colResizeList;
-    for (auto& kvp : allReporterData_)
+    if (filteredFrequency_ != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency ||
+        currentBandFilter_ != freq)
     {
-        addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
+        filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
+        currentBandFilter_ = freq;
+    
+        // Update displayed list based on new filter criteria.
+        clearAllEntries_(false);
+
+        std::map<int, int> colResizeList;
+        for (auto& kvp : allReporterData_)
+        {
+            addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
+        }
+        resizeChangedColumns_(colResizeList);
     }
-    resizeChangedColumns_(colResizeList);
 }
 
 void FreeDVReporterDialog::sortColumn_(int col)
@@ -1530,6 +1536,6 @@ bool FreeDVReporterDialog::isFiltered_(uint64_t freq)
             (bandForFreq != currentBandFilter_) ||
             (wxGetApp().appConfiguration.reportingConfiguration.freedvReporterBandFilterTracksFrequency &&
                 wxGetApp().appConfiguration.reportingConfiguration.freedvReporterBandFilterTracksExactFreq &&
-                freq != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
+                freq != filteredFrequency_);
     }
 }

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -527,15 +527,15 @@ void FreeDVReporterDialog::OnTimer(wxTimerEvent& event)
             backgroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterMsgRowBackgroundColor);
             foregroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterMsgRowForegroundColor);
         }
-        else if (isReceiving)
-        {
-            backgroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowBackgroundColor);
-            foregroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowForegroundColor);
-        }
         else if (isTransmitting)
         {
             backgroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowBackgroundColor);
             foregroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterTxRowForegroundColor);
+        }
+        else if (isReceiving)
+        {
+            backgroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowBackgroundColor);
+            foregroundColor = wxColour(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterRxRowForegroundColor);
         }
         else
         {

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -157,6 +157,7 @@ class FreeDVReporterDialog : public wxDialog
          bool sortAscending_;
          bool isConnected_;
          bool filterSelfMessageUpdates_;
+         uint64_t filteredFrequency_;
          
          void clearAllEntries_(bool clearForAllBands);
          void onReporterConnect_();


### PR DESCRIPTION
Resolves #635 by preventing clearing of the reporter list if the current frequency hasn't changed.