### PR TITLE
Rename KHz -> kHz.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -902,6 +902,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix flicker in FreeDV Reporter window when tracking by frequency. (PR #637)
     * Update Filter dialog to better handle resizing. (PR #641)
     * Fix capitalization of distance units in FreeDV Reporter window. (PR #642)
+    * Rename KHz to kHz in documentation and UI. (PR #643)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -260,14 +260,14 @@ As an aid to the above, FreeDV will show the current mode on the bottom of the w
 
 ## Transceiver Filters
 
-For most FreeDV use, your radio's receive and transmit filters should be set to the widest possible (typically around 3 KHz). 
+For most FreeDV use, your radio's receive and transmit filters should be set to the widest possible (typically around 3 kHz). 
 This allows easy switching between analog mode as well as the various FreeDV modes. There has not been any testing done to
 definitively confirm whether narrower bandwidths help with reception of FreeDV. Additionally, FreeDV already performs its own 
 transmit filtering, so using additional narrow filtering on the radio will likely have little benefit (again, untested).
 
 For reference, the channel widths of the currently supported modes are below:
 
-| Mode | Width (KHz) |
+| Mode | Width (kHz) |
 | --- | --- |
 | 1600 | 1.125 |
 | 700C | 1.500 |
@@ -368,8 +368,8 @@ along with the reporting feature as a whole:
 * [FreeDV Reporter](https://qso.freedv.org/) -- also accessible via the Tools->FreeDV Reporter menu option.
 
 The frequency that FreeDV reports is set by changing the "Report Frequency" drop down box in the main window. This 
-is either in kilohertz (KHz) or megahertz (MHz) (configurable by going to Tools->Options->Rig Control and checking
-or unchecking "Frequency entry in KHz") and will turn red if the entered value is invalid. If Hamlib support is 
+is either in kilohertz (kHz) or megahertz (MHz) (configurable by going to Tools->Options->Rig Control and checking
+or unchecking "Frequency entry in kHz") and will turn red if the entered value is invalid. If Hamlib support is 
 also enabled, this frequency will automatically remain in sync with the current VFO on the radio (i.e. if the 
 frequency is changed in the application, the radio will also change its frequency). Double-clicking on users in 
 the Tools->FreeDV Reporter window will also cause this frequency to change to match the other user.
@@ -924,8 +924,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Allow serial PTT to be enabled along with OmniRig. (PR #619)
     * Add 800XA to multi-RX list. (PR #617)
     * Add logic to report status message to FreeDV Reporter. (PR #620)
-    * Allow display and entry of frequencies in KHz. (PR #621)
-    * Add 5368.5 KHz to the default frequency list. (PR #626)
+    * Allow display and entry of frequencies in kHz. (PR #621)
+    * Add 5368.5 kHz to the default frequency list. (PR #626)
 
 ## V1.9.5 November 2023
 

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -134,7 +134,7 @@ ReportingConfiguration::ReportingConfiguration()
             
             if (reportingFrequencyAsKhz)
             {
-                // Frequencies are in KHz, so divide one more time to get MHz.
+                // Frequencies are in kHz, so divide one more time to get MHz.
                 mhz /= 1000.0;
             }
 
@@ -182,7 +182,7 @@ void ReportingConfiguration::load(wxConfigBase* config)
     load_(config, useUTCForReporting);
     
     // Note: this needs to be loaded before the frequency list so that
-    // we get the values formatted as KHz (if so configured).
+    // we get the values formatted as kHz (if so configured).
     load_(config, reportingFrequencyAsKhz);
     
     load_(config, reportingFrequencyList);

--- a/src/dlg_options.cpp
+++ b/src/dlg_options.cpp
@@ -198,7 +198,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     m_ckboxUseAnalogModes = new wxCheckBox(m_rigControlTab, wxID_ANY, _("Use USB/LSB instead of DIGU/DIGL"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizer_hamlib->Add(m_ckboxUseAnalogModes, 0, wxALL | wxALIGN_LEFT, 5);
     
-    m_ckboxFrequencyEntryAsKHz = new wxCheckBox(m_rigControlTab, wxID_ANY, _("Frequency entry in KHz"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    m_ckboxFrequencyEntryAsKHz = new wxCheckBox(m_rigControlTab, wxID_ANY, _("Frequency entry in kHz"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizer_hamlib->Add(m_ckboxFrequencyEntryAsKHz, 0, wxALL | wxALIGN_LEFT, 5);
 
     sizerRigControl->Add(sbSizer_hamlib,0, wxALL | wxEXPAND, 5);
@@ -225,7 +225,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
     {
-        m_labelEnterFreq = new wxStaticText(m_rigControlTab, wxID_ANY, wxT("Enter frequency (KHz):"), wxDefaultPosition, wxDefaultSize, 0);
+        m_labelEnterFreq = new wxStaticText(m_rigControlTab, wxID_ANY, wxT("Enter frequency (kHz):"), wxDefaultPosition, wxDefaultSize, 0);
     }
     else
     {
@@ -924,7 +924,7 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         
         if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
         {
-            m_labelEnterFreq->SetLabel(wxT("Enter frequency (KHz):"));
+            m_labelEnterFreq->SetLabel(wxT("Enter frequency (kHz):"));
         }
         else
         {

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -78,7 +78,7 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_CENTER, 80);
     m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_CENTER, 80);
     m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("KHz") : wxT("MHz"), wxLIST_FORMAT_CENTER, 80);
+    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_CENTER, 80);
     m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_CENTER, 80);
     m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_CENTER, 20);
     m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_CENTER, 80);
@@ -314,7 +314,7 @@ void FreeDVReporterDialog::refreshLayout()
     m_listSpots->GetColumn(4 + colOffset, item);
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
     {
-        item.SetText("KHz");
+        item.SetText("kHz");
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,7 @@ void MainFrame::test2020Mode_()
     }
     else
     {
-        // Sanity check: encode 1 second of 16 KHz white noise and then try to
+        // Sanity check: encode 1 second of 16 kHz white noise and then try to
         // decode it. If it takes longer than 0.5 seconds, it's unlikely that 
         // 2020/2020B will work properly on this machine.
         printf("Generating test audio...\n");
@@ -423,7 +423,7 @@ void MainFrame::loadConfiguration_()
     // Adjust frequency entry labels
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
     {
-        m_freqBox->SetLabel(_("Report Freq. (KHz)"));
+        m_freqBox->SetLabel(_("Report Freq. (kHz)"));
     }
     else
     {
@@ -3155,7 +3155,7 @@ void MainFrame::initializeFreeDVReporter_()
     // Set up QSY request handler
     wxGetApp().m_sharedReporterObject->setOnQSYRequestFn([&](std::string callsign, uint64_t freqHz, std::string message) {
         double freqFactor = 1000.0;
-        std::string fmtMsg = "%s has requested that you QSY to %.01f KHz.";
+        std::string fmtMsg = "%s has requested that you QSY to %.01f kHz.";
         
         if (!wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
         {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -214,7 +214,7 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
         // Adjust frequency labels on main window
         if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
         {
-            m_freqBox->SetLabel(_("Report Freq. (KHz)"));
+            m_freqBox->SetLabel(_("Report Freq. (kHz)"));
         }
         else
         {
@@ -1246,7 +1246,7 @@ void MainFrame::updateReportingFreqList_()
     // Update associated label if the units have changed
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
     {
-        m_freqBox->SetLabel(_("Report Freq. (KHz)"));
+        m_freqBox->SetLabel(_("Report Freq. (kHz)"));
     }
     else
     {

--- a/src/pipeline/ComputeRfSpectrumStep.h
+++ b/src/pipeline/ComputeRfSpectrumStep.h
@@ -32,7 +32,7 @@
 class ComputeRfSpectrumStep : public IPipelineStep
 {
 public:
-    // Note: only supports 8KHz, so needs to be inserted into an AudioPipeline
+    // Note: only supports 8 kHz, so needs to be inserted into an AudioPipeline
     // in order to downconvert properly.
     ComputeRfSpectrumStep(
         std::function<struct MODEM_STATS*()> modemStatsFn,


### PR DESCRIPTION
Turns out that kilo does *not* use capital 'K'. This PR renames references in the UI and documentation accordingly.