### PR TITLE
Adjust waterfall/spectrum tooltip based on issue #741.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -899,6 +899,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add monitor volume adjustment. (PR #733)
     * Avoid modifying the audio device configuration without the user explicitly doing so. (PR #735)
     * If provided by user, add config file to titlebar. (PR #738)
+    * Minor adjustments to spectrum/waterfall tooltips. (PR #743)
 3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.5. (PR #731)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -674,7 +674,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     
     // Add Waterfall Plot window
     m_panelWaterfall = new PlotWaterfall((wxFrame*) m_auiNbookCtrl, false, 0);
-    m_panelWaterfall->SetToolTip(_("Double-click to tune"));
+    m_panelWaterfall->SetToolTip(_("Double click to tune, middle click to re-center"));
     m_auiNbookCtrl->AddPage(m_panelWaterfall, _("Waterfall"), true, wxNullBitmap);
 
     // Add Spectrum Plot window
@@ -688,7 +688,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     // Actual Spectrum plot
     m_panelSpectrum = new PlotSpectrum(spectrumPanel, g_avmag,
                                        MODEM_STATS_NSPEC*((float)MAX_F_HZ/MODEM_STATS_MAX_F_HZ));
-    m_panelSpectrum->SetToolTip(_("Double-click to tune"));
+    m_panelSpectrum->SetToolTip(_("Double click to tune, middle click to re-center"));
     spectrumPanelSizer->Add(m_panelSpectrum, 0, wxALL | wxEXPAND, 5);
     
     // Spectrum plot control interface


### PR DESCRIPTION
Adds "middle click to re-center" text to the tooltip shown when over the waterfall and spectrum plots.