### PR TITLE
Shrink callsign list to make it less likely to end up off the screen.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -893,6 +893,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Fix typo in cardinal directions list. (PR #688)
+    * Shrink size of callsign list to prevent it from disappearing off the screen. (PR #692)
 
 ## V1.9.8 February 2024
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -581,6 +581,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_lastReportedCallsignListView = new wxListViewComboPopup();
     m_cboLastReportedCallsigns->SetPopupControl(m_lastReportedCallsignListView);
     m_cboLastReportedCallsigns->SetSizeHints(wxSize(100,-1));
+    m_cboLastReportedCallsigns->SetPopupMaxHeight(150);
     
     m_lastReportedCallsignListView->InsertColumn(0, wxT("Callsign"), wxLIST_FORMAT_LEFT, 100);
     m_lastReportedCallsignListView->InsertColumn(1, wxT("Frequency"), wxLIST_FORMAT_RIGHT, 75);


### PR DESCRIPTION
Resolves #691 by providing a maximum size for the callsign list.