### PR TITLE
If provided by user, add config file to titlebar.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,6 +204,12 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
         fprintf(stderr, "Loading configuration from %s\n", (const char*)configPath.ToUTF8());
         pConfig = new wxFileConfig(wxT("FreeDV"), wxT("CODEC2-Project"), configPath, configPath, wxCONFIG_USE_LOCAL_FILE);
         wxConfigBase::Set(pConfig);
+        
+        // On Linux/macOS, this replaces $HOME with "~" to shorten the title a bit.
+        wxFileName fn(configPath);
+        fn.ReplaceEnvVariable("HOME", "~");
+        
+        customConfigFileName = fn.GetShortPath();
     }
     pConfig->SetRecordDefaults();
     
@@ -240,7 +246,7 @@ bool MainApp::OnInit()
     // displayed. But it doesn't when built from command line.  Why?
 
     frame->m_auiNbookCtrl->ChangeSelection(0);
-    frame->Layout();
+    frame->Layout();    
     frame->Show();
     g_parent =frame;
 
@@ -648,6 +654,12 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     pthread_setname_np(pthread_self(), "FreeDV GUI");
 #endif // defined(__linux__)
 
+    // Add config file name to title bar if provided at the command line.
+    if (wxGetApp().customConfigFileName != "")
+    {
+        SetTitle(wxString::Format("%s (%s)", _("FreeDV ") + _(FREEDV_VERSION), wxGetApp().customConfigFileName));
+    }
+    
     m_reporterDialog = nullptr;
     m_filterDialog = nullptr;
 

--- a/src/main.h
+++ b/src/main.h
@@ -168,6 +168,7 @@ class MainApp : public wxApp
         bool                    CanAccessSerialPort(std::string portName);
         
         FreeDVConfiguration appConfiguration;
+        wxString customConfigFileName;
         
         // PTT -----------------------------------    
         unsigned int        m_intHamlibRig;


### PR DESCRIPTION
Resolves #737 by adding the path of a custom config file to the title bar. For example, if FreeDV is started via the following:

```
freedv -f `pwd`/test.conf
```

the titlebar could look something like this:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/f11d0169-6e3d-479e-b20d-9783d82315bb">
