### PR TITLE
Update tooltip for the free form text field to indicate that it's not covered by FEC.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Prevent unnecessary recreation of resamplers in analog mode. (PR #661)
 2. Enhancements:
     * Add Frequency column to RX drop-down. (PR #663)
+    * Update tooltip for the free form text field to indicate that it's not covered by FEC. (PR #665)
 3. Code cleanup:
     * Move FreeDV Reporter dialog code to dialogs section of codebase. (PR #664)
 

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -83,7 +83,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     sbSizer_callSign = new wxStaticBoxSizer(sb_textMsg, wxVERTICAL);
 
     m_txtCtrlCallSign = new wxTextCtrl(m_reportingTab, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
-    m_txtCtrlCallSign->SetToolTip(_("Txt Msg you can send along with Voice"));
+    m_txtCtrlCallSign->SetToolTip(_("Text message that you can send along with your voice. Note that this does not have error correction and thus is not guaranteed to arrive at the receiving station."));
     sbSizer_callSign->Add(m_txtCtrlCallSign, 0, wxALL | wxEXPAND, 5);
 
     sizerReporting->Add(sbSizer_callSign,0, wxALL | wxEXPAND, 5);


### PR DESCRIPTION
Implement request from https://github.com/drowe67/freedv-gui/issues/662#issuecomment-1902723806 to update the tooltip for the free-form text field to clarify the lack of FEC.