### PR TITLE
Fix bug causing hangs in non-RADE mode at end of TX.

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sh -c "apt-add-repository \"https://dl.winehq.org/wine-builds/ubuntu\""
         sudo apt-get update
         #echo "/opt/wine-staging/bin" >> $GITHUB_PATH
-        sudo apt install -y --install-recommends winehq-stable
+        sudo apt install -y --install-recommends winehq-staging
         #sudo apt install -y --install-recommends wine64 wine32
 
     - name: Install required packages

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -901,18 +901,21 @@ void MainFrame::togglePTT(void) {
         // Trigger end of TX processing. This causes us to wait for the remaining samples
         // to flow through the system before toggling PTT.  Note that there is a 1000ms 
         // timeout as backup.
-        log_info("Waiting for EOO to be queued");
-        endingTx = true;
-        while(true)
+        if (freedvInterface.getCurrentMode() == FREEDV_MODE_RADE)
         {
-            if (g_eoo_enqueued)
+            log_info("Waiting for EOO to be queued");
+            endingTx = true;
+            while(true)
             {
-                log_info("Detected that EOO has been enqueued");
-                break;
-            }
+                if (g_eoo_enqueued)
+                {
+                    log_info("Detected that EOO has been enqueued");
+                    break;
+                }
  
-            wxThread::Sleep(1);
-            wxGetApp().Yield(true);
+                wxThread::Sleep(1);
+                wxGetApp().Yield(true);
+            }
         }
 
         int sample = g_outfifo1_empty;


### PR DESCRIPTION
Reported by the RADE test group. This PR modifies the end of TX logic to add a missed check for RADE mode before waiting for EOO to be queued.