### PR TITLE
Simplify RADE build and run on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This document describes how to build the FreeDV GUI program for various operatin
   * http://freedv.org - introduction, documentation, downloads
   * [FreeDV GUI User Manual](USER_MANUAL.md)
   
-## Building on Ubuntu Linux
+## Building on Ubuntu Linux without RADE
 
   ```
   $ sudo apt install libspeexdsp-dev libsamplerate0-dev sox git \
@@ -34,7 +34,7 @@ This document describes how to build the FreeDV GUI program for various operatin
   
   Note this builds all libraries locally, nothing is installed on your machine.  ```make install``` is not required.
 
-## Building on Fedora Linux
+## Building on Fedora Linux without RADE
   ```
   $ sudo dnf groupinstall "Development Tools"
   $ sudo dnf install cmake wxGTK3-devel libsamplerate-devel \
@@ -64,43 +64,64 @@ RADE is a new FreeDV mode that uses machine learning to improve voice quality an
 We are currently focused on Windows and macOS for initial development, but it is possible to run on 
 Linux by following these steps:
 
-1. Install PyTorch, TorchAudio and matplotlib Python packages. Some distros have packages for one or more of these,
-   but you can also use pip in a Python virtual environment (recommended to ensure the latest versions):
+1. Follow the instructions above for Ubuntu or Fedora to install the libraries but do not run build_linux.
 
    ```
-   $ cd freedv-gui
-   $ python3 -m venv rade-venv
-   $ . ./rade-venv/bin/activate
-   (rade-venv) $ pip3 install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
-   (rade-venv) $ pip3 install matplotlib
+   Ubuntu: $ sudo apt install...
+   Fedora: $ sudo dnf install...
+   ...
    ```
 
-   *Note: you may need to install `python3-venv` or your distro's equivalent package in order to create Python virtual environments. Python 3.9+ is also required for PyTorch to work.*
+2. Obtain the FreeDV-GUI source code for version 2.0.0 or later. The location and version is likely to change frequently.
+Currently (January 2025) there are releases at https://github.com/drowe67/freedv-gui/releases.
+Download the version 2.x.x tar.gz file, and extract it to your PC. Change to that directory.
+You could also clone the github site https://github.com/drowe67/freedv-gui but you will have to choose a version 2.x.x branch. 
 
-2. Build FreeDV to make sure the correct dependencies are linked in (namely numpy):
+3. Make sure you have the python3-venv package. On Ubuntu you will need to install this from your package manager.
+Make sure your Python is version 3.9 or higher.
 
-   ```
-   (rade-venv) $ pwd
-   /home/<user>/freedv-gui
-   (rade-venv) $ ./build_linux.sh
-   ```
-
-3. Make sure FreeDV can find the ML model:
-
-   ```
-   (rade-venv) $ pwd
-   /home/<user>/freedv-gui
-   (rade-venv) $ cd build_linux
-   (rade-venv) $ ln -s $(pwd)/rade_src/model19_check3 model19_check3
-   ```
-
-4. Execute FreeDV:
+4. Install the PyTorch, TorchAudio, numpy and matplotlib Python packages.
+You will need to use a Python virtual environment unless your Linux has all required Python packages.
+A virtual environment is recommended to get the latest versions.
 
    ```
-   (rade-venv) $ pwd
-   /home/<user>/freedv-gui/build_linux
-   (rade-venv) $ PYTHONPATH="$(pwd)/rade_src:$PYTHONPATH" src/freedv
+   The current directory is freedv-gui.
+
+   <..>/freedv-gui $ python3 -m venv rade-venv
+   <..>/freedv-gui $ source rade-venv/bin/activate
+
+   The current directory is freedv-gui and the virtual environment is activated.
+
+   (rade-venv) <..>/freedv-gui $ pip3 install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+   (rade-venv) <..>/freedv-gui $ pip3 install numpy
+   (rade-venv) <..>/freedv-gui $ pip3 install matplotlib
    ```
