### PR TITLE
Fix bug where FreeDV crashes if only RX sound devices are configured with mic filters turned on.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -897,6 +897,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue preventing errors from being displayed for issues involving the FreeDV->Speaker sound device. (PR #668)
     * Fix issue resulting in incorrect audio device usage after validation failure if no valid default exists. (PR #668)
     * Fix bug where PTT button background color doesn't change when toggling PTT via space bar. (PR #669)
+    * Fix bug where FreeDV crashes if only RX sound devices are configured with mic filters turned on. (PR #673)
 2. Enhancements:
     * Add Frequency column to RX drop-down. (PR #663)
     * Update tooltip for the free form text field to indicate that it's not covered by FEC. (PR #665)

--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -6,6 +6,8 @@
     
 #include "main.h"
 
+extern int g_nSoundCards;
+
 #define SBQ_MAX_ARGS 5
 
 void *MainFrame::designAnEQFilter(const char filterType[], float freqHz, float gaindB, float Q, int sampleRate)
@@ -59,7 +61,7 @@ void *MainFrame::designAnEQFilter(const char filterType[], float freqHz, float g
 void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSampleRate)
 {
     // init Mic In Equaliser Filters
-    if (cb->micInEQEnable) {
+    if (cb->micInEQEnable && g_nSoundCards > 1) {
         assert(cb->sbqMicInBass == nullptr && cb->sbqMicInTreble == nullptr && cb->sbqMicInMid == nullptr);
         //printf("designing new Min In filters\n");
         cb->sbqMicInBass   = designAnEQFilter("bass", wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassFreqHz, wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassGaindB, txSampleRate);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1532,8 +1532,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             {
                 if (g_nSoundCards == 1)
                 {
-                    // RX In isn't used here but we need to provide it anyway.
-                    designEQFilters(g_rxUserdata, wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate, wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate);
+                    designEQFilters(g_rxUserdata, wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate, 0);
                 }
                 else
                 {   
@@ -2696,10 +2695,20 @@ void MainFrame::startRxStream()
             wxGetApp().appConfiguration.filterConfiguration.micInChannel.eqEnable ||
             wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable)
         {
-            designEQFilters(
-                g_rxUserdata, 
-                wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate, 
-                wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate);
+            if (g_nSoundCards == 1)
+            {
+                designEQFilters(
+                    g_rxUserdata, 
+                    wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate, 
+                    0);
+            }
+            else
+            {
+                designEQFilters(
+                    g_rxUserdata, 
+                    wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate, 
+                    wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate);
+            }
         }
 
         m_newMicInFilter = m_newSpkOutFilter = false;


### PR DESCRIPTION
Accidentally discovered this bug while testing #672 on a Linux VM. Per testing, it's now fixed with this PR.