### PR TITLE
Enable use of space bar for PTT when in the FreeDV Reporter window.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Prevent unnecessary recreation of resamplers in analog mode. (PR #661)
 2. Enhancements:
     * Add Frequency column to RX drop-down. (PR #663)
+    * Enable use of space bar for PTT when in the FreeDV Reporter window. (PR #666)
 3. Code cleanup:
     * Move FreeDV Reporter dialog code to dialogs section of codebase. (PR #664)
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -392,6 +392,11 @@ FreeDVReporterDialog::~FreeDVReporterDialog()
     m_bandFilter->Disconnect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnBandFilterChange), NULL, this);
 }
 
+bool FreeDVReporterDialog::isTextMessageFieldInFocus()
+{
+    return m_statusMessage->HasFocus();
+}
+
 void FreeDVReporterDialog::refreshLayout()
 {
     int colOffset = 0;

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -68,6 +68,8 @@ class FreeDVReporterDialog : public wxDialog
         
         void setBandFilter(FilterFrequency freq);
         
+        bool isTextMessageFieldInFocus();
+        
     protected:
 
         // Handlers for events.

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -787,7 +787,12 @@ int MainApp::FilterEvent(wxEvent& event)
         (((wxKeyEvent&)event).GetKeyCode() == WXK_SPACE))
         {
             // only use space to toggle PTT if we are running and no modal dialogs (like options) up
-            if (frame->m_RxRunning && frame->IsActive() && wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
+            bool mainWindowActive = frame->IsActive();
+            bool reporterActiveButNotUpdatingTextMessage = 
+                frame->m_reporterDialog != nullptr && frame->m_reporterDialog->IsActive() && 
+                !frame->m_reporterDialog->isTextMessageFieldInFocus();
+            if (frame->m_RxRunning && (mainWindowActive || reporterActiveButNotUpdatingTextMessage) && 
+                wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
 
                 // space bar controls rx/rx if keyer not running
                 if (frame->vk_state == VK_IDLE) {


### PR DESCRIPTION
Per request from https://github.com/drowe67/freedv-gui/issues/660#issuecomment-1902091627, this PR enables use of the space bar to toggle PTT when the FreeDV Reporter window is active (except when the text message field inside that window has focus).