### PR TITLE
Fix assertion failure due to VK path inadvertantly remaining in filename

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -895,7 +895,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix bug preventing saving of the previously used path when playing back files. (PR #729)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
-    * Update configuration of the Voice Keyer feature based on user feedback. (PR #730)
+    * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746)
     * Add monitor volume adjustment. (PR #733)
     * Avoid modifying the audio device configuration without the user explicitly doing so. (PR #735)
     * If provided by user, add config file to titlebar. (PR #738)

--- a/src/config/FreeDVConfiguration.cpp
+++ b/src/config/FreeDVConfiguration.cpp
@@ -193,7 +193,14 @@ void FreeDVConfiguration::load(wxConfigBase* config)
         voiceKeyerWaveFilePath = path;
         voiceKeyerWaveFile = name;
     }
-    
+    else
+    {
+        // Make sure path isn't in the filename
+        voiceKeyerWaveFile->Replace(voiceKeyerWaveFilePath, "");
+        voiceKeyerWaveFile->Replace("/", "");
+        voiceKeyerWaveFile->Replace("\\", "");
+    }
+
     load_(config, voiceKeyerRxPause);
     load_(config, voiceKeyerRepeats);
     


### PR DESCRIPTION
A wxWidgets assertion window was reported during RADAE testing involving the voice keyer changes in #730. This is due to previous migration logic somehow not removing the path from the filename on load.