### PR TITLE
If disabled, make sure we don't try calling rade_text_* with a null pointer.

### DIFF
--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -110,12 +110,12 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
             int hasEooOut = 0;
             float eooOut[rade_n_eoo_bits(dv_)];
             nout = rade_rx(dv_, features_out, &hasEooOut, eooOut, input_buf_cplx);
-            if (hasEooOut)
+            if (hasEooOut && textPtr_ != nullptr)
             {
                 // Handle RX of bits from EOO.
                 rade_text_rx(textPtr_, eooOut, rade_n_eoo_bits(dv_) / 2);
             }
-            else
+            else if (!hasEooOut)
             {
                 if (featuresFile_)
                 {


### PR DESCRIPTION
This PR prevents calling `rade_text_rx()` on EOO if the user's disabled reporting. Without this change, errors similar to the following are possible:

![image (1)](https://github.com/user-attachments/assets/7da5992a-835a-456c-954b-c83c75fc2a20)
