### PR TITLE
Left justify data and labels, remove '--' and align data start with label start for easier readability and cleaner looks

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -906,6 +906,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)
+    * Adjust FreeDV Reporter data display to better match accepted UX standards. (PR #644)
 3. Build system:
     * Include PDB debugging file for FreeDV. (PR #633)
 4. Documentation:

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -27,7 +27,7 @@
 
 extern FreeDVInterface freedvInterface;
 
-#define UNKNOWN_STR "--"
+#define UNKNOWN_STR ""
 #if defined(WIN32)
 #define NUM_COLS (14) /* Note: need empty column 0 to work around callsign truncation issue. */
 #else

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -301,11 +301,11 @@ void FreeDVReporterDialog::refreshLayout()
 
     if (wxGetApp().appConfiguration.reportingConfiguration.useMetricDistances)
     {
-        item.SetText("km");
+        item.SetText("km ");
     }
     else
     {
-        item.SetText("mi");
+        item.SetText("Miles");
     }
 
     m_listSpots->SetColumn(2 + colOffset, item);
@@ -1453,7 +1453,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, " "+data->userMessage, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, " "+data->lastTx, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, data->lastTx, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->txMode, colResizeList);
@@ -1468,7 +1468,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, data->snr, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, " "+data->lastUpdate, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, data->lastUpdate, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
     
     // Messaging updates take highest priority.

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -81,12 +81,12 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_LEFT, 20);
-    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_CENTER, 80);
+    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_LEFT, 120);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 120);
     m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_RIGHT, 40);
-    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_CENTER, 120);
+    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_LEFT, 120);
 
     // On Windows, the last column will end up taking a lot more space than desired regardless
     // of the space we actually need. Create a "dummy" column to take that space instead.
@@ -1453,7 +1453,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, " "+data->userMessage, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastTx, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastTx, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->txMode, colResizeList);
@@ -1468,7 +1468,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, data->snr, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastUpdate, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastUpdate, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
     
     // Messaging updates take highest priority.

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -76,16 +76,16 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
 
     m_listSpots->InsertColumn(col++, wxT("Callsign"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_LEFT, 20);
     m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_LEFT, 120);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 120);
-    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_LEFT, 40);
+    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_RIGHT, 40);
     m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_LEFT, 120);
 
     // On Windows, the last column will end up taking a lot more space than desired regardless

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -71,26 +71,26 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     // Create "hidden" column at the beginning. The column logic in wxWidgets
     // seems to want to add an image to column 0, which affects
     // autosizing.
-    m_listSpots->InsertColumn(col++, wxT(""), wxLIST_FORMAT_CENTER, 1);
+    m_listSpots->InsertColumn(col++, wxT(""), wxLIST_FORMAT_LEFT, 1);
 #endif // defined(WIN32)
 
-    m_listSpots->InsertColumn(col++, wxT("Callsign"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("KHz") : wxT("MHz"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_CENTER, 20);
-    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_CENTER, 80);
-    m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_CENTER, 120);
-    m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_CENTER, 120);
-    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_CENTER, 40);
-    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_CENTER, 120);
+    m_listSpots->InsertColumn(col++, wxT("Callsign"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("KHz") : wxT("MHz"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_LEFT, 20);
+    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_LEFT, 120);
+    m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 120);
+    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_LEFT, 40);
+    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_LEFT, 120);
 
     // On Windows, the last column will end up taking a lot more space than desired regardless
     // of the space we actually need. Create a "dummy" column to take that space instead.
-    m_listSpots->InsertColumn(col++, wxT(""), wxLIST_FORMAT_CENTER, 1);
+    m_listSpots->InsertColumn(col++, wxT(""), wxLIST_FORMAT_LEFT, 1);
 
     sectionSizer->Add(m_listSpots, 0, wxALL | wxEXPAND, 2);
 
@@ -1438,43 +1438,43 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     col = 1;
 #endif // defined(WIN32)
 
