### PR TITLE
Add support for only adjusting frequency, not mode.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -905,6 +905,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Minor adjustments to spectrum/waterfall tooltips. (PR #743)
     * Implement new logging framework. (PR #773)
     * Windows: Detect whether microphone permissions have been granted and display error if not. (PR #790)
+    * Add rig control option to prevent auto-adjustment of the radio's current mode. (PR #809)
 3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.6. (PR #748)

--- a/src/config/RigControlConfiguration.cpp
+++ b/src/config/RigControlConfiguration.cpp
@@ -24,6 +24,7 @@
 RigControlConfiguration::RigControlConfiguration()
     : hamlibUseForPTT("/Hamlib/UseForPTT", false)
     , hamlibEnableFreqModeChanges("/Hamlib/EnableFreqModeChanges", true)
+    , hamlibEnableFreqChangesOnly("/Hamlib/EnableFreqChangesOnly", false)
     , hamlibUseAnalogModes("/Hamlib/UseAnalogModes", false)
     , hamlibIcomCIVAddress("/Hamlib/IcomCIVHex", 0)
     , hamlibRigName("/Hamlib/RigNameStr", "")

--- a/src/config/RigControlConfiguration.h
+++ b/src/config/RigControlConfiguration.h
@@ -33,6 +33,7 @@ public:
     
     ConfigurationDataElement<bool> hamlibUseForPTT;
     ConfigurationDataElement<bool> hamlibEnableFreqModeChanges;
+    ConfigurationDataElement<bool> hamlibEnableFreqChangesOnly;
     ConfigurationDataElement<bool> hamlibUseAnalogModes;
     ConfigurationDataElement<unsigned int> hamlibIcomCIVAddress;
     ConfigurationDataElement<wxString> hamlibRigName;

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -200,8 +200,17 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     wxStaticBox *sb_hamlib = new wxStaticBox(m_rigControlTab, wxID_ANY, _("Frequency/Mode Control Options"));
     sbSizer_hamlib = new wxStaticBoxSizer(sb_hamlib, wxVERTICAL);
     
-    m_ckboxEnableFreqModeChanges = new wxCheckBox(m_rigControlTab, wxID_ANY, _("Enable frequency and mode changes"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    sbSizer_hamlib->Add(m_ckboxEnableFreqModeChanges, 0, wxALL | wxALIGN_LEFT, 5);
+    wxSizer* freqModeSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_ckboxEnableFreqModeChanges = new wxRadioButton(m_rigControlTab, wxID_ANY, _("Enable frequency and mode changes"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+    freqModeSizer->Add(m_ckboxEnableFreqModeChanges, 0, wxALL | wxALIGN_LEFT, 5);
+    
+    m_ckboxEnableFreqChangesOnly = new wxRadioButton(m_rigControlTab, wxID_ANY, _("Enable frequency changes only"), wxDefaultPosition, wxDefaultSize);
+    freqModeSizer->Add(m_ckboxEnableFreqChangesOnly, 0, wxALL | wxALIGN_LEFT, 5);
+    
+    m_ckboxNoFreqModeChanges = new wxRadioButton(m_rigControlTab, wxID_ANY, _("No frequency or mode changes"), wxDefaultPosition, wxDefaultSize);
+    freqModeSizer->Add(m_ckboxNoFreqModeChanges, 0, wxALL | wxALIGN_LEFT, 5);
+    
+    sbSizer_hamlib->Add(freqModeSizer, 0, wxALL | wxALIGN_LEFT, 5);
     
     m_ckboxUseAnalogModes = new wxCheckBox(m_rigControlTab, wxID_ANY, _("Use USB/LSB instead of DIGU/DIGL"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizer_hamlib->Add(m_ckboxUseAnalogModes, 0, wxALL | wxALIGN_LEFT, 5);
@@ -737,7 +746,9 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     m_ckboxMultipleRx->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnMultipleRxEnable), NULL, this);
     
-    m_ckboxEnableFreqModeChanges->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    m_ckboxEnableFreqModeChanges->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    m_ckboxEnableFreqChangesOnly->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    m_ckboxNoFreqModeChanges->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
     
     m_freqList->Connect(wxEVT_LISTBOX, wxCommandEventHandler(OptionsDlg::OnReportingFreqSelectionChange), NULL, this);
     m_txtCtrlNewFrequency->Connect(wxEVT_TEXT, wxCommandEventHandler(OptionsDlg::OnReportingFreqTextChange), NULL, this);
@@ -785,8 +796,10 @@ OptionsDlg::~OptionsDlg()
     
     m_ckboxMultipleRx->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnMultipleRxEnable), NULL, this);
     
-    m_ckboxEnableFreqModeChanges->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
-
+    m_ckboxEnableFreqModeChanges->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    m_ckboxEnableFreqChangesOnly->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    m_ckboxNoFreqModeChanges->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
+    
     m_freqList->Disconnect(wxEVT_LISTBOX, wxCommandEventHandler(OptionsDlg::OnReportingFreqSelectionChange), NULL, this);
     m_txtCtrlNewFrequency->Disconnect(wxEVT_TEXT, wxCommandEventHandler(OptionsDlg::OnReportingFreqTextChange), NULL, this);
     m_freqListAdd->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(OptionsDlg::OnReportingFreqAdd), NULL, this);
@@ -830,6 +843,8 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_txtTxRxDelayMilliseconds->SetValue(wxString::Format("%d", wxGetApp().appConfiguration.txRxDelayMilliseconds.get()));
         m_ckboxUseAnalogModes->SetValue(wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseAnalogModes);
         m_ckboxEnableFreqModeChanges->SetValue(wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges);
+        m_ckboxEnableFreqChangesOnly->SetValue(wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly);
+        m_ckboxNoFreqModeChanges->SetValue(!wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges && !wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly);
         m_ckboxFrequencyEntryAsKHz->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz);
         
         /* Voice Keyer */
@@ -988,6 +1003,7 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseAnalogModes = m_ckboxUseAnalogModes->GetValue();
         
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges = m_ckboxEnableFreqModeChanges->GetValue();
+        wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly = m_ckboxEnableFreqChangesOnly->GetValue();
         
         wxGetApp().appConfiguration.reportingConfiguration.reportingFreeTextString = m_txtCtrlCallSign->GetValue();
 
@@ -1365,6 +1381,8 @@ void OptionsDlg::updateRigControlState()
     if (!sessionActive_)
     {
         m_ckboxEnableFreqModeChanges->Enable(true);
+        m_ckboxEnableFreqChangesOnly->Enable(true);
+        m_ckboxNoFreqModeChanges->Enable(true);
         m_ckboxEnableSpacebarForPTT->Enable(true);
         m_txtTxRxDelayMilliseconds->Enable(true);
         m_ckboxUseAnalogModes->Enable(m_ckboxEnableFreqModeChanges->GetValue());
@@ -1374,6 +1392,8 @@ void OptionsDlg::updateRigControlState()
         // Rig control settings cannot be updated during a session.
         m_ckboxUseAnalogModes->Enable(false);
         m_ckboxEnableFreqModeChanges->Enable(false);
+        m_ckboxEnableFreqChangesOnly->Enable(false);
+        m_ckboxNoFreqModeChanges->Enable(false);
         m_ckboxEnableSpacebarForPTT->Enable(false);
         m_txtTxRxDelayMilliseconds->Enable(false);
     }

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -89,11 +89,13 @@ class OptionsDlg : public wxDialog
         wxNotebookPage *m_debugTab; // Debug
         
         /* Hamlib options */
-        wxCheckBox   *m_ckboxUseAnalogModes;
-        wxCheckBox   *m_ckboxEnableFreqModeChanges;
-        wxCheckBox   *m_ckboxEnableSpacebarForPTT;
-        wxTextCtrl   *m_txtTxRxDelayMilliseconds;
-        wxCheckBox   *m_ckboxFrequencyEntryAsKHz;
+        wxCheckBox    *m_ckboxUseAnalogModes;
+        wxRadioButton *m_ckboxEnableFreqModeChanges;
+        wxRadioButton *m_ckboxEnableFreqChangesOnly;
+        wxRadioButton *m_ckboxNoFreqModeChanges;
+        wxCheckBox    *m_ckboxEnableSpacebarForPTT;
+        wxTextCtrl    *m_txtTxRxDelayMilliseconds;
+        wxCheckBox    *m_ckboxFrequencyEntryAsKHz;
         
         /* Waterfall color */
         wxRadioButton *m_waterfallColorScheme1; // Multicolored

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -838,7 +838,7 @@ void FreeDVReporterDialog::OnDoubleClick(wxMouseEvent& event)
 {
     auto selectedIndex = m_listSpots->GetFirstSelected();
     if (selectedIndex >= 0 && wxGetApp().rigFrequencyController && 
-        wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+        (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly))
     {
         std::string* sidPtr = (std::string*)m_listSpots->GetItemData(selectedIndex);
         

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3669,7 +3669,8 @@ void MainFrame::initializeFreeDVReporter_()
         wxString fullMessage = wxString::Format(wxString(fmtMsg), callsign, frequencyReadable);
         int dialogStyle = wxOK | wxICON_INFORMATION | wxCENTRE;
         
-        if (wxGetApp().rigFrequencyController != nullptr && wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+        if (wxGetApp().rigFrequencyController != nullptr && 
+            (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly))
         {
             fullMessage = wxString::Format(_("%s Would you like to change to that frequency now?"), fullMessage);
             dialogStyle = wxYES_NO | wxICON_QUESTION | wxCENTRE;

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -396,7 +396,8 @@ bool MainFrame::OpenHamlibRig() {
         auto tmp = std::make_shared<HamlibRigController>(
             rig, (const char*)port.mb_str(wxConvUTF8), serial_rate, wxGetApp().appConfiguration.rigControlConfiguration.hamlibIcomCIVAddress, 
             pttType, pttType == HamlibRigController::PTT_VIA_CAT || pttType == HamlibRigController::PTT_VIA_NONE ? (const char*)port.mb_str(wxConvUTF8) : (const char*)pttPort.mb_str(wxConvUTF8),
-            wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges);
+            (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly),
+            wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly);
 
         // Hamlib also controls PTT.
         firstFreqUpdateOnConnect_ = false;
@@ -413,7 +414,7 @@ bool MainFrame::OpenHamlibRig() {
 
         wxGetApp().rigFrequencyController->onRigConnected += [&](IRigController*) {
             if (wxGetApp().rigFrequencyController && 
-                wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges &&
+                (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly) &&
                 wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0)
             {
                 // Suppress the frequency update message that will occur immediately after
@@ -422,7 +423,11 @@ bool MainFrame::OpenHamlibRig() {
 
                 // Set frequency/mode to the one pre-selected by the user before start.
                 wxGetApp().rigFrequencyController->setFrequency(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
-                wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+                
+                if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+                {
+                    wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+                }
             }
         };
 
@@ -530,7 +535,8 @@ void MainFrame::OpenOmniRig()
 {
     auto tmp = std::make_shared<OmniRigController>(
         wxGetApp().appConfiguration.rigControlConfiguration.omniRigRigId,
-        wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges);
+        (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly),
+        wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly);
 
     // OmniRig also controls PTT.
     wxGetApp().rigFrequencyController = tmp;
@@ -548,10 +554,13 @@ void MainFrame::OpenOmniRig()
     };
 
     wxGetApp().rigFrequencyController->onRigConnected += [&](IRigController*) {
-        if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+        if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly)
         {
             wxGetApp().rigFrequencyController->setFrequency(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
-            wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+            if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+            {
+                wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+            }
         }
     };
 
@@ -1245,11 +1254,14 @@ void MainFrame::OnChangeReportFrequency( wxCommandEvent& event )
     {      
         if (wxGetApp().rigFrequencyController != nullptr && 
             wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0 && 
-            wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+            (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges || wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly))
         {
             // Request frequency/mode change on the radio side
             wxGetApp().rigFrequencyController->setFrequency(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
-            wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+            if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges)
+            {
+                wxGetApp().rigFrequencyController->setMode(getCurrentMode_());
+            }
         }
     }
 

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -59,7 +59,7 @@ bool HamlibRigController::RigCompare_(const struct rig_caps *rig1, const struct 
     return rig1->rig_model < rig2->rig_model;
 }
 
-HamlibRigController::HamlibRigController(std::string rigName, std::string serialPort, const int serialRate, const int civHex, const PttType pttType, std::string pttSerialPort, bool restoreFreqModeOnDisconnect)
+HamlibRigController::HamlibRigController(std::string rigName, std::string serialPort, const int serialRate, const int civHex, const PttType pttType, std::string pttSerialPort, bool restoreFreqModeOnDisconnect, bool freqOnly)
     : rigName_(rigName)
     , serialPort_(serialPort)
     , serialRate_(serialRate)
@@ -74,12 +74,13 @@ HamlibRigController::HamlibRigController(std::string rigName, std::string serial
     , restoreOnDisconnect_(restoreFreqModeOnDisconnect)
     , origFreq_(0)
     , origMode_(RIG_MODE_NONE)
+    , freqOnly_(freqOnly)
 {
     // Perform initial load of rig list if this is our first time being created.
     InitializeHamlibLibrary();
 }
 
-HamlibRigController::HamlibRigController(int rigIndex, std::string serialPort, const int serialRate, const int civHex, const PttType pttType, std::string pttSerialPort, bool restoreFreqModeOnDisconnect)
+HamlibRigController::HamlibRigController(int rigIndex, std::string serialPort, const int serialRate, const int civHex, const PttType pttType, std::string pttSerialPort, bool restoreFreqModeOnDisconnect, bool freqOnly)
     : rigName_(RigIndexToName(rigIndex))
     , serialPort_(serialPort)
     , serialRate_(serialRate)
@@ -94,6 +95,7 @@ HamlibRigController::HamlibRigController(int rigIndex, std::string serialPort, c
     , restoreOnDisconnect_(restoreFreqModeOnDisconnect)
     , origFreq_(0)
     , origMode_(RIG_MODE_NONE)
+    , freqOnly_(freqOnly)
 {
     // Perform initial load of rig list if this is our first time being created.
     InitializeHamlibLibrary();
@@ -381,7 +383,10 @@ void HamlibRigController::disconnectImpl_()
         {
             vfo_t currVfo = getCurrentVfo_(); 
             setFrequencyHelper_(currVfo, origFreq_);
-            setModeHelper_(currVfo, origMode_);
+            if (!freqOnly_)
+            {
+                setModeHelper_(currVfo, origMode_);
+            }
         }
         
         origFreq_ = 0;

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -47,8 +47,8 @@ public:
         PTT_VIA_NONE,
     };
     
-    HamlibRigController(std::string rigName, std::string serialPort, const int serialRate, const int civHex = 0, const PttType pttType = PTT_VIA_CAT, std::string pttSerialPort = std::string(), bool restoreFreqModeOnDisconnect = false);
-    HamlibRigController(int rigIndex, std::string serialPort, const int serialRate, const int civHex = 0, const PttType pttType = PTT_VIA_CAT, std::string pttSerialPort = std::string(), bool restoreFreqModeOnDisconnect = false);
+    HamlibRigController(std::string rigName, std::string serialPort, const int serialRate, const int civHex = 0, const PttType pttType = PTT_VIA_CAT, std::string pttSerialPort = std::string(), bool restoreFreqModeOnDisconnect = false, bool freqOnly = false);
+    HamlibRigController(int rigIndex, std::string serialPort, const int serialRate, const int civHex = 0, const PttType pttType = PTT_VIA_CAT, std::string pttSerialPort = std::string(), bool restoreFreqModeOnDisconnect = false, bool freqOnly = false);
     virtual ~HamlibRigController();
     
     virtual void connect() override;
@@ -82,6 +82,7 @@ private:
     bool restoreOnDisconnect_;
     uint64_t origFreq_;
     rmode_t origMode_;
+    bool freqOnly_;
     
     vfo_t getCurrentVfo_();
     void setFrequencyHelper_(vfo_t currVfo, uint64_t frequencyHz);

--- a/src/rig_control/omnirig/OmniRigController.cpp
+++ b/src/rig_control/omnirig/OmniRigController.cpp
@@ -32,7 +32,7 @@ using namespace std::chrono_literals;
 
 #define OMNI_RIG_WAIT_TIME (200ms)
 
-OmniRigController::OmniRigController(int rigId, bool restoreOnDisconnect)
+OmniRigController::OmniRigController(int rigId, bool restoreOnDisconnect, bool freqOnly)
     : rigId_(rigId)
     , omniRig_(nullptr)
     , rig_(nullptr)
@@ -42,6 +42,7 @@ OmniRigController::OmniRigController(int rigId, bool restoreOnDisconnect)
     , currMode_(UNKNOWN)
     , restoreOnDisconnect_(restoreOnDisconnect)
     , writableParams_(0)
+    , freqOnly_(freqOnly)
 {
     // empty
 }
@@ -156,9 +157,13 @@ void OmniRigController::disconnectImpl_()
         if (restoreOnDisconnect_)
         {
             setFrequencyImpl_(origFreq_);
-            rig_->put_Mode(origMode_);
+            
+            if (!freqOnly_)
+            {
+                rig_->put_Mode(origMode_);
+            }
         }
-
+        
         rig_->Release();
         omniRig_->Release();
         omniRig_ = nullptr;

--- a/src/rig_control/omnirig/OmniRigController.h
+++ b/src/rig_control/omnirig/OmniRigController.h
@@ -31,7 +31,7 @@
 class OmniRigController : public ThreadedObject, public IRigFrequencyController, public IRigPttController
 {
 public:
-    OmniRigController(int rigId, bool restoreFreqModeOnDisconnect = false);
+    OmniRigController(int rigId, bool restoreFreqModeOnDisconnect = false, bool freqOnly = false);
     virtual ~OmniRigController();
 
     virtual void connect() override;
@@ -52,6 +52,7 @@ private:
     IRigFrequencyController::Mode currMode_;
     bool restoreOnDisconnect_;
     long writableParams_; // used to help determine VFO
+    bool freqOnly_;
 
     void connectImpl_();
     void disconnectImpl_();


### PR DESCRIPTION
Per request from the RADE test group, this PR adds an additional rig control option to allow only adjusting frequency and not mode. This is due to mode adjustment being fairly buggy for some radios in hamlib.

Example UI:

<img width="985" alt="Screenshot 2025-01-14 at 12 49 11 PM" src="https://github.com/user-attachments/assets/20722304-3026-4b88-b00f-cc807fb9c7fa" />
