### PR TITLE
Ensure that __pycache__ folders are cleaned up by the Windows uninstaller.

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -58,4 +58,14 @@ jobs:
       working-directory: ${{github.workspace}}/build_osx
       run: |
           FREEDV_COMPUTER_TO_RADIO_DEVICE="BlackHoleRadio 2ch" FREEDV_RADIO_TO_COMPUTER_DEVICE="BlackHoleRadio 2ch 2" FREEDV_COMPUTER_TO_SPEAKER_DEVICE="BlackHole1 2ch" FREEDV_MICROPHONE_TO_COMPUTER_DEVICE="BlackHole2 2ch" ctest -V
-           
+
+    - name: Package executable
+      working-directory: ${{github.workspace}}/build_osx
+      run: |
+          make release
+
+    - name: Stash disk image
+      uses: actions/upload-artifact@v4
+      with:
+        name: FreeDV
+        path: ${{github.workspace}}/build_osx/src/FreeDV.dmg

--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -149,6 +149,6 @@ set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
 
 # Make sure we fully clean up after Python on uninstall.
 set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-    "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\Lib'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\scripts'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\share'")
+    "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\Lib'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\scripts'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\share\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\__pycache__\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\radae\\\\__pycache__'")
 
 endif(WIN32)

--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -149,6 +149,6 @@ set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
 
 # Make sure we fully clean up after Python on uninstall.
 set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-    "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\Lib'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\scripts'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\share\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\__pycache__\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\radae\\\\__pycache__'")
+    "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\Lib'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\scripts'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\share'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\__pycache__'\r\nRMDir /r /REBOOTOK '\$INSTDIR\\\\bin\\\\radae\\\\__pycache__'")
 
 endif(WIN32)


### PR DESCRIPTION
During testing, it was discovered that the Windows uninstaller wasn't fully deleting FreeDV's folder in C:\Program Files. This PR ensures that the `__pycache__` folders inside that folder are removed so that the uninstaller can fully remove the application folder.