### PR TITLE
Fix various VK UI issues discovered by test team.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -898,7 +898,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix various audio dropout issues, especially on Linux. (PR #761)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
-    * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746)
+    * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746, #793)
     * Add monitor volume adjustment. (PR #733)
     * Avoid modifying the audio device configuration without the user explicitly doing so. (PR #735)
     * If provided by user, add config file to titlebar. (PR #738)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -221,12 +221,13 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
         }
         
         // Update voice keyer file if different
-        auto newVkFile = wxGetApp().appConfiguration.voiceKeyerWaveFilePath->mb_str();
-        if (vkFileName_ != newVkFile)
+        wxFileName fullVKPath(wxGetApp().appConfiguration.voiceKeyerWaveFilePath, wxGetApp().appConfiguration.voiceKeyerWaveFile);
+        if (vkFileName_ != fullVKPath.GetFullPath().mb_str())
         {
             // Clear filename to force reselection next time VK is triggered.
             vkFileName_ = "";
             wxGetApp().appConfiguration.voiceKeyerWaveFile = "";
+            setVoiceKeyerButtonLabel_("");
         }
         
         // Adjust frequency labels on main window

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -27,6 +27,7 @@
 #include "topFrame.h"
 #include "gui/util/NameOverrideAccessible.h"
 #include "gui/util/LabelOverrideAccessible.h"
+#include "util/logging/ulog.h"
 
 extern int g_playFileToMicInEventId;
 extern int g_recFileFromRadioEventId;
@@ -997,5 +998,30 @@ void TopFrame::setVoiceKeyerButtonLabel_(wxString filename)
         wxString tmpString = filename + _("...");
         m_togBtnVoiceKeyer->GetTextExtent(tmpString, &filenameWidth, &tmp);
     }
-    m_togBtnVoiceKeyer->SetLabel(vkLabel + _("\n") + filename + (isTruncated ? _("...") : _("")));
+    
+    if (filename.size() > 0)
+    {
+        m_togBtnVoiceKeyer->SetLabel(vkLabel + _("\n") + filename + (isTruncated ? _("...") : _("")));
+    }
+    else
+    {
+        m_togBtnVoiceKeyer->SetLabel(vkLabel);
+    }
+    
+    // Resize button height as needed.
+    wxSize currentSize = m_togBtnVoiceKeyer->GetSize();
+    wxSize bestSize = m_togBtnVoiceKeyer->GetBestSize();
+    currentSize.SetHeight(bestSize.GetHeight());
+    m_togBtnVoiceKeyer->SetSize(currentSize);
+    m_togBtnVoiceKeyer->Refresh();
+    
+    // XXX - wxWidgets doesn't handle button height changes properly until the user resizes 
+    // the window (even if only by a pixel or two). As a really hacky workaround, we 
+    // emulate this behavior when changing the button height.
+    wxSize winSize = GetSize();
+    SetSize(winSize.GetWidth(), winSize.GetHeight());
+    SetSize(winSize.GetWidth(), winSize.GetHeight() - 1);
+    SetSize(winSize.GetWidth(), winSize.GetHeight());
+        
+    log_info("Set voice keyer button label to %s", (const char*)m_togBtnVoiceKeyer->GetLabel().ToUTF8());
 }

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -36,6 +36,22 @@ void MainFrame::OnTogBtnVoiceKeyerClick (wxCommandEvent& event)
     {
         if (vk_state == VK_IDLE)
         {
+            // Check if VK file exists. If it doesn't, force the user to select another one.
+            if (vkFileName_ == "" || !wxFile::Exists(vkFileName_))
+            {
+                vkFileName_ = "";
+                wxCommandEvent tmpEvent;
+                OnChooseAlternateVoiceKeyerFile(tmpEvent);
+        
+                if (vkFileName_ == "")
+                {
+                    // Cancel VK if user refuses to choose a new file.
+                    m_togBtnVoiceKeyer->SetBackgroundColour(wxNullColour);
+                    m_togBtnVoiceKeyer->SetValue(false);
+                    goto end_handling;
+                }
+            }
+            
             m_togBtnVoiceKeyer->SetValue(true);
             VoiceKeyerProcessEvent(VK_START);
         }
@@ -43,6 +59,7 @@ void MainFrame::OnTogBtnVoiceKeyerClick (wxCommandEvent& event)
             VoiceKeyerProcessEvent(VK_SPACE_BAR);
     }
 
+end_handling:
     event.Skip();
 }
 
@@ -192,23 +209,6 @@ extern int g_sfTxFs;
 int MainFrame::VoiceKeyerStartTx(void)
 {
     int next_state;
-    
-    // Check if VK file exists. If it doesn't, force the user to select another one.
-    if (vkFileName_ == "" || !wxFile::Exists(vkFileName_))
-    {
-        vkFileName_ = "";
-        wxCommandEvent tmpEvent;
-        OnChooseAlternateVoiceKeyerFile(tmpEvent);
-        
-        if (vkFileName_ == "")
-        {
-            // Cancel VK if user refuses to choose a new file.
-            next_state = VK_IDLE;
-            m_togBtnVoiceKeyer->SetBackgroundColour(wxNullColour);
-            m_togBtnVoiceKeyer->SetValue(false);
-            return next_state;
-        }
-    }
 
     // start playing wave file or die trying
 


### PR DESCRIPTION
Implements the following:

1. Hardens the "modified" comparison when saving options from Tools->Options (to avoid clearing the VK filename when the folder's not modified).
2. Fixes bug that prevented the Voice Keyer button from properly resizing after selecting a new voice keyer file.