### PR TITLE
Fix bug preventing saving of the previously used path when playing back files.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -891,9 +891,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 ## V1.9.9.3 TBD 2024
 
-1. Enhancements:
+1. Bugfixes:
+    * Fix bug preventing saving of the previously used path when playing back files. (PR #729)
+2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
-2. Build system:
+3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
 
 ## V1.9.9.2 June 2024

--- a/src/playrec.cpp
+++ b/src/playrec.cpp
@@ -141,6 +141,9 @@ void MainFrame::OnPlayFileFromRadio(wxCommandEvent& event)
             wxMessageBox(strErr, wxT("Couldn't open sound file"), wxOK);
             return;
         }
+        
+        // Save path for future use
+        wxGetApp().appConfiguration.playFileFromRadioPath = tmpString;
 
         wxWindow * const ctrl = openFileDialog.GetExtraControl();
 
@@ -305,6 +308,9 @@ void MainFrame::OnRecFileFromRadio(wxCommandEvent& event)
             wxMessageBox(strErr, wxT("Couldn't open sound file"), wxOK);
             return;
         }
+        
+        // Save path for future use
+        wxGetApp().appConfiguration.recFileFromRadioPath = tmpString;
 
         SetStatusText(wxT("Recording file ") + fileName + wxT(" from radio") , 0);
         m_menuItemRecFileFromRadio->SetItemLabel(wxString(_("Stop Record File - From Radio...")));


### PR DESCRIPTION
During review of #728 I noticed that we weren't actually saving the previously used paths when playing back files through the application (i.e. Tools->Start Play/Record File...). This PR fixes that, allowing the user to start from the folder that was used before (and not requiring navigating back to it every time).