### PR TITLE
Detect if microphone permissions have been granted in Windows.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -904,6 +904,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * If provided by user, add config file to titlebar. (PR #738)
     * Minor adjustments to spectrum/waterfall tooltips. (PR #743)
     * Implement new logging framework. (PR #773)
+    * Windows: Detect whether microphone permissions have been granted and display error if not. (PR #790)
 3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.6. (PR #748)

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -10,4 +10,10 @@ add_library(fdv_os_wrapper STATIC
     ${OS_WRAP_FILES}
 )
 
+if(BOOTSTRAP_WXWIDGETS)
+    add_dependencies(fdv_os_wrapper wx::core wx::base wx::aui wx::html wx::net wx::adv wx::propgrid wx::xrc)
+    target_compile_definitions(fdv_os_wrapper PRIVATE ${WXBUILD_BUILD_DEFS})
+    target_include_directories(fdv_os_wrapper PRIVATE ${WXBUILD_INCLUDES})
+endif(BOOTSTRAP_WXWIDGETS)
+
 target_include_directories(fdv_os_wrapper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/..)

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(APPLE)
     set(OS_WRAP_FILES osx_interface.mm)
-else(APPLE)
+elseif(WIN32)
+    set(OS_WRAP_FILES windows_interface.cpp)
+else()
     set(OS_WRAP_FILES osx_stubs.cpp)
-endif(APPLE)
+endif()
 
 add_library(fdv_os_wrapper STATIC
     ${OS_WRAP_FILES}

--- a/src/os/osx_stubs.cpp
+++ b/src/os/osx_stubs.cpp
@@ -36,9 +36,7 @@ std::string GetOperatingSystemString()
 {
 #ifdef __linux__
     return "linux";
-#elif _WIN32
-    return "windows";
 #else
     return "other";
-#endif // __linux__ || _WIN32
+#endif // __linux__
 }

--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -22,6 +22,7 @@
 
 #include "os_interface.h"
 
+#include <wx/wx.h>
 #include <wx/msw/registry.h>
 
 void VerifyMicrophonePermissions(std::promise<bool>& micPromise)

--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -29,15 +29,18 @@ void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
 {
     bool microphonePermissionsGranted = false;
     
-    wxRegKey currentUserMicrophoneKey(wxRegKey::HKCU, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone");
+    // General Microphone enable/disable (applies to all users)
+    wxRegKey localMachineMicrophoneKey(wxRegKey::HKLM, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone");
+
+    // "Let desktop apps access your microphone" (applies on a per-user basis, requires above to be enabled)
     wxRegKey currentUserNonPackagedKey(wxRegKey::HKCU, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone\\NonPackaged");
     
-    bool currentUserMicrophoneAllowed = false;
-    if (currentUserMicrophoneKey.Exists())
+    bool localMachineMicrophoneAllowed = false;
+    if (localMachineMicrophoneKey.Exists())
     {
         wxString regValue;
-        currentUserMicrophoneKey.QueryValue("Value", regValue, true);
-        currentUserMicrophoneAllowed = regValue == "Allow";
+        localMachineMicrophoneKey.QueryValue("Value", regValue, true);
+        localMachineMicrophoneAllowed = regValue == "Allow";
     }
     
     bool currentUserNonPackagedAllowed = false;
@@ -48,7 +51,7 @@ void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
         currentUserNonPackagedAllowed = regValue == "Allow";
     }
     
-    microphonePermissionsGranted = currentUserMicrophoneAllowed && currentUserNonPackagedAllowed;
+    microphonePermissionsGranted = localMachineMicrophoneAllowed && currentUserNonPackagedAllowed;
     micPromise.set_value(microphonePermissionsGranted);
 }
 

--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -1,0 +1,62 @@
+//==========================================================================
+// Name:            windows_interface.cpp
+//
+// Purpose:         Implements Windowes specific logic for OS functions.
+// Created:         December 31, 2024
+// Authors:         Mooneer Salem
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#include "os_interface.h"
+
+#include <wx/msw/registry.h>
+
+void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
+{
+    bool microphonePermissionsGranted = false;
+    
+    wxRegKey currentUserMicrophoneKey(wxRegKey::HKCU, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone");
+    wxRegKey currentUserNonPackagedKey(wxRegKey::HKCU, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone\\NonPackaged");
+    
+    bool currentUserMicrophoneAllowed = false;
+    if (currentUserMicrophoneKey.Exists())
+    {
+        wxString regValue;
+        currentUserMicrophoneKey.QueryValue("Value", regValue, true);
+        currentUserMicrophoneAllowed = regValue == "Allow";
+    }
+    
+    bool currentUserNonPackagedAllowed = false;
+    if (currentUserNonPackagedKey.Exists())
+    {
+        wxString regValue;
+        currentUserNonPackagedKey.QueryValue("Value", regValue, true);
+        currentUserNonPackagedAllowed = regValue == "Allow";
+    }
+    
+    microphonePermissionsGranted = currentUserMicrophoneAllowed && currentUserNonPackagedAllowed;
+    micPromise.set_value(microphonePermissionsGranted);
+}
+
+void ResetMainWindowColorSpace()
+{
+    // empty
+}
+
+std::string GetOperatingSystemString()
+{
+    return "windows";
+}


### PR DESCRIPTION
Resolves #772 by detecting one common cause of the microphone being unusable in Windows. This mirrors the Registry keys used as part of the GH action used to test Windows builds.