### PR TITLE
Fix bug where PTT button background color doesn't change when toggling PTT via space bar.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -896,6 +896,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Better handle high sample rate audio devices and those with >2 channels. (PR #668)
     * Fix issue preventing errors from being displayed for issues involving the FreeDV->Speaker sound device. (PR #668)
     * Fix issue resulting in incorrect audio device usage after validation failure if no valid default exists. (PR #668)
+    * Fix bug where PTT button background color doesn't change when toggling PTT via space bar. (PR #669)
 2. Enhancements:
     * Add Frequency column to RX drop-down. (PR #663)
     * Update tooltip for the free form text field to indicate that it's not covered by FEC. (PR #665)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -794,13 +794,18 @@ int MainApp::FilterEvent(wxEvent& event)
             if (frame->m_RxRunning && (mainWindowActive || reporterActiveButNotUpdatingTextMessage) && 
                 wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
 
-                // space bar controls rx/rx if keyer not running
+                // space bar controls tx/rx if keyer not running
                 if (frame->vk_state == VK_IDLE) {
                     if (frame->m_btnTogPTT->GetValue())
                         frame->m_btnTogPTT->SetValue(false);
                     else
                         frame->m_btnTogPTT->SetValue(true);
 
+                    // Update background color of button here because when toggling PTT via keyboard,
+                    // the background color for some reason doesn't update inside togglePTT().
+                    frame->m_btnTogPTT->SetBackgroundColour(frame->m_btnTogPTT->GetValue() ? *wxRED : wxNullColour);
+
+                    // Actually toggle PTT.
                     frame->togglePTT();
                 }
                 else // space bar stops keyer


### PR DESCRIPTION
As the PR says. This is more of a workaround since ideally, `togglePTT()` itself would be fixed (but want to avoid more impact than needed for what's basically a display bug).