### PR TITLE
Suppress spurious warnings from Opus/RADE compilation.

### DIFF
--- a/cmake/BuildOpus.cmake
+++ b/cmake/BuildOpus.cmake
@@ -80,6 +80,11 @@ set_target_properties(opus PROPERTIES
     IMPORTED_IMPLIB   "${BINARY_DIR}/.libs/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}"
 )
 
-include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include)
+set(FARGAN_CONFIG_H_FILE "${SOURCE_DIR}/config.h")
+set(FARGAN_ARM_CONFIG_H_FILE "")
+set(FARGAN_X86_CONFIG_H_FILE "")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/fargan_config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/fargan_config.h")
+include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
 list(APPEND FREEDV_PACKAGE_SEARCH_PATHS ${BINARY_DIR}/.libs)
 endif(APPLE AND BUILD_OSX_UNIVERSAL)

--- a/cmake/BuildOpus.cmake
+++ b/cmake/BuildOpus.cmake
@@ -32,8 +32,11 @@ ExternalProject_Add(build_opus_arm
 ExternalProject_Get_Property(build_opus_arm BINARY_DIR)
 ExternalProject_Get_Property(build_opus_arm SOURCE_DIR)
 set(OPUS_ARM_BINARY_DIR ${BINARY_DIR})
+set(OPUS_ARM_SOURCE_DIR ${SOURCE_DIR})
 ExternalProject_Get_Property(build_opus_x86 BINARY_DIR)
+ExternalProject_Get_Property(build_opus_x86 SOURCE_DIR)
 set(OPUS_X86_BINARY_DIR ${BINARY_DIR})
+set(OPUS_X86_SOURCE_DIR ${SOURCE_DIR})
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}
@@ -44,7 +47,12 @@ add_custom_target(
     libopus.a
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include)
+set(FARGAN_CONFIG_H_FILE "${SOURCE_DIR}/config.h")
+set(FARGAN_ARM_CONFIG_H_FILE "${OPUS_ARM_SOURCE_DIR}/config.h")
+set(FARGAN_X86_CONFIG_H_FILE "${OPUS_X86_SOURCE_DIR}/config.h")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/fargan_config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/fargan_config.h")
+include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(opus STATIC IMPORTED)
 add_dependencies(opus libopus.a)

--- a/fargan_config.h.in
+++ b/fargan_config.h.in
@@ -1,0 +1,15 @@
+#ifndef FARGAN_CONFIG_H
+#define FARGAN_CONFIG_H
+
+// Include Opus config.h to suppress warnings
+#ifdef __APPLE__
+#ifdef __aarch64__
+#include "@FARGAN_ARM_CONFIG_H_FILE@"
+#else
+#include "@FARGAN_X86_CONFIG_H_FILE@"
+#endif // __aarch64__
+#else
+#include "@FARGAN_CONFIG_H_FILE@"
+#endif // __APPLE__
+
+#endif // FARGAN_CONFIG_H

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -144,7 +144,11 @@ void FreeDVInterface::start(int txMode, int fifoSizeMs, bool singleRxThread, boo
             txMode_ = mode;
             modemStatsIndex_ = 0;
 
-            rade_ = rade_open("TBD");
+            // Suppress const string warning.
+            // TBD - modelFile may be used by RADE in the future!
+            char modelFile[1];
+            modelFile[0] = 0;
+            rade_ = rade_open(modelFile);
             assert(rade_ != nullptr);
 
             float zeros[320] = {0};

--- a/src/freedv_interface.h
+++ b/src/freedv_interface.h
@@ -45,6 +45,7 @@
 // TBD - need to wrap in "extern C" to avoid linker errors
 extern "C" 
 {
+    #include "fargan_config.h"
     #include "fargan.h"
     #include "lpcnet.h"
 }


### PR DESCRIPTION
Suppresses warnings that incorrectly imply that FARGAN is not using any CPU optimizations.