### PR TITLE
Make sure reporting message is sent using UTF8.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -896,6 +896,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix bug preventing proper time display in FreeDV Reporter on macOS. (PR #748)
     * Set timeout for Hamlib comms to avoid GUI getting stuck. (PR #746)
     * Fix various audio dropout issues, especially on Linux. (PR #761)
+    * Fix issue preventing non-ASCII text from appearing properly in FreeDV Reporter messages. (PR #812)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
     * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746, #793)

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -1777,7 +1777,7 @@ void FreeDVReporterDialog::onMessageUpdateFn_(std::string sid, std::string lastU
             }
             else
             {
-                iter->second->userMessage = message;
+                iter->second->userMessage = wxString::FromUTF8(message);
             }
             
             auto lastUpdateTime = makeValidTime_(lastUpdate, iter->second->lastUpdateDate);

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -573,7 +573,7 @@ void FreeDVReporterDialog::setReporter(std::shared_ptr<FreeDVReporter> reporter)
 
         // Update status message
         auto statusMsg = m_statusMessage->GetValue();
-        reporter_->updateMessage(statusMsg.ToStdString());
+        reporter_->updateMessage(statusMsg.utf8_string());
     }
     else
     {
@@ -649,7 +649,7 @@ void FreeDVReporterDialog::OnSendQSY(wxCommandEvent& event)
 
 void FreeDVReporterDialog::OnOpenWebsite(wxCommandEvent& event)
 {
-    std::string url = "https://" + wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->ToStdString() + "/";
+    std::string url = "https://" + wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->utf8_string() + "/";
     wxLaunchDefaultBrowser(url);
 }
 
@@ -954,7 +954,7 @@ void FreeDVReporterDialog::OnStatusTextSend(wxCommandEvent& event)
 
     if (reporter_)
     {
-        reporter_->updateMessage(statusMsg.ToStdString());
+        reporter_->updateMessage(statusMsg.utf8_string());
     }
 
     wxGetApp().appConfiguration.reportingConfiguration.freedvReporterStatusText = statusMsg;


### PR DESCRIPTION
On Windows, it's apparently not possible to use anything other than English letters and numbers for the FreeDV Reporter message dialog (whereas it seems to work at least in macOS). This PR is a WIP that will hopefully allow the use of foreign language text and emojis.