### PR TITLE
Fix stuttering during EOO TX.

### DIFF
--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -13,7 +13,7 @@ ExternalProject_Add(build_rade
    SOURCE_DIR rade_src
    BINARY_DIR rade_build
    GIT_REPOSITORY https://github.com/drowe67/radae.git
-   GIT_TAG dr-timing-bug
+   GIT_TAG main
    CMAKE_ARGS ${RADE_CMAKE_ARGS}
    #CMAKE_CACHE_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
    INSTALL_COMMAND ""

--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -13,7 +13,7 @@ ExternalProject_Add(build_rade
    SOURCE_DIR rade_src
    BINARY_DIR rade_build
    GIT_REPOSITORY https://github.com/drowe67/radae.git
-   GIT_TAG dr-cport
+   GIT_TAG dr-timing-bug
    CMAKE_ARGS ${RADE_CMAKE_ARGS}
    #CMAKE_CACHE_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
    INSTALL_COMMAND ""

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -907,6 +907,7 @@ void MainFrame::togglePTT(void) {
             auto diff = highResClock.now() - before;
             if (diff >= std::chrono::milliseconds(1000) || (g_outfifo1_empty != sample))
             {
+                log_info("All TX finished, going out of PTT");
                 break;
             }
 

--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -91,6 +91,8 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
             assert(outputSamples != nullptr);
 
             codec2_fifo_read(outputSampleFifo_, outputSamples, *numOutputSamples);
+
+            log_info("Returning %d EOO samples (remaining in FIFO: %d)", *numOutputSamples, codec2_fifo_used(outputSampleFifo_));
         }
 
         return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());;
@@ -171,5 +173,9 @@ void RADETransmitStep::restartVocoder()
         eooOutShort[index] = eooOut[index].real * 32767;
     }
 
-    codec2_fifo_write(outputSampleFifo_, eooOutShort, numEOOSamples);
+    log_info("Queueing %d EOO samples to output FIFO", numEOOSamples);
+    if (codec2_fifo_write(outputSampleFifo_, eooOutShort, numEOOSamples) != 0)
+    {
+        log_warn("Could not queue EOO samples (remaining space in FIFO = %d)", codec2_fifo_free(outputSampleFifo_));
+    }
 }

--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -80,6 +80,21 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
 {
     short* outputSamples = nullptr;
     *numOutputSamples = 0;
+
+    if (numInputSamples == 0)
+    {
+        // Special case logic for EOO -- make sure we only send 20ms worth at a time
+        *numOutputSamples = std::min(codec2_fifo_used(outputSampleFifo_), (int)(8000*.02));
+        if (*numOutputSamples > 0)
+        {
+            outputSamples = new short[*numOutputSamples];
+            assert(outputSamples != nullptr);
+
+            codec2_fifo_read(outputSampleFifo_, outputSamples, *numOutputSamples);
+        }
+
+        return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());;
+    }
     
     short* inputPtr = inputSamples.get();
     while (numInputSamples > 0 && inputPtr != nullptr)

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -267,15 +267,6 @@ void TxRxThread::initializePipeline_()
         // TX attenuation step
         auto txAttenuationStep = new LevelAdjustStep(outputSampleRate_, []() {
             double dbLoss = g_txLevel / 10.0;
-            
-#if 0
-            if (freedvInterface.getTxMode() == FREEDV_MODE_RADE)
-            {
-                // Attenuate by 4 dB as there's no BPF; anything louder distorts the signal
-                dbLoss -= 4.0;
-            }
-#endif // 0
-            
             double scaleFactor = exp(dbLoss/20.0 * log(10.0));
             return scaleFactor; 
         });

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -667,8 +667,11 @@ void TxRxThread::txProcessing_()
                     auto outputSamples = pipeline_->execute(inputSamplesPtr, 0, &nout);
                     if (nout > 0 && outputSamples.get() != nullptr)
                     {
-                        log_info("Injecting %d samples of EOO into TX stream", nout);
-                        codec2_fifo_write(cbData->outfifo1, outputSamples.get(), nout);
+                        log_debug("Injecting %d samples of resampled EOO into TX stream", nout);
+                        if (codec2_fifo_write(cbData->outfifo1, outputSamples.get(), nout) != 0)
+                        {
+                            log_warn("Could not inject resampled EOO samples (space remaining in FIFO = %d)", cbData->outfifo1);
+                        }
                     }
                 }
                 break;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -651,10 +651,13 @@ void TxRxThread::txProcessing_()
             int nread = codec2_fifo_read(cbData->infifo2, insound_card, nsam_in_48);            
             if (nread != 0 && endingTx)
             {
-                if (freedvInterface.getCurrentMode() >= FREEDV_MODE_RADE)
+                if (freedvInterface.getCurrentMode() >= FREEDV_MODE_RADE && !hasEooBeenSent_)
                 {
+                    log_info("Triggering sending of EOO");
+                    
                     // Special case for handling RADE EOT
                     freedvInterface.restartTxVocoder();
+                    hasEooBeenSent_ = true;
 
                     short* inputSamples = new short[1];
                     auto inputSamplesPtr = std::shared_ptr<short>(inputSamples, std::default_delete<short[]>());
@@ -668,6 +671,10 @@ void TxRxThread::txProcessing_()
                     } while (nout > 0);
                 }
                 break;