-    bool changed = setColumnForRow_(itemIndex, col++, data->callsign, colResizeList);
+    bool changed = setColumnForRow_(itemIndex, col++, " "+data->callsign, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->gridSquare, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->gridSquare, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->distance, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->distance, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->version, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->version, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->freqString, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->freqString, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->status, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->status, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->userMessage, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->userMessage, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastTx, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastTx, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->txMode, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->txMode, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastRxCallsign, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastRxCallsign, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastRxMode, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastRxMode, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->snr, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->snr, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, data->lastUpdate, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, " "+data->lastUpdate, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
     
     // Messaging updates take highest priority.

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -76,17 +76,17 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
 
     m_listSpots->InsertColumn(col++, wxT("Callsign"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxT("km   "), wxLIST_FORMAT_RIGHT, 80);
+    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz   ") : wxT("MHz   "), wxLIST_FORMAT_RIGHT, 80);
+    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_LEFT, 20);
-    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_LEFT, 80);
+    m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_CENTER, 80);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_LEFT, 120);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 120);
-    m_listSpots->InsertColumn(col++, wxT("SNR   "), wxLIST_FORMAT_RIGHT, 40);
-    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_LEFT, 120);
+    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_RIGHT, 40);
+    m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_CENTER, 120);
 
     // On Windows, the last column will end up taking a lot more space than desired regardless
     // of the space we actually need. Create a "dummy" column to take that space instead.
@@ -1061,14 +1061,8 @@ void FreeDVReporterDialog::onUserConnectFn_(std::string sid, std::string lastUpd
                 temp->distanceVal *= 0.621371;
             }
 
-            if (0 < temp->distanceVal < 10.0)
-            {
-                temp->distance = wxString::Format("%.01f", temp->distanceVal);
-            }
-            else
-            {
-                temp->distance = wxString::Format("%.0f", temp->distanceVal);
-            }
+        temp->distance = wxString::Format("%.0f", temp->distanceVal);
+
         }
 
         temp->version = version;

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -76,16 +76,16 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
 
     m_listSpots->InsertColumn(col++, wxT("Callsign"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Locator"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxT("km"), wxLIST_FORMAT_RIGHT, 80);
+    m_listSpots->InsertColumn(col++, wxT("km   "), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Version"), wxLIST_FORMAT_LEFT, 80);
-    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz") : wxT("MHz"), wxLIST_FORMAT_RIGHT, 80);
+    m_listSpots->InsertColumn(col++, wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz ? wxT("kHz   ") : wxT("MHz   "), wxLIST_FORMAT_RIGHT, 80);
     m_listSpots->InsertColumn(col++, wxT("Status"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Msg"), wxLIST_FORMAT_LEFT, 20);
     m_listSpots->InsertColumn(col++, wxT("Last TX"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 80);
     m_listSpots->InsertColumn(col++, wxT("RX Call"), wxLIST_FORMAT_LEFT, 120);
     m_listSpots->InsertColumn(col++, wxT("Mode"), wxLIST_FORMAT_LEFT, 120);
-    m_listSpots->InsertColumn(col++, wxT("SNR"), wxLIST_FORMAT_RIGHT, 40);
+    m_listSpots->InsertColumn(col++, wxT("SNR   "), wxLIST_FORMAT_RIGHT, 40);
     m_listSpots->InsertColumn(col++, wxT("Last Update"), wxLIST_FORMAT_LEFT, 120);
 
     // On Windows, the last column will end up taking a lot more space than desired regardless
@@ -1061,7 +1061,7 @@ void FreeDVReporterDialog::onUserConnectFn_(std::string sid, std::string lastUpd
                 temp->distanceVal *= 0.621371;
             }
 
-            if (temp->distanceVal < 10.0)
+            if (0 < temp->distanceVal < 10.0)
             {
                 temp->distance = wxString::Format("%.01f", temp->distanceVal);
             }
@@ -1444,13 +1444,13 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, " "+data->gridSquare, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, " "+data->distance, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, data->distance, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->version, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, " "+data->freqString, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, data->freqString, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->status, colResizeList);
@@ -1471,7 +1471,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     changed = setColumnForRow_(itemIndex, col++, " "+data->lastRxMode, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
-    changed = setColumnForRow_(itemIndex, col++, " "+data->snr, colResizeList);
+    changed = setColumnForRow_(itemIndex, col++, data->snr, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->lastUpdate, colResizeList);


### PR DESCRIPTION
This PR attempts to improve the readability and looks of the internal reporter by left aligning all the data in each column rather than centring it within the current column widths which looks ragged. 

It makes sure that the start of each data item is below the start of the column label.

It removes the '--' items which indicate that there is no data. However we can see that there is no data if there is nothing there.
I can maybe understand using this in a purely testing environment but not for production as it is serving no purpose.

I will add a screen shot later.