### PR TITLE
Add heading column to FreeDV Reporter window.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -902,6 +902,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update tooltip for the free form text field to indicate that it's not covered by FEC. (PR #665)
     * Enable use of space bar for PTT when in the FreeDV Reporter window. (PR #666)
     * Move TX Mode column to left of Status in FreeDV Reporter window. (PR #670)
+    * Add heading column to FreeDV Reporter window. (PR #672)
 3. Code cleanup:
     * Move FreeDV Reporter dialog code to dialogs section of codebase. (PR #664)
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -1092,7 +1092,8 @@ double FreeDVReporterDialog::DegreesToRadians_(double degrees)
 
 double FreeDVReporterDialog::RadiansToDegrees_(double radians)
 {
-    return (radians > 0 ? radians : (2*M_PI + radians)) * 360 / (2*M_PI);
+    auto result = (radians > 0 ? radians : (2*M_PI + radians)) * 360 / (2*M_PI);
+    return (result == 360) ? 0 : result;
 }
 
 int FreeDVReporterDialog::ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -50,6 +50,7 @@ static int DefaultColumnWidths_[] = {
     70,
     65,
     60,
+    60,
     70,
     60,
     65,
@@ -101,6 +102,8 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_listSpots->InsertColumn(col, wxT("Locator"), wxLIST_FORMAT_LEFT, DefaultColumnWidths_[col]);
     col++;
     m_listSpots->InsertColumn(col, wxT("km"), wxLIST_FORMAT_RIGHT, DefaultColumnWidths_[col]);
+    col++;
+    m_listSpots->InsertColumn(col, wxT("Hdg"), wxLIST_FORMAT_RIGHT, DefaultColumnWidths_[col]);
     col++;
     m_listSpots->InsertColumn(col, wxT("Version"), wxLIST_FORMAT_LEFT, DefaultColumnWidths_[col]);
     col++;
@@ -605,7 +608,7 @@ void FreeDVReporterDialog::OnSortColumn(wxListEvent& event)
     }
 #endif // defined(WIN32)
 
-    if (col > 12)
+    if (col > (NUM_COLS - 1))
     {
         // Don't allow sorting by "fake" columns.
         col = -1;
@@ -998,7 +1001,7 @@ double FreeDVReporterDialog::calculateDistance_(wxString gridSquare1, wxString g
     double lat1 = 0;
     double lon1 = 0;
     double lat2 = 0;
-    double lon2 = 0 ;
+    double lon2 = 0;
     
     // Grab latitudes and longitudes for the two locations.
     calculateLatLonFromGridSquare_(gridSquare1, lat1, lon1);
@@ -1057,9 +1060,39 @@ void FreeDVReporterDialog::calculateLatLonFromGridSquare_(wxString gridSquare, d
     }
 }
 
+double FreeDVReporterDialog::calculateBearingInDegrees_(wxString gridSquare1, wxString gridSquare2)
+{
+    double lat1 = 0;
+    double lon1 = 0;
+    double lat2 = 0;
+    double lon2 = 0;
+    
+    // Grab latitudes and longitudes for the two locations.
+    calculateLatLonFromGridSquare_(gridSquare1, lat1, lon1);
+    calculateLatLonFromGridSquare_(gridSquare2, lat2, lon2);
+
+    // Convert latitudes and longitudes into radians
+    lat1 = DegreesToRadians_(lat1);
+    lat2 = DegreesToRadians_(lat2);
+    lon1 = DegreesToRadians_(lon1);
+    lon2 = DegreesToRadians_(lon2);
+
+    double diffLongitude = lon2 - lon1;
+    double x = cos(lat2) * sin(diffLongitude);
+    double y = (cos(lat1) * sin(lat2)) - (sin(lat1) * cos(lat2) * cos(diffLongitude));
+    double radians = atan2(x, y);
+
+    return RadiansToDegrees_(radians);
+}
+
 double FreeDVReporterDialog::DegreesToRadians_(double degrees)
 {
     return degrees * (M_PI / 180.0);
+}
+
+double FreeDVReporterDialog::RadiansToDegrees_(double radians)
+{
+    return (radians > 0 ? radians : (2*M_PI + radians)) * 360 / (2*M_PI);
 }
 
 int FreeDVReporterDialog::ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)
@@ -1084,21 +1117,24 @@ int FreeDVReporterDialog::ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPt
             result = leftData->distanceVal - rightData->distanceVal;
             break;
         case 3:
-            result = leftData->version.CmpNoCase(rightData->version);
+            result = leftData->headingVal - rightData->headingVal;
             break;
         case 4:
-            result = leftData->frequency - rightData->frequency;
+            result = leftData->version.CmpNoCase(rightData->version);
             break;
         case 5:
-            result = leftData->txMode.CmpNoCase(rightData->txMode);
+            result = leftData->frequency - rightData->frequency;
             break;
         case 6:
-            result = leftData->status.CmpNoCase(rightData->status);
+            result = leftData->txMode.CmpNoCase(rightData->txMode);
             break;
         case 7:
-            result = leftData->userMessage.CmpNoCase(rightData->userMessage);
+            result = leftData->status.CmpNoCase(rightData->status);
             break;
         case 8:
+            result = leftData->userMessage.CmpNoCase(rightData->userMessage);
+            break;
+        case 9:
             if (leftData->lastTxDate.IsValid() && rightData->lastTxDate.IsValid())
             {
                 if (leftData->lastTxDate.IsEarlierThan(rightData->lastTxDate))
@@ -1127,16 +1163,16 @@ int FreeDVReporterDialog::ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPt
                 result = 0;
             }
             break;
-        case 9:
+        case 10:
             result = leftData->lastRxCallsign.CmpNoCase(rightData->lastRxCallsign);
             break;
-        case 10:
+        case 11:
             result = leftData->lastRxMode.CmpNoCase(rightData->lastRxMode);
             break;
-        case 11:
+        case 12:
             result = leftData->snr.CmpNoCase(rightData->snr);
             break;
-        case 12:
+        case 13:
             if (leftData->lastUpdateDate.IsValid() && rightData->lastUpdateDate.IsValid())
             {
                 if (leftData->lastUpdateDate.IsEarlierThan(rightData->lastUpdateDate))
@@ -1248,6 +1284,8 @@ void FreeDVReporterDialog::onUserConnectFn_(std::string sid, std::string lastUpd
             // Invalid grid square means we can't calculate a distance.
             temp->distance = UNKNOWN_STR;
             temp->distanceVal = 0;
+            temp->heading = UNKNOWN_STR;
+            temp->headingVal = 0;
         }
         else
         {
@@ -1261,6 +1299,9 @@ void FreeDVReporterDialog::onUserConnectFn_(std::string sid, std::string lastUpd
             }
 
             temp->distance = wxString::Format("%.0f", temp->distanceVal);
+
+            temp->headingVal = calculateBearingInDegrees_(wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare, gridSquareWxString);
+            temp->heading = wxString::Format("%.0f", temp->headingVal);
         }
 
         temp->version = version;
@@ -1653,6 +1694,9 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, data->distance, colResizeList);
+    needResort |= changed && currentSortColumn_ == (col - 1);
+
+    changed = setColumnForRow_(itemIndex, col++, data->heading, colResizeList);
     needResort |= changed && currentSortColumn_ == (col - 1);
 
     changed = setColumnForRow_(itemIndex, col++, " "+data->version, colResizeList);

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -1301,8 +1301,16 @@ void FreeDVReporterDialog::onUserConnectFn_(std::string sid, std::string lastUpd
 
             temp->distance = wxString::Format("%.0f", temp->distanceVal);
 
-            temp->headingVal = calculateBearingInDegrees_(wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare, gridSquareWxString);
-            temp->heading = wxString::Format("%.0f", temp->headingVal);
+            if (wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare == gridSquareWxString)
+            {
+                temp->headingVal = 0;
+                temp->heading = UNKNOWN_STR;
+            }
+            else
+            {
+                temp->headingVal = calculateBearingInDegrees_(wxGetApp().appConfiguration.reportingConfiguration.reportingGridSquare, gridSquareWxString);
+                temp->heading = wxString::Format("%.0f", temp->headingVal);
+            }
         }
 
         temp->version = version;

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -142,6 +142,8 @@ class FreeDVReporterDialog : public wxDialog
              wxString gridSquare;
              double distanceVal;
              wxString distance;
+             double headingVal;
+             wxString heading;
              wxString version;
              uint64_t frequency;
              wxString freqString;
@@ -195,6 +197,7 @@ class FreeDVReporterDialog : public wxDialog
          void sortColumn_(int col, bool direction);
          
          double calculateDistance_(wxString gridSquare1, wxString gridSquare2);
+         double calculateBearingInDegrees_(wxString gridSquare1, wxString gridSquare2);
          void calculateLatLonFromGridSquare_(wxString gridSquare, double& lat, double& lon);
          
          void execQueuedAction_();
@@ -204,6 +207,7 @@ class FreeDVReporterDialog : public wxDialog
 
          static wxCALLBACK int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
          static double DegreesToRadians_(double degrees);
+         static double RadiansToDegrees_(double radians);
 };
 
 #endif // __FREEDV_REPORTER_DIALOG__


### PR DESCRIPTION
Resolves #671 by adding a heading for each user in the FreeDV Reporter window. For example:

![Screenshot 2024-01-25 at 8 05 46 PM](https://github.com/drowe67/freedv-gui/assets/449242/5f12ea22-e0c1-4c86-ac71-2592b4396884)

Values have been cross-checked with https://www.chris.org/cgi-bin/finddis and appear to be correct.