### PR TITLE
Add additional error reporting in case of PortAudio failures.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Cache PortAudio sound info to improve startup performance. (PR #689)
     * Fix typo in cardinal directions list. (PR #688)
     * Shrink size of callsign list to prevent it from disappearing off the screen. (PR #692)
+2. Enhancements:
+    * Add additional error reporting in case of PortAudio failures. (PR #695)
 
 ## V1.9.8 February 2024
 

--- a/src/audio/PortAudioDevice.cpp
+++ b/src/audio/PortAudioDevice.cpp
@@ -20,6 +20,8 @@
 //
 //=========================================================================
 
+#include <sstream>
+#include <iomanip>
 #include <cstring>
 #include "PortAudioDevice.h"
 #include "portaudio.h"
@@ -95,9 +97,18 @@ void PortAudioDevice::start()
         error = Pa_StartStream(deviceStream_);
         if (error != paNoError)
         {
+            std::string errText = Pa_GetErrorText(error);
+            if (error == paUnanticipatedHostError)
+            {
+                std::stringstream ss;
+                auto errInfo = Pa_GetLastHostErrorInfo();
+                ss << " (error code " << std::hex << errInfo->errorCode << " - " << std::string(errInfo->errorText) << ")";
+                errText += ss.str();
+            }
+
             if (onAudioErrorFunction)
             {
-                onAudioErrorFunction(*this, Pa_GetErrorText(error), onAudioErrorState);
+                onAudioErrorFunction(*this, errText, onAudioErrorState);
             }
             
             Pa_CloseStream(deviceStream_);
@@ -106,9 +117,18 @@ void PortAudioDevice::start()
     }
     else
     {
+        std::string errText = Pa_GetErrorText(error);
+        if (error == paUnanticipatedHostError)
+        {
+            std::stringstream ss;
+            auto errInfo = Pa_GetLastHostErrorInfo();
+            ss << " (error code " << std::hex << errInfo->errorCode << " - " << std::string(errInfo->errorText) << ")";
+            errText += ss.str();
+        }
+
         if (onAudioErrorFunction)
         {
-            onAudioErrorFunction(*this, Pa_GetErrorText(error), onAudioErrorState);
+            onAudioErrorFunction(*this, errText, onAudioErrorState);
         }
         deviceStream_ = nullptr;
     }

--- a/src/audio/PortAudioEngine.cpp
+++ b/src/audio/PortAudioEngine.cpp
@@ -20,6 +20,8 @@
 //
 //=========================================================================
 
+#include <sstream>
+#include <iomanip>
 #include <mutex>
 #include <condition_variable>
 
@@ -47,9 +49,18 @@ void PortAudioEngine::start()
     auto error = Pa_Initialize();
     if (error != paNoError)
     {
+        std::string errText = Pa_GetErrorText(error);
+        if (error == paUnanticipatedHostError)
+        {
+            std::stringstream ss;
+            auto errInfo = Pa_GetLastHostErrorInfo();
+            ss << " (error code " << std::hex << errInfo->errorCode << " - " << std::string(errInfo->errorText) << ")";
+            errText += ss.str();
+        }
+
         if (onAudioErrorFunction)
         {
-            onAudioErrorFunction(*this, Pa_GetErrorText(error), onAudioErrorState);
+            onAudioErrorFunction(*this, errText, onAudioErrorState);
         }
     }
     else


### PR DESCRIPTION
This PR adds additional error reporting in the case when PortAudio returns `paUnanticipatedHostError`.