### PR TITLE
Disable 800XA when in RX Only mode.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -889,6 +889,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## TBD TBD 2024
+
+1. Bugfixes:
+    * Disable 800XA radio button when in RX Only mode. (PR #716)
+
 ## V1.9.9.1 April 2024
 
 1. Bugfixes:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1937,6 +1937,7 @@ void MainFrame::performFreeDVOn_()
                 m_rb700c->Disable();
                 m_rb700d->Disable();
                 m_rb700e->Disable();
+                m_rb800xa->Disable();
                 m_rb2020->Disable();
         #if defined(FREEDV_MODE_2020B)
                 m_rb2020b->Disable();


### PR DESCRIPTION
Fixes #714 by adding missed line to disable the 800XA radio button when configured for RX Only.