+
+5. Build FreeDV:
+
+   ```
+   (rade-venv) <..>/freedv-gui $ ./build_linux.sh
+   ```
+
+6. Make sure FreeDV can find the ML model:
+
+   ```
+   (rade-venv) <..>/freedv-gui $ cd build_linux
+   (rade-venv) <..>/freedv-gui/build_linux  $ ln -s rade_src/model19_check3 model19_check3
+   ```
+
+7. Execute FreeDV:
+
+   ```
+   The current directory is freedv-gui/build_linux and the virtual environment is activated.
+
+   (rade-venv) <..>/freedv-gui/build_linux $ PYTHONPATH="$(pwd)/rade_src:$PYTHONPATH" src/freedv
+   ```
+   There is a convenient FreeDV-GUI laucher Python script in freedv-gui/config to use instead:
+```
+   python3 <path to freedv-gui/contrib>/launch_linux_rade.py
+```
+   The RADE mode is under active development and it is best to run FreeDV-GUI directly from freedv-gui instead of installing it.
 
 ## Building without LPCNet
 

--- a/contrib/launch_linux_rade.py
+++ b/contrib/launch_linux_rade.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Currently (January 2025) the RADE mode of FreeDV on Linux requires a virtual environment.
+# This Python script is used on Linux to start the FreeDV GUI program. It removes the need
+# to activate a virtual environment, and may be used in a FreeDV.desktop shortcut. Its name is
+# "launch_linux_rade.py" and it must be located in freedv-gui/contrib. To use it, run it with any
+# Python version.
+
+import sys, subprocess, os, os.path
+
+DEBUG = 0
+
+env = os.environ
+
+# This Python script is <FreeDV-GUI directory>/contrib/launch_linux_rade.py.
+# Use the file path of this script to find the FreeDV-GUI directory.
+freedv_dir = os.path.abspath(__file__)
+freedv_dir, tail = os.path.split(freedv_dir)
+freedv_dir, tail = os.path.split(freedv_dir)
+if DEBUG: print ("freedv_dir", freedv_dir)
+build_linux = os.path.join(freedv_dir, "build_linux")
+if DEBUG: print ("build_linux", build_linux)
+rade_src = os.path.join(build_linux, "rade_src")
+if DEBUG: print ("rade_src", rade_src)
+rade_venv_bin = os.path.join(freedv_dir, "rade-venv", "bin")
+if DEBUG: print ("rade_venv_bin", rade_venv_bin)
+
+# Site packages are in rade-venv/lib/pythonX.Y/site-packages.
+site_pkg = ''
+lib = os.path.join(freedv_dir, "rade-venv", "lib")
+for pyname in os.listdir(lib):
+  pkg = os.path.join(lib, pyname, "site-packages")
+  if os.path.isdir(pkg):
+    site_pkg = pkg
+    break
+if not site_pkg:		# Should not happen.
+  site_pkg = os.path.join(lib, "site-packages")
+if DEBUG: print ("site_pkg", site_pkg)
+
+# Modify PYTHONPATH:
+path = rade_src + ":" + site_pkg
+if "PYTHONPATH" in env:
+  env["PYTHONPATH"] = path + ":" + env["PYTHONPATH"]
+else:
+  env["PYTHONPATH"] = path
+
+#Modify PATH
+if "PATH" in env:
+  env["PATH"] = rade_venv_bin + ":" + env["PATH"]
+else:
+  env["PATH"] = rade_venv_bin
+
+# Remove PYTHONHOME:
+if "PYTHONHOME" in env:
+  del env["PYTHONHOME"]
+
+if DEBUG: print ("PATH", env["PATH"])
+if DEBUG: print ("PYTHONPATH", env["PYTHONPATH"])
+
+os.chdir(build_linux)
+subprocess.run(os.path.join(build_linux, "src", "freedv"))
+


### PR DESCRIPTION
I added to the build_linux part of README.md to make it clearer how to build for RADE on Linux. I added the file freedv-gui/contrib/launch_linux_rade.py to make it simpler to launch FreeDV-GUI on Linux.

These changes are only relevant on Linux. They will not be necessary once Python is removed from FreeDV-GUI.