### PR TITLE
Update 80/160m default frequencies.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -889,7 +889,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
-## V2.0.0 TBD 2024
+## V2.0.0 TBD 2025
 
 1. Bugfixes:
     * Fix bug preventing saving of the previously used path when playing back files. (PR #729)
@@ -909,6 +909,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Implement new logging framework. (PR #773)
     * Windows: Detect whether microphone permissions have been granted and display error if not. (PR #790)
     * Add rig control option to prevent auto-adjustment of the radio's current mode. (PR #809)
+    * Update default 80 and 160m calling frequencies. (PR #831)
 3. Build system:
     * Allow overrriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.6. (PR #748)

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -52,12 +52,12 @@ ReportingConfiguration::ReportingConfiguration()
     , useUTCForReporting("/CallsignList/UseUTCTime", false)
         
     , reportingFrequencyList("/Reporting/FrequencyList", {
-        _("1.9970"),
+        _("1.8700"),
         _("3.6250"),
         _("3.6430"),
         _("3.6930"),
         _("3.6970"),
-        _("3.8500"),
+        _("3.8030"),
         _("5.4035"),
         _("5.3665"),
         _("5.3685"),


### PR DESCRIPTION
Updates default frequency list as follows:

1. 1.9970 MHz is now 1.8700 MHz.
2. 3.8500 MHz is now 3.8030 MHz.

The above changes are to better handle the Japanese band plan.