### PR TITLE
Allow unlimited length user messages while still truncating their display by default.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Cache PortAudio sound info to improve startup performance. (PR #689)
     * Fix typo in cardinal directions list. (PR #688)
     * Shrink size of callsign list to prevent it from disappearing off the screen. (PR #692)
+2. Enhancements:
+    * Allow longer length user messages. (PR #694)
 
 ## V1.9.8 February 2024
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -898,6 +898,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Add additional error reporting in case of PortAudio failures. (PR #695)
     * Allow longer length user messages. (PR #694)
+    * Add context menu for copying messages to the clipboard. (PR #694)
 
 ## V1.9.8 February 2024
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -792,6 +792,10 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
         
         if (tipWindow_ == nullptr && userMessage != userMessageTruncated)
         {
+            // Use screen coordinates to determine bounds.
+            auto pos = rect.GetPosition();
+            rect.SetPosition(ClientToScreen(pos));
+            
             tipWindow_ = new wxTipWindow(m_listSpots, userMessage, 1000, &tipWindow_, &rect);
         }
     }

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -844,11 +844,19 @@ void FreeDVReporterDialog::OnRightClickSpotsList( wxContextMenuEvent& event )
         tipWindow_->Close();
         tipWindow_ = nullptr;
     }
-    
+
     if (tempUserMessage != _(""))
     {
         // Only show the popup if we're already hovering over a message.
-        m_listSpots->PopupMenu(spotsPopupMenu_); //, wxPoint(-sz.GetWidth() - 25, 0));
+        const wxPoint pt = wxGetMousePosition();
+        int mouseX = pt.x - m_listSpots->GetScreenPosition().x;
+        int mouseY = pt.y - m_listSpots->GetScreenPosition().y;
+
+        // 170 here has been determined via experimentation to avoid an issue 
+        // on some KDE installations where the popup menu immediately closes after
+        // right-clicking. This in effect causes the popup to open to the left of
+        // the mouse pointer.
+        m_listSpots->PopupMenu(spotsPopupMenu_, wxPoint(mouseX - 170, mouseY));
     }
 }
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -772,31 +772,34 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
     int mouseX = pt.x - m_listSpots->GetScreenPosition().x;
     int mouseY = pt.y - m_listSpots->GetScreenPosition().y;
     
-    auto selectedIndex = m_listSpots->GetFirstSelected();
     wxRect rect;
     int desiredCol = USER_MESSAGE_COL;
 #if defined(WIN32)
     desiredCol++;
 #endif // defined(WIN32)
     
-    bool itemSelected = selectedIndex >= 0;
-    bool gotUserMessageColBounds = itemSelected && m_listSpots->GetSubItemRect(selectedIndex, desiredCol, rect);
-    bool mouseInBounds = gotUserMessageColBounds && rect.Contains(mouseX, mouseY);
-    
-    if (itemSelected && gotUserMessageColBounds && mouseInBounds)
+    for (auto index = 0; index < m_listSpots->GetItemCount(); index++)
     {
-        // Show popup corresponding to the full message.
-        std::string* sidPtr = (std::string*)m_listSpots->GetItemData(selectedIndex);
-        auto userMessage = allReporterData_[*sidPtr]->userMessage;
-        wxString userMessageTruncated = userMessage.SubString(0, MESSAGE_CHAR_LIMIT - 1);
-        
-        if (tipWindow_ == nullptr && userMessage != userMessageTruncated)
+        bool gotUserMessageColBounds = m_listSpots->GetSubItemRect(index, desiredCol, rect);
+        bool mouseInBounds = gotUserMessageColBounds && rect.Contains(mouseX, mouseY);
+    
+        if (gotUserMessageColBounds && mouseInBounds)
         {
-            // Use screen coordinates to determine bounds.
-            auto pos = rect.GetPosition();
-            rect.SetPosition(ClientToScreen(pos));
+            // Show popup corresponding to the full message.
+            std::string* sidPtr = (std::string*)m_listSpots->GetItemData(index);
+            auto userMessage = allReporterData_[*sidPtr]->userMessage;
+            wxString userMessageTruncated = userMessage.SubString(0, MESSAGE_CHAR_LIMIT - 1);
+        
+            if (tipWindow_ == nullptr && userMessage != userMessageTruncated)
+            {
+                // Use screen coordinates to determine bounds.
+                auto pos = rect.GetPosition();
+                rect.SetPosition(ClientToScreen(pos));
             
-            tipWindow_ = new wxTipWindow(m_listSpots, userMessage, 1000, &tipWindow_, &rect);
+                tipWindow_ = new wxTipWindow(m_listSpots, userMessage, 1000, &tipWindow_, &rect);
+            }
+            
+            break;
         }
     }
 }

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -811,6 +811,15 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
                 rect.SetPosition(ClientToScreen(pos));
             
                 tipWindow_ = new wxTipWindow(m_listSpots, tempUserMessage, 1000, &tipWindow_, &rect);
+                tipWindow_->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnRightClickSpotsList), NULL, this);
+                tipWindow_->Connect(wxEVT_RIGHT_DOWN, wxMouseEventHandler(FreeDVReporterDialog::SkipMouseEvent), NULL, this);
+                
+                // Make sure we actually override behavior of needed events inside the tooltip.
+                for (auto& child : tipWindow_->GetChildren())
+                {
+                    child->Connect(wxEVT_RIGHT_DOWN, wxMouseEventHandler(FreeDVReporterDialog::SkipMouseEvent), NULL, this);
+                    child->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnRightClickSpotsList), NULL, this);
+                }
             }
             
             break;
