### PR TITLE
Fix buffer overflow issue causing loud audio after EOO.

### DIFF
--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -167,7 +167,7 @@ void RADETransmitStep::restartVocoder()
     const int NUM_SAMPLES_SILENCE = 60 * getOutputSampleRate() / 1000;
     int numEOOSamples = rade_n_tx_eoo_out(dv_);
     RADE_COMP eooOut[numEOOSamples];
-    short eooOutShort[numEOOSamples];
+    short eooOutShort[numEOOSamples + NUM_SAMPLES_SILENCE];
 
     rade_tx_eoo(dv_, eooOut);
 


### PR DESCRIPTION
Resolves #810 by making sure we actually have enough buffer for the EOO + a bit of silence.