### PR TITLE
Fix bug preventing Request QSY button from being enabled in RADE mode.

### DIFF
--- a/src/freedv_interface.h
+++ b/src/freedv_interface.h
@@ -71,7 +71,7 @@ public:
     void stop();
     void changeTxMode(int txMode);
     int getTxMode() const { return txMode_; }
-    bool isRunning() const { return dvObjects_.size() > 0; }
+    bool isRunning() const { return rade_ != nullptr || dvObjects_.size() > 0; }
     bool isModeActive(int mode) const { return std::find(enabledModes_.begin(), enabledModes_.end(), mode) != enabledModes_.end(); }
     void setRunTimeOptions(bool clip, bool bpf);
     


### PR DESCRIPTION
This PR fixes an issue preventing the Request QSY button in the FreeDV Reporter window from working when in RADE mode.

(Thanks @Tyrbiter for reporting this issue via email.)