### PR TITLE
Suppress RADE output based on configured log verbosity.

### DIFF
--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -152,7 +152,7 @@ void FreeDVInterface::start(int txMode, int fifoSizeMs, bool singleRxThread, boo
             // TBD - modelFile may be used by RADE in the future!
             char modelFile[1];
             modelFile[0] = 0;
-            rade_ = rade_open(modelFile, RADE_USE_C_ENCODER | RADE_USE_C_DECODER);
+            rade_ = rade_open(modelFile, RADE_USE_C_ENCODER | RADE_USE_C_DECODER | (wxGetApp().appConfiguration.debugVerbose ? 0 : RADE_VERBOSE_0));
             assert(rade_ != nullptr);
 
             float zeros[320] = {0};


### PR DESCRIPTION
Resolves #784 by suppressing RADE logging based on whether the user has enabled verbose logs or not.