### PR TITLE
Fix issue preventing usage of the 5th and 6th letter of the grid square.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -903,7 +903,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update Filter dialog to better handle resizing. (PR #641)
     * Fix capitalization of distance units in FreeDV Reporter window. (PR #642)
     * Rename KHz to kHz in documentation and UI. (PR #643)
-    * Avoid calculating distances in FreeDV Reporter window for those with invalid grid squares. (PR #646)
+    * Avoid calculating distances in FreeDV Reporter window for those with invalid grid squares. (PR #646, #649)
     * Fix display bugs in FreeDV Reporter window when switching between dark and light mode. (PR #646)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)

--- a/src/freedv_reporter.cpp
+++ b/src/freedv_reporter.cpp
@@ -901,7 +901,7 @@ void FreeDVReporterDialog::calculateLatLonFromGridSquare_(wxString gridSquare, d
     // If grid square is 6 or more letters, THEN use the next two.
     // Otherwise, optional.
     wxString optionalSegment = gridSquare.Mid(4, 2);
-    wxRegEx allLetters(_("^[a-z]{2}$"));
+    wxRegEx allLetters(_("^[A-Z]{2}$"));
     if (gridSquare.Length() >= 6 && allLetters.Matches(optionalSegment))
     {
         lon += ((char)gridSquare.GetChar(4) - charA) * 5.0 / 60;


### PR DESCRIPTION
Followup to PR #646 that fixes a bug introduced in the grid square math calculation. After this fix, distances appear to calculate correctly using the [ARRL grid square distance calculator](https://contest-clubs.arrl.org/griddistancecalc.php):

![Screenshot 2024-01-12 at 12 46 59 AM](https://github.com/drowe67/freedv-gui/assets/449242/94acb8c4-f693-4566-a8b3-c7dd23aa7805)