### PR TITLE
Add support for displaying cardinal directions instead of headings.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -906,6 +906,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Move TX Mode column to left of Status in FreeDV Reporter window. (PR #670)
     * Add heading column to FreeDV Reporter window. (PR #672, #675)
     * Prevent FreeDV Reporter window from being above the main window. (PR #679)
+    * Add support for displaying cardinal directions instead of headings. (PR #685)
 3. Code cleanup:
     * Move FreeDV Reporter dialog code to dialogs section of codebase. (PR #664)
 

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -80,6 +80,7 @@ ReportingConfiguration::ReportingConfiguration()
     , freedvReporterMsgRowForegroundColor("/Reporting/FreeDV/MsgRowForegroundColor", "#000000")
         
     , reportingFrequencyAsKhz("/Reporting/FrequencyAsKHz", false)
+    , reportingDirectionAsCardinal("/Reporting/DirectionAsCardinal", false)
 {
     // Special handling for the frequency list to properly handle locales
     reportingFrequencyList.setLoadProcessor([this](std::vector<wxString> list) {
@@ -196,6 +197,8 @@ void ReportingConfiguration::load(wxConfigBase* config)
     load_(config, freedvReporterMsgRowBackgroundColor);
     load_(config, freedvReporterMsgRowForegroundColor);
 
+    load_(config, reportingDirectionAsCardinal);
+
     // Special load handling for reporting below.
     wxString freqStr = config->Read(reportingFrequency.getElementName(), oldFreqStr);
     reportingFrequency.setWithoutProcessing(atoll(freqStr.ToUTF8()));
@@ -235,6 +238,8 @@ void ReportingConfiguration::save(wxConfigBase* config)
     save_(config, freedvReporterRxRowForegroundColor);
     save_(config, freedvReporterMsgRowBackgroundColor);
     save_(config, freedvReporterMsgRowForegroundColor);
+
+    save_(config, reportingDirectionAsCardinal);
     
     // Special save handling for reporting below.
     wxString tempFreqStr = wxString::Format(wxT("%" PRIu64), reportingFrequency.getWithoutProcessing());

--- a/src/config/ReportingConfiguration.h
+++ b/src/config/ReportingConfiguration.h
@@ -69,6 +69,7 @@ public:
     ConfigurationDataElement<wxString> freedvReporterMsgRowForegroundColor;
     
     ConfigurationDataElement<bool> reportingFrequencyAsKhz;
+    ConfigurationDataElement<bool> reportingDirectionAsCardinal;
     
     virtual void load(wxConfigBase* config) override;
     virtual void save(wxConfigBase* config) override;

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -146,6 +146,9 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     m_useMetricDistances = new wxCheckBox(m_reportingTab, wxID_ANY, _("Distances in km"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizerReportingFreeDVNoCall->Add(m_useMetricDistances, 0,  wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
+    m_useCardinalDirections = new wxCheckBox(m_reportingTab, wxID_ANY, _("Show cardinal directions"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    sbSizerReportingFreeDVNoCall->Add(m_useCardinalDirections, 0,  wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
     m_ckboxFreeDVReporterForceReceiveOnly = new wxCheckBox(m_reportingTab, wxID_ANY, _("Force RX Only reporting"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizerReportingFreeDVNoCall->Add(m_ckboxFreeDVReporterForceReceiveOnly, 0,  wxALL | wxALIGN_CENTER_VERTICAL, 5);
     
@@ -880,6 +883,7 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_ckboxFreeDVReporterEnable->SetValue(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterEnabled);
         m_freedvReporterHostname->SetValue(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname);
         m_useMetricDistances->SetValue(wxGetApp().appConfiguration.reportingConfiguration.useMetricDistances);
+        m_useCardinalDirections->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingDirectionAsCardinal);
         m_ckboxFreeDVReporterForceReceiveOnly->SetValue(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterForceReceiveOnly);
         
         // Callsign list config
@@ -1052,6 +1056,7 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname = m_freedvReporterHostname->GetValue();
         wxGetApp().appConfiguration.reportingConfiguration.useMetricDistances = m_useMetricDistances->GetValue();
         wxGetApp().appConfiguration.reportingConfiguration.freedvReporterForceReceiveOnly = m_ckboxFreeDVReporterForceReceiveOnly->GetValue();
+        wxGetApp().appConfiguration.reportingConfiguration.reportingDirectionAsCardinal = m_useCardinalDirections->GetValue();
                 
         // Callsign list config
         wxGetApp().appConfiguration.reportingConfiguration.useUTCForReporting = m_ckbox_use_utc_time->GetValue();
@@ -1286,6 +1291,7 @@ void OptionsDlg::updateReportingState()
             m_ckboxPskReporterEnable->Enable(true);
             m_ckboxFreeDVReporterEnable->Enable(true);
             m_ckboxFreeDVReporterForceReceiveOnly->Enable(true);
+            m_useCardinalDirections->Enable(true);
         }
         else
         {
@@ -1296,6 +1302,7 @@ void OptionsDlg::updateReportingState()
             m_ckboxFreeDVReporterEnable->Enable(false);
             m_ckboxManualFrequencyReporting->Enable(false);
             m_ckboxFreeDVReporterForceReceiveOnly->Enable(true);
+            m_useCardinalDirections->Enable(true);
         }    
     }
     else
@@ -1311,6 +1318,7 @@ void OptionsDlg::updateReportingState()
         m_useMetricDistances->Enable(false);
         m_freedvReporterHostname->Enable(false);
         m_ckboxFreeDVReporterForceReceiveOnly->Enable(false);
+        m_useCardinalDirections->Enable(false);
         
         m_ckbox_use_utc_time->Enable(false);
     }

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -149,6 +149,7 @@ class OptionsDlg : public wxDialog
         wxCheckBox    *m_ckboxFreeDVReporterEnable;
         wxTextCtrl    *m_freedvReporterHostname;
         wxCheckBox    *m_useMetricDistances;
+        wxCheckBox    *m_useCardinalDirections;
         wxCheckBox    *m_ckboxFreeDVReporterForceReceiveOnly;
         
         wxButton*     m_BtnFifoReset;

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -455,10 +455,12 @@ void FreeDVReporterDialog::refreshLayout()
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingDirectionAsCardinal)
     {
         item.SetText("Dir");
+        item.SetAlign(wxLIST_FORMAT_LEFT);
     }
     else
     {
         item.SetText("Hdg");
+        item.SetAlign(wxLIST_FORMAT_RIGHT);
     }
     m_listSpots->SetColumn(HEADING_COL + colOffset, item);
 

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -208,6 +208,7 @@ class FreeDVReporterDialog : public wxFrame
          static wxCALLBACK int ListCompareFn_(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
          static double DegreesToRadians_(double degrees);
          static double RadiansToDegrees_(double radians);
+         static wxString GetCardinalDirection_(int degrees);
 };
 
 #endif // __FREEDV_REPORTER_DIALOG__


### PR DESCRIPTION
Resolves #682 by adding a new setting in Tools->Options to show directions (e.g. N/S/E/W) instead of degrees for the Heading/Direction column.