### PR TITLE
Prevent unnecessary recreation of resamplers in analog mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 1.9.7.2)
+set(PROJECT_VERSION 1.9.8)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -48,7 +48,7 @@ endif(APPLE)
 
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "devel")
 
 # Prevent in-source builds to protect automake/autoconf config.
 # If an in-source build is attempted, you will still need to clean up a few

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -889,6 +889,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V1.9.8 TBD 2024
+
+1. Bugfixes:
+    * Prevent unnecessary recreation of resamplers in analog mode. (PR #661)
+    
 ## V1.9.7.2 January 2024
 
 1. Bugfixes:

--- a/src/pipeline/AudioPipeline.cpp
+++ b/src/pipeline/AudioPipeline.cpp
@@ -130,8 +130,9 @@ void AudioPipeline::reloadResultResampler_()
 {
     bool createResampler = 
         resultSampler_ == nullptr || 
-        (pipelineSteps_.size() == 0 && getInputSampleRate() != getOutputSampleRate()) ||
-        resultSampler_->getInputSampleRate() != pipelineSteps_[pipelineSteps_.size() - 1]->getOutputSampleRate();
+        (pipelineSteps_.size() == 0 && 
+            (resultSampler_->getInputSampleRate() != getInputSampleRate() || resultSampler_->getOutputSampleRate() != getOutputSampleRate())) ||
+        (pipelineSteps_.size() > 0 && resultSampler_->getInputSampleRate() != pipelineSteps_[pipelineSteps_.size() - 1]->getOutputSampleRate());
     
     if (createResampler)
     {


### PR DESCRIPTION
Resolves #658 by fixing a bug where the `AudioPipeline` that does not have any steps inside it was unnecessarily recreating the output `ResampleStep` every time it processed a 20ms chunk of audio. This causes the state of the resampler to be lost, resulting in scratchy or dropped audio.

Note that the following must be true in order to observe this issue:

1. The sample rate for the digital input device ("From Radio to Computer") needs to be different than for the analog device ("From Computer to Speakers/Headphones"), and
2. FreeDV must be in analog mode. (Normal digital operation goes through a different flow inside the overall audio pipeline which doesn't seem to be affected by this issue.)