### PR TITLE
Fix issue causing intermittent crashes when filters are enabled while running.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "devel")
+set(FREEDV_VERSION_TAG "")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.7)
+set(PROJECT_VERSION 1.9.7.1)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -48,7 +48,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -889,6 +889,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.7.1 January 2024
+
+1. Bugfixes:
+    * Fix issue causing intermittent crashes when filters are enabled while running. (PR #656)
+
 ## V1.9.7 January 2024
 
 1. Bugfixes:

--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -100,25 +100,24 @@ void  MainFrame::deleteEQFilters(paCallBackData *cb)
         {
             sox_biquad_destroy(cb->sbqMicInBass);
         }
+        cb->sbqMicInBass = nullptr;
         
         if (cb->sbqMicInTreble != nullptr)
         {
             sox_biquad_destroy(cb->sbqMicInTreble);
         }
+        cb->sbqMicInTreble = nullptr;
         
         if (cb->sbqMicInMid != nullptr)
         {
             sox_biquad_destroy(cb->sbqMicInMid);
         }
+        cb->sbqMicInMid = nullptr;
         
         if (cb->sbqMicInVol != nullptr)
         {
             sox_biquad_destroy(cb->sbqMicInVol);
         }
-        
-        cb->sbqMicInBass = nullptr;
-        cb->sbqMicInTreble = nullptr;
-        cb->sbqMicInMid = nullptr;
         cb->sbqMicInVol = nullptr;
     }
     
@@ -128,25 +127,24 @@ void  MainFrame::deleteEQFilters(paCallBackData *cb)
         {
             sox_biquad_destroy(cb->sbqSpkOutBass);    
         }
+        cb->sbqSpkOutBass = nullptr;
 
         if (cb->sbqSpkOutTreble != nullptr)
         {
             sox_biquad_destroy(cb->sbqSpkOutTreble);
         }
+        cb->sbqSpkOutTreble = nullptr;
 
         if (cb->sbqSpkOutMid != nullptr)
         {
             sox_biquad_destroy(cb->sbqSpkOutMid);
         }
+        cb->sbqSpkOutMid = nullptr;
         
         if (cb->sbqSpkOutVol != nullptr)
         {
             sox_biquad_destroy(cb->sbqSpkOutVol);
         }
-
-        cb->sbqSpkOutBass = nullptr;
-        cb->sbqSpkOutTreble = nullptr;
-        cb->sbqSpkOutMid = nullptr;
         cb->sbqSpkOutVol = nullptr;
     }
 }

--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -58,6 +58,8 @@ void *MainFrame::designAnEQFilter(const char filterType[], float freqHz, float g
 
 void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSampleRate)
 {
+    deleteEQFilters(cb);
+    
     // init Mic In Equaliser Filters
     if (cb->micInEQEnable) {
         assert(cb->sbqMicInBass == nullptr && cb->sbqMicInTreble == nullptr && cb->sbqMicInMid == nullptr);


### PR DESCRIPTION
Reported on the digitalvoice mailing list. This is due to changes in 1.9.7 with how the filters are re-created upon modification. The workaround in this PR is to ensure that the filters are actually deleted before recreating them.