### PR TITLE
Only adjust height by 1px on startup, not width.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -907,6 +907,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix display bugs in FreeDV Reporter window when switching between dark and light mode. (PR #646)
     * Add guard code to prevent FreeDV Reporter window from being off screen on startup. (PR #650)
     * Fix issue preventing FreeDV startup on macOS <= 10.13. (PR #652)
+    * On startup, only jiggle height and not width. (PR #653)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,7 +406,7 @@ void MainFrame::loadConfiguration_()
     });
     CallAfter([=]()
     {
-        SetSize(w + 1, h + 1);
+        SetSize(w, h - 1);
     });
     CallAfter([=]()
     {


### PR DESCRIPTION
Per a PR comment at https://github.com/drowe67/freedv-gui/pull/650, it's not actually necessary to shift width, just height; in fact, making height larger causes problems on at least one environment. This PR makes that adjustment and avoids said issue.