+            }
+            else
+            {
+                hasEooBeenSent_ = false;
             }
             
             short* inputSamples = new short[nsam_in_48];

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -47,6 +47,7 @@ public:
         , inputSampleRate_(inputSampleRate)
         , outputSampleRate_(outputSampleRate)
         , equalizedMicAudioLink_(micAudioLink)
+        , hasEooBeenSent_(false)
     { 
         assert(inputSampleRate_ > 0);
         assert(outputSampleRate_ > 0);
@@ -72,6 +73,7 @@ private:
     int inputSampleRate_;
     int outputSampleRate_;
     LinkStep* equalizedMicAudioLink_;
+    bool hasEooBeenSent_;
     
     void initializePipeline_();
     void txProcessing_();

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -11,6 +11,7 @@ extern SNDFILE            *g_sfRecMicFile;
 bool                g_recVoiceKeyerFile;
 extern bool g_voice_keyer_tx;
 extern wxMutex g_mutexProtectingCallbackData;
+extern bool endingTx;
 
 void MainFrame::OnTogBtnVoiceKeyerClick (wxCommandEvent& event)
 {
@@ -283,6 +284,7 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         if (vk_event == VK_SPACE_BAR) {
             m_btnTogPTT->SetValue(false); 
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
+            endingTx = true;
             togglePTT();
             m_togBtnVoiceKeyer->SetValue(false);
             m_togBtnVoiceKeyer->SetBackgroundColour(wxNullColour);
@@ -293,7 +295,8 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         if (vk_event == VK_PLAY_FINISHED) {
             m_btnTogPTT->SetValue(false); 
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
-            togglePTT();
+            endingTx = true;
+            CallAfter([&]() { togglePTT(); });
             vk_repeat_counter++;
             if (vk_repeat_counter > vk_repeats) {
                 m_togBtnVoiceKeyer->SetValue(false);
@@ -371,6 +374,7 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
 
         m_btnTogPTT->SetValue(false); 
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
+        endingTx = true;
         togglePTT();
         m_togBtnVoiceKeyer->SetValue(false);
         m_togBtnVoiceKeyer->SetBackgroundColour(wxNullColour);


### PR DESCRIPTION
Resolves the following EOO related transmit issues:

1. Prevents multiple transmission of EOO by adding logic to suppress its generation during a TX cycle once it's requested.
2. Fixes issue preventing EOO from being transmitted when using the voice keyer.
3. Adjusts scaling of EOO to match regular RADE signal (i.e. multiply by 16383 instead of 32767).