### PR TITLE
Set timeout for Hamlib comms to avoid GUI getting stuck.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -893,6 +893,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Fix bug preventing saving of the previously used path when playing back files. (PR #729)
+    * Set timeout for Hamlib comms to avoid GUI getting stuck. (PR #746)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
     * Update configuration of the Voice Keyer feature based on user feedback. (PR #730)

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -286,6 +286,10 @@ void HamlibRigController::connectImpl_()
             break;
     }
     
+    rig_set_conf(rig_, rig_token_lookup(rig_, "timeout"), "1000");
+    rig_set_conf(rig_, rig_token_lookup(rig_, "retry"), "1");
+    rig_set_conf(rig_, rig_token_lookup(rig_, "timeout_retry"), "1");
+    
     auto result = rig_open(rig_);
     if (result == RIG_OK) 
     {


### PR DESCRIPTION
Resolves #742 by setting a timeout when connecting to the radio via Hamlib. Note that this requires hamlib 4.6~git to have full effect (especially with Icom radios).