### PR TITLE
More column sizing adjustments

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -903,10 +903,12 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update Filter dialog to better handle resizing. (PR #641)
     * Fix capitalization of distance units in FreeDV Reporter window. (PR #642)
     * Rename KHz to kHz in documentation and UI. (PR #643)
+    * Avoid calculating distances in FreeDV Reporter window for those with invalid grid squares. (PR #646)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)
     * Adjust FreeDV Reporter data display to better match accepted UX standards. (PR #644)
+    * Further reduce required space for each column in FreeDV Reporter window. (PR #646)
 3. Build system:
     * Include PDB debugging file for FreeDV. (PR #633)
 4. Documentation:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -904,6 +904,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix capitalization of distance units in FreeDV Reporter window. (PR #642)
     * Rename KHz to kHz in documentation and UI. (PR #643)
     * Avoid calculating distances in FreeDV Reporter window for those with invalid grid squares. (PR #646)
+    * Fix display bugs in FreeDV Reporter window when switching between dark and light mode. (PR #646)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -54,7 +54,7 @@ static int DefaultColumnWidths_[] = {
     65,
     60,
     75,
-    80,
+    60,
     65,
     60,
     60,

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -243,6 +243,7 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     this->Connect(wxEVT_SIZE, wxSizeEventHandler(FreeDVReporterDialog::OnSize));
     this->Connect(wxEVT_MOVE, wxMoveEventHandler(FreeDVReporterDialog::OnMove));
     this->Connect(wxEVT_SHOW, wxShowEventHandler(FreeDVReporterDialog::OnShow));
+    this->Connect(wxEVT_SYS_COLOUR_CHANGED, wxSysColourChangedEventHandler(FreeDVReporterDialog::OnSystemColorChanged));
     
     m_listSpots->Connect(wxEVT_LIST_ITEM_SELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemSelected), NULL, this);
     m_listSpots->Connect(wxEVT_LIST_ITEM_DESELECTED, wxListEventHandler(FreeDVReporterDialog::OnItemDeselected), NULL, this);
@@ -428,6 +429,20 @@ void FreeDVReporterDialog::setReporter(std::shared_ptr<FreeDVReporter> reporter)
         // Spot list no longer valid, delete the items currently on there
         clearAllEntries_(true);
     }
+}
+
+void FreeDVReporterDialog::OnSystemColorChanged(wxSysColourChangedEvent& event)
+{
+    // Works around issues on wxWidgets with certain controls not changing backgrounds
+    // when the user switches between light and dark mode.
+    wxColour currentControlBackground = wxTransparentColour;
+
+    m_listSpots->SetBackgroundColour(currentControlBackground);
+#if !defined(WIN32)
+    ((wxWindow*)m_listSpots->m_headerWin)->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+#endif //!defined(WIN32)
+
+    event.Skip();
 }
 
 void FreeDVReporterDialog::OnInitDialog(wxInitDialogEvent& event)

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -47,7 +47,7 @@ static int DefaultColumnWidths_[] = {
     1,
 #endif // defined(WIN32)
     70,
-    70,
+    65,
     60,
     70,
     60,
@@ -1567,18 +1567,14 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
 
 int FreeDVReporterDialog::getSizeForTableCellString_(wxString str)
 {
-    auto itemFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT); //attr.font;
     int textWidth = 0;
     int textHeight = 0; // note: unused
 
-    m_listSpots->GetTextExtent(str, &textWidth, &textHeight, nullptr, nullptr, &itemFont);
+    m_listSpots->GetTextExtent(str, &textWidth, &textHeight);
 
     // Add buffer for sort indicator and to ensure wxWidgets doesn't truncate anything almost exactly
     // fitting the new column size.
     textWidth += m_sortIcons->GetIcon(upIconIndex_).GetSize().GetWidth();
-
-    // Add additional buffer to provide space between columns.
-    textWidth += 15;
 
     return textWidth;
 }

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -188,6 +188,9 @@ class FreeDVReporterDialog : public wxDialog
          
          void execQueuedAction_();
 
+         void resizeAllColumns_();
+         int getSizeForTableCellString_(wxString string);
+
          static wxCALLBACK int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
          static double DegreesToRadians_(double degrees);
 };

--- a/src/freedv_reporter.h
+++ b/src/freedv_reporter.h
@@ -83,7 +83,8 @@ class FreeDVReporterDialog : public wxDialog
         void    OnStatusTextSet(wxCommandEvent& event);
         void    OnStatusTextClear(wxCommandEvent& event);
         void    OnStatusTextChange(wxCommandEvent& event);
-        
+        void    OnSystemColorChanged(wxSysColourChangedEvent& event);
+
         void OnItemSelected(wxListEvent& event);
         void OnItemDeselected(wxListEvent& event);
         void OnSortColumn(wxListEvent& event);


### PR DESCRIPTION
This PR performs the following to address feedback posted at https://github.com/drowe67/freedv-gui/pull/644#issuecomment-1879870187:

1. Limits displayed grid squares to six characters in length and actually ignores invalid input (vs. trying to calculate a distance that's probably wrong).
2. Instead of using wxWidgets' column autosizing, implement our own, ensuring that column sizes don't drop below hardcoded minimums. 