@@ -822,8 +831,20 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
     }
 }
 
+void FreeDVReporterDialog::SkipMouseEvent(wxMouseEvent& event)
+{
+    wxContextMenuEvent contextEvent;
+    OnRightClickSpotsList(contextEvent);
+}
+
 void FreeDVReporterDialog::OnRightClickSpotsList( wxContextMenuEvent& event )
 {
+    if (tipWindow_ != nullptr)
+    {
+        tipWindow_->Close();
+        tipWindow_ = nullptr;
+    }
+    
     if (tempUserMessage != _(""))
     {
         // Only show the popup if we're already hovering over a message.

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -801,16 +801,16 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
         {
             // Show popup corresponding to the full message.
             std::string* sidPtr = (std::string*)m_listSpots->GetItemData(index);
-            tempUserMessage = allReporterData_[*sidPtr]->userMessage;
-            wxString userMessageTruncated = tempUserMessage.SubString(0, MESSAGE_CHAR_LIMIT - 1);
+            tempUserMessage_ = allReporterData_[*sidPtr]->userMessage;
+            wxString userMessageTruncated = tempUserMessage_.SubString(0, MESSAGE_CHAR_LIMIT - 1);
         
-            if (tipWindow_ == nullptr && tempUserMessage != userMessageTruncated)
+            if (tipWindow_ == nullptr && tempUserMessage_ != userMessageTruncated)
             {
                 // Use screen coordinates to determine bounds.
                 auto pos = rect.GetPosition();
                 rect.SetPosition(ClientToScreen(pos));
             
-                tipWindow_ = new wxTipWindow(m_listSpots, tempUserMessage, 1000, &tipWindow_, &rect);
+                tipWindow_ = new wxTipWindow(m_listSpots, tempUserMessage_, 1000, &tipWindow_, &rect);
                 tipWindow_->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnRightClickSpotsList), NULL, this);
                 tipWindow_->Connect(wxEVT_RIGHT_DOWN, wxMouseEventHandler(FreeDVReporterDialog::SkipMouseEvent), NULL, this);
                 
@@ -826,7 +826,7 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
         }
         else
         {
-            tempUserMessage = _("");
+            tempUserMessage_ = _("");
         }
     }
 }
