### PR TITLE
Only show whole number SNRs in main window.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1696,7 +1696,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         if (snr_limited < -5.0) snr_limited = -5.0;
         if (snr_limited > 40.0) snr_limited = 40.0;
         char snr[15];
-        snprintf(snr, 15, "%4.1f dB", g_snr);
+        snprintf(snr, 15, "%4.0f dB", g_snr);
 
         if (freedvInterface.getSync())
         {

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -431,7 +431,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     //------------------------------
     // Box for S/N ratio (Numeric)
     //------------------------------
-    m_textSNR = new wxStaticText(snrBox, wxID_ANY, wxT(" 0.0 dB"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
+    m_textSNR = new wxStaticText(snrBox, wxID_ANY, wxT("--"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
     m_textSNR->SetMinSize(wxSize(70,-1));
     snrSizer->Add(m_textSNR, 0, wxALIGN_CENTER_HORIZONTAL, 1);
 


### PR DESCRIPTION
Resolves #820 by only showing whole number SNRs, making the display updates look more consistent between slow and fast SNR updates.