### PR TITLE
Fix issue possibly degrading RADE RX audio quality.

### DIFF
--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
             // demod per frame processing
             for(int i=0; i<nin; i++) 
             {
-                input_buf_cplx[i].real = (float)input_buf[i] / 32767.0;
+                input_buf_cplx[i].real = input_buf[i] / 32767.0;
                 input_buf_cplx[i].imag = 0.0;
             }
 


### PR DESCRIPTION
Walter K5WH reported that the latest test build of 2.0 didn't sound as good on RADE as the 20241018 version. Using the RADE tools and the automated test framework, I recorded a loss of 0.182 between freedv-gui and `radae_rx` in the RADE repo. After implementing the code change in this PR, the loss dropped to 0.001.

(See companion issue https://github.com/drowe67/radae/issues/41 indicating minimal loss between Python and C decoders.)