### PR TITLE
Fix issue causing delayed filter updates when going from tracking band to frequency.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,6 +895,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Cache PortAudio sound info to improve startup performance. (PR #689)
     * Fix typo in cardinal directions list. (PR #688)
     * Shrink size of callsign list to prevent it from disappearing off the screen. (PR #692)
+    * Fix issue causing delayed filter updates when going from tracking band to frequency. (PR #704)
 2. Enhancements:
     * Add additional error reporting in case of PortAudio failures. (PR #695)
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -931,22 +931,18 @@ void FreeDVReporterDialog::refreshQSYButtonState()
 
 void FreeDVReporterDialog::setBandFilter(FilterFrequency freq)
 {
-    if (filteredFrequency_ != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency ||
-        currentBandFilter_ != freq)
-    {
-        filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
-        currentBandFilter_ = freq;
-    
-        // Update displayed list based on new filter criteria.
-        clearAllEntries_(false);
+    filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
+    currentBandFilter_ = freq;
 
-        std::map<int, int> colResizeList;
-        for (auto& kvp : allReporterData_)
-        {
-            addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
-        }
-        resizeChangedColumns_(colResizeList);
+    // Update displayed list based on new filter criteria.
+    clearAllEntries_(false);
+
+    std::map<int, int> colResizeList;
+    for (auto& kvp : allReporterData_)
+    {
+        addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
     }
+    resizeChangedColumns_(colResizeList);
 }
 
 void FreeDVReporterDialog::sortColumn_(int col)


### PR DESCRIPTION
This PR resolves an issue discovered by @barjac in #703 where updates to the displayed list don't occur immediately when switching from tracking band to frequency, but do update the next time the user receives an update from the server for the users not matching the current filter.