### PR TITLE
Fix issue preventing suppression of the Msg tooltip for non-truncated messages

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -897,6 +897,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Set timeout for Hamlib comms to avoid GUI getting stuck. (PR #746)
     * Fix various audio dropout issues, especially on Linux. (PR #761)
     * Fix issue preventing non-ASCII text from appearing properly in FreeDV Reporter messages. (PR #812)
+    * Fix issue preventing suppression of the Msg tooltip for non-truncated messages. (PR #829)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
     * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746, #793)

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -869,6 +869,7 @@ void FreeDVReporterDialog::AdjustToolTip(wxMouseEvent& event)
             std::string* sidPtr = (std::string*)m_listSpots->GetItemData(index);
             tempUserMessage_ = allReporterData_[*sidPtr]->userMessage;
             wxString userMessageTruncated = m_listSpots->GetItemText(index, desiredCol);
+            userMessageTruncated = userMessageTruncated.SubString(1, userMessageTruncated.size() - 1);
         
             if (tipWindow_ == nullptr && tempUserMessage_ != userMessageTruncated)
             {

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -695,7 +695,7 @@ void FreeDVReporterDialog::AdjustMsgColWidth(wxListEvent& event)
     for (int index = 0; index < m_listSpots->GetItemCount(); index++)
     {
         std::string* sidPtr = (std::string*)m_listSpots->GetItemData(index);
-        wxString tempUserMessage = _(" ") + allReporterData_[*sidPtr]->userMessage;
+        wxString tempUserMessage = _(" ") + allReporterData_[*sidPtr]->userMessage;  // note: extra space at beginning is to provide extra space from previous col
         
         textWidth = getSizeForTableCellString_(tempUserMessage);
         int tmpLength = allReporterData_[*sidPtr]->userMessage.Length() - 1;
@@ -1987,7 +1987,7 @@ void FreeDVReporterDialog::addOrUpdateListIfNotFiltered_(ReporterData* data, std
     int textWidth = 0;
     int currentColWidth = m_listSpots->GetColumnWidth(col);
     
-    wxString userMessageTruncated = _(" ") + data->userMessage;
+    wxString userMessageTruncated = _(" ") + data->userMessage; // note: extra space at beginning is to provide extra space from previous col
     textWidth = getSizeForTableCellString_(userMessageTruncated);
     int tmpLength = data->userMessage.Length() - 1;
     while (textWidth > currentColWidth && tmpLength > 0)


### PR DESCRIPTION
Resolves #826 by removing the extra space added for UI display purposes before comparing with the message received from the server.