### PR TITLE
Fix issue preventing FreeDV startup on macOS <= 10.13.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -905,6 +905,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Rename KHz to kHz in documentation and UI. (PR #643)
     * Avoid calculating distances in FreeDV Reporter window for those with invalid grid squares. (PR #646, #649)
     * Fix display bugs in FreeDV Reporter window when switching between dark and light mode. (PR #646)
+    * Fix issue preventing FreeDV startup on macOS <= 10.13. (PR #652)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -61,6 +61,10 @@ void VerifyMicrophonePermissions(std::promise<bool>& microphonePromise)
             }
         }
     }
+    else
+    {
+        microphonePromise.set_value(true);
+    }
 #else
     microphonePromise.set_value(true);
 #endif // !APPLE_OLD_XCODE


### PR DESCRIPTION
Reported on Discord. This PR adds some missed code that's required to get past the microphone permissions check for macOS versions <= 10.13.