### PR TITLE
Fix issue preventing TX audio from resuming after going from TX->RX in full duplex mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "devel")
+set(FREEDV_VERSION_TAG "")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -889,7 +889,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
-## V1.9.7 TBD 2024
+## V1.9.7 January 2024
 
 1. Bugfixes:
     * Use double precision instead of float for loading frequency list. (PR #627)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -909,6 +909,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue preventing FreeDV startup on macOS <= 10.13. (PR #652)
     * On startup, only jiggle height and not width. (PR #653)
     * Fix issue preventing FreeDV from being linked with older versions of Xcode. (PR #654)
+    * Fix issue preventing TX audio from resuming after going from TX->RX in full duplex mode. (PR #655)
 2. Enhancements:
     * Allow user to refresh status message even if it hasn't been changed. (PR #632)
     * Increase priority of status message highlight. (PR #632)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -876,6 +876,7 @@ void MainFrame::togglePTT(void) {
             }
         }
         g_tx = false;
+        endingTx = false;
 
         // tx-> rx transition, swap to the page we were on for last rx
         m_auiNbookCtrl->ChangeSelection(wxGetApp().appConfiguration.currentNotebookTab);


### PR DESCRIPTION
Reported on the digitalvoice mailing list. This bug is a side effect of recent changes to allow adding a TX delay, so this PR will ensure that TX audio continues to be output in full duplex mode even after returning to RX.