### PR TITLE
Revert #704 and use alternate solution.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -896,7 +896,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix typo in cardinal directions list. (PR #688)
     * Shrink size of callsign list to prevent it from disappearing off the screen. (PR #692)
     * Clean up memory leak in FreeDV Reporter window. (PR #705)
-    * Fix issue causing delayed filter updates when going from tracking band to frequency. (PR #704)
+    * Fix issue causing delayed filter updates when going from tracking band to frequency. (PR #710)
     * Fix hanging issue with footswitch configured. (PR #707)
 2. Enhancements:
     * Add additional error reporting in case of PortAudio failures. (PR #695)

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -765,7 +765,12 @@ void FreeDVReporterDialog::OnFilterTrackingEnable(wxCommandEvent& event)
         freq = 
             (FilterFrequency)wxGetApp().appConfiguration.reportingConfiguration.freedvReporterBandFilter.get();
     }
-    
+
+    // Force refresh of filters since the user expects this to happen immediately after changing a
+    // filter setting.
+    filteredFrequency_ = 0;
+    currentBandFilter_ = BAND_ALL;
+
     setBandFilter(freq);
 }
 
@@ -1044,18 +1049,22 @@ void FreeDVReporterDialog::refreshQSYButtonState()
 
 void FreeDVReporterDialog::setBandFilter(FilterFrequency freq)
 {
-    filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
-    currentBandFilter_ = freq;
-
-    // Update displayed list based on new filter criteria.
-    clearAllEntries_(false);
-
-    std::map<int, int> colResizeList;
-    for (auto& kvp : allReporterData_)
+    if (filteredFrequency_ != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency ||
+        currentBandFilter_ != freq)
     {
-        addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
+        filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
+        currentBandFilter_ = freq;
+
+        // Update displayed list based on new filter criteria.
+        clearAllEntries_(false);
+
+        std::map<int, int> colResizeList;
+        for (auto& kvp : allReporterData_)
+        {
+            addOrUpdateListIfNotFiltered_(kvp.second, colResizeList);
+        }
+        resizeChangedColumns_(colResizeList);
     }
-    resizeChangedColumns_(colResizeList);
 }
 
 void FreeDVReporterDialog::sortColumn_(int col)


### PR DESCRIPTION
Per additional feedback, this PR reverts #704 and forces a re-filtering when changing the filter type instead. This should hopefully avoid the unnecessary flickering.