### PR TITLE
Add monitor volume adjustment

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -896,6 +896,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
     * Update configuration of the Voice Keyer feature based on user feedback. (PR #730)
+    * Add monitor volume adjustment. (PR #733)
 3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.5. (PR #731)

--- a/src/config/FreeDVConfiguration.cpp
+++ b/src/config/FreeDVConfiguration.cpp
@@ -107,7 +107,9 @@ FreeDVConfiguration::FreeDVConfiguration()
     , tabLayout("/MainFrame/TabLayout", _(""))
 
     , monitorVoiceKeyerAudio("/Monitor/VoiceKeyerAudio", false)
+    , monitorVoiceKeyerAudioVol("/Monitor/VoiceKeyerAudioVol", 0)
     , monitorTxAudio("/Monitor/TransmitAudio", false)
+    , monitorTxAudioVol("/Monitor/TransmitAudioVol", 0)
 
     , txRxDelayMilliseconds("/Audio/TxRxDelayMilliseconds", 0)
 
@@ -220,6 +222,8 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     
     load_(config, monitorVoiceKeyerAudio);
     load_(config, monitorTxAudio);
+    load_(config, monitorVoiceKeyerAudioVol);
+    load_(config, monitorTxAudioVol);
     
     quickRecordPath.setDefaultVal(documentsDir);
     load_(config, quickRecordPath);
@@ -312,6 +316,8 @@ void FreeDVConfiguration::save(wxConfigBase* config)
 
     save_(config, monitorVoiceKeyerAudio);
     save_(config, monitorTxAudio);
+    save_(config, monitorVoiceKeyerAudioVol);
+    save_(config, monitorTxAudioVol);
 
     save_(config, txRxDelayMilliseconds);
 

--- a/src/config/FreeDVConfiguration.h
+++ b/src/config/FreeDVConfiguration.h
@@ -118,7 +118,9 @@ public:
     ConfigurationDataElement<wxString> tabLayout;
 
     ConfigurationDataElement<bool> monitorVoiceKeyerAudio;
+    ConfigurationDataElement<float> monitorVoiceKeyerAudioVol;
     ConfigurationDataElement<bool> monitorTxAudio;
+    ConfigurationDataElement<float> monitorTxAudioVol;
 
     ConfigurationDataElement<int> txRxDelayMilliseconds;
 

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(fdv_gui_dialogs STATIC
     dlg_filter.cpp
     dlg_options.cpp
     dlg_ptt.cpp
-    freedv_reporter.cpp)
+    freedv_reporter.cpp
+    monitor_volume_adj.cpp)
 
 target_include_directories(fdv_gui_dialogs PRIVATE ${CODEC2_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/../.. ${CMAKE_CURRENT_BINARY_DIR}/../..)
 

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -30,12 +30,9 @@ MonitorVolumeAdjPopup::MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
     : wxPopupTransientWindow(parent)
     , configVal_(configVal)
 {
-    wxStaticBoxSizer* mainSizer = new wxStaticBoxSizer(wxVERTICAL, this);
+    wxStaticBoxSizer* mainSizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Monitor volume (dB)"));
     
-    wxStaticText* controlLabel = new wxStaticText(mainSizer->GetStaticBox(), wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
-    mainSizer->Add(controlLabel, 0, wxALL | wxEXPAND, 2);
-    
-    volumeSlider_ = new wxSlider(mainSizer->GetStaticBox(), wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
+    volumeSlider_ = new wxSlider(mainSizer->GetStaticBox(), wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxSize(250, -1), wxSL_AUTOTICKS | wxSL_LABELS);
     mainSizer->Add(volumeSlider_, 0, wxALL | wxEXPAND, 2);
         
     SetSizerAndFit(mainSizer);
@@ -53,7 +50,7 @@ MonitorVolumeAdjPopup::MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
 
 MonitorVolumeAdjPopup::~MonitorVolumeAdjPopup()
 {
-    // TBD
+    volumeSlider_->Disconnect(wxEVT_SLIDER, wxCommandEventHandler(MonitorVolumeAdjPopup::OnSliderAdjusted), NULL, this);
 }
 
 void MonitorVolumeAdjPopup::OnSliderAdjusted(wxCommandEvent& event)

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -19,6 +19,7 @@
 //
 //==========================================================================
 
+#include <wx/stattext.h>
 #include <wx/sizer.h>
 #include "monitor_volume_adj.h"
 

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -23,7 +23,7 @@
 #include <wx/sizer.h>
 #include "monitor_volume_adj.h"
 
-MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal )
+MonitorVolumeAdjPopup::MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal )
     : wxPopupTransientWindow(parent)
     , configVal_(configVal)
 {
@@ -39,7 +39,7 @@ MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
     Layout();
     
     // Link event handlers
-    volumeSlider_->Connect(wxEVT_SLIDER, wxCommandEventHandler(MontiorVolumeAdjPopup::OnSliderAdjusted), NULL, this);
+    volumeSlider_->Connect(wxEVT_SLIDER, wxCommandEventHandler(MonitorVolumeAdjPopup::OnSliderAdjusted), NULL, this);
     
     // Make popup show up to the left of (and above) mouse cursor position
     wxPoint pt = wxGetMousePosition();
@@ -48,12 +48,12 @@ MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
     SetPosition( pt );
 }
 
-MontiorVolumeAdjPopup::~MontiorVolumeAdjPopup()
+MonitorVolumeAdjPopup::~MonitorVolumeAdjPopup()
 {
     // TBD
 }
 
-void MontiorVolumeAdjPopup::OnSliderAdjusted(wxCommandEvent& event)
+void MonitorVolumeAdjPopup::OnSliderAdjusted(wxCommandEvent& event)
 {
     configVal_ = volumeSlider_->GetValue();
 }

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -22,19 +22,23 @@
 #include <wx/sizer.h>
 #include "monitor_volume_adj.h"
 
-MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent )
+MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal )
     : wxPopupTransientWindow(parent)
+    , configVal_(configVal)
 {
     wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
     
     wxStaticText* controlLabel = new wxStaticText(this, wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
     mainSizer->Add(controlLabel, 0, wxALL | wxEXPAND, 2);
     
-    volumeSlider_ = new wxSlider(this, wxID_ANY, 0, -20, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
+    volumeSlider_ = new wxSlider(this, wxID_ANY, configVal, -20, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
     mainSizer->Add(volumeSlider_, 0, wxALL | wxEXPAND, 2);
     
     SetSizerAndFit(mainSizer);
     Layout();
+    
+    // Link event handlers
+    volumeSlider_->Connect(wxEVT_SLIDER, wxCommandEventHandler(MontiorVolumeAdjPopup::OnSliderAdjusted), NULL, this);
     
     // Make popup show up to the left of (and above) mouse cursor position
     wxPoint pt = wxGetMousePosition();
@@ -46,4 +50,9 @@ MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent )
 MontiorVolumeAdjPopup::~MontiorVolumeAdjPopup()
 {
     // TBD
+}
+
+void MontiorVolumeAdjPopup::OnSliderAdjusted(wxCommandEvent& event)
+{
+    configVal_ = volumeSlider_->GetValue();
 }

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -1,0 +1,49 @@
+//==========================================================================
+// Name:            monitor_volume_adj.cpp
+// Purpose:         Popup to allow adjustment of monitor volume
+// Created:         Jul 12, 2024
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#include <wx/sizer.h>
+#include "monitor_volume_adj.h"
+
+MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent )
+    : wxPopupTransientWindow(parent)
+{
+    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+    
+    wxStaticText* controlLabel = new wxStaticText(this, wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
+    mainSizer->Add(controlLabel, 0, wxALL | wxEXPAND, 2);
+    
+    volumeSlider_ = new wxSlider(this, wxID_ANY, 0, -20, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
+    mainSizer->Add(volumeSlider_, 0, wxALL | wxEXPAND, 2);
+    
+    SetSizerAndFit(mainSizer);
+    Layout();
+    
+    // Make popup show up to the left of (and above) mouse cursor position
+    wxPoint pt = wxGetMousePosition();
+    wxSize sz = GetSize();
+    pt -= wxPoint(sz.GetWidth(), sz.GetHeight());
+    SetPosition( pt );
+}
+
+MontiorVolumeAdjPopup::~MontiorVolumeAdjPopup()
+{
+    // TBD
+}

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -21,20 +21,23 @@
 
 #include <wx/stattext.h>
 #include <wx/sizer.h>
+#include <wx/panel.h>
+#include <wx/statbox.h>
+
 #include "monitor_volume_adj.h"
 
 MonitorVolumeAdjPopup::MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal )
     : wxPopupTransientWindow(parent)
     , configVal_(configVal)
 {
-    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+    wxStaticBoxSizer* mainSizer = new wxStaticBoxSizer(wxVERTICAL, this);
     
-    wxStaticText* controlLabel = new wxStaticText(this, wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
+    wxStaticText* controlLabel = new wxStaticText(mainSizer->GetStaticBox(), wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
     mainSizer->Add(controlLabel, 0, wxALL | wxEXPAND, 2);
     
-    volumeSlider_ = new wxSlider(this, wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
+    volumeSlider_ = new wxSlider(mainSizer->GetStaticBox(), wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
     mainSizer->Add(volumeSlider_, 0, wxALL | wxEXPAND, 2);
-    
+        
     SetSizerAndFit(mainSizer);
     Layout();
     

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -31,7 +31,7 @@ MontiorVolumeAdjPopup::MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
     wxStaticText* controlLabel = new wxStaticText(this, wxID_ANY, wxT("Monitor volume (dB):"), wxDefaultPosition, wxDefaultSize, 0);
     mainSizer->Add(controlLabel, 0, wxALL | wxEXPAND, 2);
     
-    volumeSlider_ = new wxSlider(this, wxID_ANY, configVal, -20, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
+    volumeSlider_ = new wxSlider(this, wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS | wxSL_LABELS);
     mainSizer->Add(volumeSlider_, 0, wxALL | wxEXPAND, 2);
     
     SetSizerAndFit(mainSizer);

--- a/src/gui/dialogs/monitor_volume_adj.h
+++ b/src/gui/dialogs/monitor_volume_adj.h
@@ -28,13 +28,13 @@
 #include "config/ConfigurationDataElement.h"
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
-// Class MontiorVolumeAdjPopup
+// Class MonitorVolumeAdjPopup
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
-class MontiorVolumeAdjPopup : public wxPopupTransientWindow
+class MonitorVolumeAdjPopup : public wxPopupTransientWindow
 {
     public:        
-        MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal );
-        ~MontiorVolumeAdjPopup();
+        MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal );
+        ~MonitorVolumeAdjPopup();
         
     protected:
         void OnSliderAdjusted(wxCommandEvent& event);

--- a/src/gui/dialogs/monitor_volume_adj.h
+++ b/src/gui/dialogs/monitor_volume_adj.h
@@ -1,0 +1,43 @@
+//==========================================================================
+// Name:            monitor_volume_adj.h
+// Purpose:         Popup to allow adjustment of monitor volume
+// Created:         Jul 12, 2024
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#ifndef __MONITOR_VOLUME_ADJ__
+#define __MONITOR_VOLUME_ADJ__
+
+#include <wx/popupwin.h>
+#include <wx/slider.h>
+
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
+// Class MontiorVolumeAdjPopup
+//-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
+class MontiorVolumeAdjPopup : public wxPopupTransientWindow
+{
+    public:        
+        MontiorVolumeAdjPopup( wxWindow* parent );
+        ~MontiorVolumeAdjPopup();
+        
+    protected:
+        
+    private:
+        wxSlider* volumeSlider_;
+};
+
+#endif // __MONITOR_VOLUME_ADJ__

--- a/src/gui/dialogs/monitor_volume_adj.h
+++ b/src/gui/dialogs/monitor_volume_adj.h
@@ -25,19 +25,23 @@
 #include <wx/popupwin.h>
 #include <wx/slider.h>
 
+#include "config/ConfigurationDataElement.h"
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 // Class MontiorVolumeAdjPopup
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 class MontiorVolumeAdjPopup : public wxPopupTransientWindow
 {
     public:        
-        MontiorVolumeAdjPopup( wxWindow* parent );
+        MontiorVolumeAdjPopup( wxWindow* parent, ConfigurationDataElement<float>& configVal );
         ~MontiorVolumeAdjPopup();
         
     protected:
+        void OnSliderAdjusted(wxCommandEvent& event);
         
     private:
         wxSlider* volumeSlider_;
+        ConfigurationDataElement<float>& configVal_;
 };
 
 #endif // __MONITOR_VOLUME_ADJ__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -760,16 +760,16 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     voiceKeyerPopupMenu_ = new wxMenu();
     assert(voiceKeyerPopupMenu_ != nullptr);
 
-    auto chooseVKFileMenuItem = voiceKeyerPopupMenu_->Append(wxID_ANY, _("&Use another voice keyer file..."));
+    chooseVKFileMenuItem_ = voiceKeyerPopupMenu_->Append(wxID_ANY, _("&Use another voice keyer file..."));
     voiceKeyerPopupMenu_->Connect(
-        chooseVKFileMenuItem->GetId(), wxEVT_COMMAND_MENU_SELECTED, 
+        chooseVKFileMenuItem_->GetId(), wxEVT_COMMAND_MENU_SELECTED, 
         wxCommandEventHandler(MainFrame::OnChooseAlternateVoiceKeyerFile),
         NULL,
         this);
         
-    auto recordNewVoiceKeyerFileMenuItem = voiceKeyerPopupMenu_->Append(wxID_ANY, _("&Record new voice keyer file..."));
+    recordNewVoiceKeyerFileMenuItem_ = voiceKeyerPopupMenu_->Append(wxID_ANY, _("&Record new voice keyer file..."));
     voiceKeyerPopupMenu_->Connect(
-        recordNewVoiceKeyerFileMenuItem->GetId(), wxEVT_COMMAND_MENU_SELECTED, 
+        recordNewVoiceKeyerFileMenuItem_->GetId(), wxEVT_COMMAND_MENU_SELECTED, 
         wxCommandEventHandler(MainFrame::OnRecordNewVoiceKeyerFile),
         NULL,
         this);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -784,6 +784,15 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
         NULL,
         this);
         
+    adjustMonitorVKVolMenuItem_ = voiceKeyerPopupMenu_->Append(wxID_ANY, _("Adjust Monitor Volume..."));
+    adjustMonitorVKVolMenuItem_->Enable(wxGetApp().appConfiguration.monitorVoiceKeyerAudio);
+    voiceKeyerPopupMenu_->Connect(
+        adjustMonitorVKVolMenuItem_->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+        wxCommandEventHandler(MainFrame::OnSetMonitorVKAudioVol),
+        NULL,
+        this
+        );
+        
     // Create PTT popup menu
     pttPopupMenu_ = new wxMenu();
     assert(pttPopupMenu_ != nullptr);
@@ -795,6 +804,15 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
         wxCommandEventHandler(MainFrame::OnSetMonitorTxAudio),
         NULL,
         this);
+        
+    adjustMonitorPttVolMenuItem_ = pttPopupMenu_->Append(wxID_ANY, _("Adjust Monitor Volume..."));
+    adjustMonitorPttVolMenuItem_->Enable(wxGetApp().appConfiguration.monitorTxAudio);
+    pttPopupMenu_->Connect(
+        adjustMonitorPttVolMenuItem_->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+        wxCommandEventHandler(MainFrame::OnSetMonitorTxAudioVol),
+        NULL,
+        this
+        );
 
     m_RxRunning = false;
 

--- a/src/main.h
+++ b/src/main.h
@@ -435,6 +435,9 @@ class MainFrame : public TopFrame
         void OnSetMonitorVKAudio( wxCommandEvent& event );
         void OnSetMonitorTxAudio( wxCommandEvent& event );
         
+        void OnSetMonitorVKAudioVol( wxCommandEvent& event );
+        void OnSetMonitorTxAudioVol( wxCommandEvent& event );
+        
     private:
         std::shared_ptr<IAudioDevice> rxInSoundDevice;
         std::shared_ptr<IAudioDevice> rxOutSoundDevice;
@@ -480,6 +483,8 @@ class MainFrame : public TopFrame
         
         wxMenu* voiceKeyerPopupMenu_;
         wxMenu* pttPopupMenu_;
+        wxMenuItem* adjustMonitorPttVolMenuItem_;
+        wxMenuItem* adjustMonitorVKVolMenuItem_;
         
         int         getSoundCardIDFromName(wxString& name, bool input);
         bool        validateSoundCardSetup();

--- a/src/main.h
+++ b/src/main.h
@@ -485,6 +485,8 @@ class MainFrame : public TopFrame
         wxMenu* pttPopupMenu_;
         wxMenuItem* adjustMonitorPttVolMenuItem_;
         wxMenuItem* adjustMonitorVKVolMenuItem_;
+        wxMenuItem* chooseVKFileMenuItem_;
+        wxMenuItem* recordNewVoiceKeyerFileMenuItem_;
         
         int         getSoundCardIDFromName(wxString& name, bool input);
         bool        validateSoundCardSetup();

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -842,7 +842,7 @@ void MainFrame::OnSetMonitorTxAudio( wxCommandEvent& event )
 
 void MainFrame::OnSetMonitorTxAudioVol( wxCommandEvent& event )
 {
-    auto popup = new MontiorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorTxAudioVol);
+    auto popup = new MonitorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorTxAudioVol);
     popup->Popup();
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -842,7 +842,7 @@ void MainFrame::OnSetMonitorTxAudio( wxCommandEvent& event )
 
 void MainFrame::OnSetMonitorTxAudioVol( wxCommandEvent& event )
 {
-    auto popup = new MontiorVolumeAdjPopup(this);
+    auto popup = new MontiorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorTxAudioVol);
     popup->Popup();
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -19,6 +19,7 @@
 #include "gui/dialogs/dlg_options.h"
 #include "gui/dialogs/dlg_ptt.h"
 #include "gui/dialogs/freedv_reporter.h"
+#include "gui/dialogs/monitor_volume_adj.h"
 
 #if defined(WIN32)
 #include "rig_control/omnirig/OmniRigController.h"
@@ -836,6 +837,13 @@ int MainApp::FilterEvent(wxEvent& event)
 void MainFrame::OnSetMonitorTxAudio( wxCommandEvent& event )
 {
     wxGetApp().appConfiguration.monitorTxAudio = event.IsChecked();
+    adjustMonitorPttVolMenuItem_->Enable(wxGetApp().appConfiguration.monitorTxAudio);
+}
+
+void MainFrame::OnSetMonitorTxAudioVol( wxCommandEvent& event )
+{
+    auto popup = new MontiorVolumeAdjPopup(this);
+    popup->Popup();
 }
 
 //-------------------------------------------------------------------------

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -385,6 +385,21 @@ void TxRxThread::initializePipeline_()
             
             auto monitorPipeline = new AudioPipeline(inputSampleRate_, outputSampleRate_);
             monitorPipeline->appendPipelineStep(equalizedMicAudioLink_->getOutputPipelineStep());
+            
+            auto monitorLevelStep = std::make_shared<LevelAdjustStep>(outputSampleRate_, [&]() {
+                double volInDb = 0;
+                if (g_voice_keyer_tx && wxGetApp().appConfiguration.monitorVoiceKeyerAudio)
+                {
+                    volInDb = wxGetApp().appConfiguration.monitorVoiceKeyerAudioVol;
+                }
+                else
+                {
+                    volInDb = wxGetApp().appConfiguration.monitorTxAudioVol;
+                }
+                
+                return std::exp(volInDb/20.0f * std::log(10.0f));
+            });
+            monitorPipeline->appendPipelineStep(monitorLevelStep);
 
             auto muteStep = new MuteStep(outputSampleRate_);
             

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "main.h"
+#include "gui/dialogs/monitor_volume_adj.h"
 
 extern SNDFILE            *g_sfRecMicFile;
 bool                g_recVoiceKeyerFile;
@@ -168,6 +169,14 @@ void MainFrame::OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& event )
 void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )
 {
     wxGetApp().appConfiguration.monitorVoiceKeyerAudio = event.IsChecked();
+    adjustMonitorVKVolMenuItem_->Enable(wxGetApp().appConfiguration.monitorVoiceKeyerAudio);
+    
+}
+
+void MainFrame::OnSetMonitorVKAudioVol( wxCommandEvent& event )
+{
+    auto popup = new MontiorVolumeAdjPopup(this);
+    popup->Popup();
 }
 
 extern SNDFILE *g_sfPlayFile;

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -158,12 +158,15 @@ void MainFrame::OnChooseAlternateVoiceKeyerFile( wxCommandEvent& event )
 
 void MainFrame::OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& event )
 {
-    // Only handle right-click if idle
-    if (vk_state == VK_IDLE && !m_btnTogPTT->GetValue())
-    {
-        auto sz = m_togBtnVoiceKeyer->GetSize();
-        m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
-    }
+    // Only enable VK file selection on idle
+    bool enabled = vk_state == VK_IDLE && !m_btnTogPTT->GetValue();
+    chooseVKFileMenuItem_->Enable(enabled);
+    recordNewVoiceKeyerFileMenuItem_->Enable(enabled);
+    
+    // Trigger right-click menu popup in a location that will prevent it from
+    // ending up off the screen.
+    auto sz = m_togBtnVoiceKeyer->GetSize();
+    m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
 }
 
 void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -178,7 +178,7 @@ void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )
 
 void MainFrame::OnSetMonitorVKAudioVol( wxCommandEvent& event )
 {
-    auto popup = new MontiorVolumeAdjPopup(this);
+    auto popup = new MontiorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorVoiceKeyerAudioVol);
     popup->Popup();
 }
 

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -178,7 +178,7 @@ void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )
 
 void MainFrame::OnSetMonitorVKAudioVol( wxCommandEvent& event )
 {
-    auto popup = new MontiorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorVoiceKeyerAudioVol);
+    auto popup = new MonitorVolumeAdjPopup(this, wxGetApp().appConfiguration.monitorVoiceKeyerAudioVol);
     popup->Popup();
 }
 


### PR DESCRIPTION
Resolves #732 by adding new right-click menu items for adjusting monitoring volume under PTT and Voice Keyer. Example:

<img width="397" alt="image" src="https://github.com/user-attachments/assets/75049825-07de-448c-9d47-186f067a725e"><br/>
<img width="379" alt="image" src="https://github.com/user-attachments/assets/8bfe8b8d-303b-41e2-8264-58ea6258c886">

Clicking outside of the box that appears will close it. Additionally, updates here are live (i.e. if you're transmitting, you can hear the volume changing as you adjust the slider).