@@ -845,7 +845,7 @@ void FreeDVReporterDialog::OnRightClickSpotsList( wxContextMenuEvent& event )
         tipWindow_ = nullptr;
     }
 
-    if (tempUserMessage != _(""))
+    if (tempUserMessage_ != _(""))
     {
         // Only show the popup if we're already hovering over a message.
         const wxPoint pt = wxGetMousePosition();
@@ -866,7 +866,7 @@ void FreeDVReporterDialog::OnCopyUserMessage(wxCommandEvent& event)
     {
         // This data objects are held by the clipboard,
         // so do not delete them in the app.
-        wxTheClipboard->SetData( new wxTextDataObject(tempUserMessage) );
+        wxTheClipboard->SetData( new wxTextDataObject(tempUserMessage_) );
         wxTheClipboard->Close();
     }
 }

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -112,7 +112,7 @@ class FreeDVReporterDialog : public wxFrame
         int upIconIndex_;
         int downIconIndex_;
         wxMenu* spotsPopupMenu_;
-        wxString tempUserMessage; // to store the currently hovering message prior to going on the clipboard
+        wxString tempUserMessage_; // to store the currently hovering message prior to going on the clipboard
 
         // QSY text
         wxTextCtrl* m_qsyText;

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <wx/imaglist.h>
+#include <wx/tipwin.h>
 
 #include "main.h"
 #include "defines.h"
@@ -97,6 +98,7 @@ class FreeDVReporterDialog : public wxFrame
         void OnItemDeselected(wxListEvent& event);
         void OnSortColumn(wxListEvent& event);
         void OnTimer(wxTimerEvent& event);
+        void AdjustToolTip(wxMouseEvent& event);
         void OnFilterTrackingEnable(wxCommandEvent& event);
         
         void OnDoubleClick(wxMouseEvent& event);
@@ -134,6 +136,8 @@ class FreeDVReporterDialog : public wxFrame
         std::vector<std::function<void()> > fnQueue_;
         std::mutex fnQueueMtx_;
 
+        wxTipWindow* tipWindow_;
+        
      private:
          struct ReporterData
          {

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -100,6 +100,8 @@ class FreeDVReporterDialog : public wxFrame
         void OnTimer(wxTimerEvent& event);
         void AdjustToolTip(wxMouseEvent& event);
         void OnFilterTrackingEnable(wxCommandEvent& event);
+        void OnRightClickSpotsList(wxContextMenuEvent& event);
+        void OnCopyUserMessage(wxCommandEvent& event);
         
         void OnDoubleClick(wxMouseEvent& event);
         
@@ -108,6 +110,8 @@ class FreeDVReporterDialog : public wxFrame
         wxImageList*  m_sortIcons;
         int upIconIndex_;
         int downIconIndex_;
+        wxMenu* spotsPopupMenu_;
+        wxString tempUserMessage; // to store the currently hovering message prior to going on the clipboard
 
         // QSY text
         wxTextCtrl* m_qsyText;

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -102,6 +102,7 @@ class FreeDVReporterDialog : public wxFrame
         void OnFilterTrackingEnable(wxCommandEvent& event);
         void OnRightClickSpotsList(wxContextMenuEvent& event);
         void OnCopyUserMessage(wxCommandEvent& event);
+        void SkipMouseEvent(wxMouseEvent& event);
         
         void OnDoubleClick(wxMouseEvent& event);
         


### PR DESCRIPTION
This PR lifts the 15 character limit on user messages, allowing users to send much longer messages as desired. However, display of the longer messages is still truncated to 15 characters by default (to keep the behavior the same for smaller displays); to view the full message, you need to select the user in the list and hover over the column. For example:

<img width="1193" alt="Screenshot 2024-02-29 at 11 27 26 PM" src="https://github.com/drowe67/freedv-gui/assets/449242/eeb4a660-719b-4222-9cef-a8a8d13714db">
