### PR TITLE
Relax microphone permissions checking on Windows.

### DIFF
--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -32,9 +32,6 @@ void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
     // General Microphone enable/disable (applies to all users)
     wxRegKey localMachineMicrophoneKey(wxRegKey::HKLM, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone");
 
-    // "Let desktop apps access your microphone" (applies on a per-user basis, requires above to be enabled)
-    wxRegKey currentUserNonPackagedKey(wxRegKey::HKCU, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone\\NonPackaged");
-    
     bool localMachineMicrophoneAllowed = false;
     if (localMachineMicrophoneKey.Exists())
     {
@@ -43,15 +40,7 @@ void VerifyMicrophonePermissions(std::promise<bool>& micPromise)
         localMachineMicrophoneAllowed = regValue == "Allow";
     }
     
-    bool currentUserNonPackagedAllowed = false;
-    if (currentUserNonPackagedKey.Exists())
-    {
-        wxString regValue;
-        currentUserNonPackagedKey.QueryValue("Value", regValue, true);
-        currentUserNonPackagedAllowed = regValue == "Allow";
-    }
-    
-    microphonePermissionsGranted = localMachineMicrophoneAllowed && currentUserNonPackagedAllowed;
+    microphonePermissionsGranted = localMachineMicrophoneAllowed;
     micPromise.set_value(microphonePermissionsGranted);
 }
 


### PR DESCRIPTION
Per report from the digitalvoice mailing list and further debugging, it turns out that on some Windows machines `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged` does not exist even if the specific "desktop app" microphone permission has been granted. This PR removes the check for this Registry key while keeping the other general microphone permissions check.