### PR TITLE
Save Hamlib rig names on startup as they're able to change out from under us.

### DIFF
--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -66,6 +66,7 @@ public:
 
 private:
     using RigList = std::vector<const struct rig_caps *>;
+    using RigNameList = std::vector<std::string>;
     
     std::string rigName_;
     std::string serialPort_;
@@ -96,6 +97,7 @@ private:
     void requestCurrentFrequencyModeImpl_();
     
     static RigList RigList_;
+    static RigNameList RigNameList_;
     static std::mutex RigListMutex_;
 
     static bool RigCompare_(const struct rig_caps *rig1, const struct rig_caps *rig2);


### PR DESCRIPTION
Hamlib 4.6 added some logic to cause the rig name for FLrig (and possibly) others to change on first usage. For example, with FLrig, the rig name according to FreeDV could end up becoming something like "FLrig IC-7300(FLrig)" internally. As FreeDV uses the rig name and not its ID number to find the rig to use for connecting via Hamlib, the name changing without it knowing causes FreeDV to crash.

This PR saves off the names of the supported Hamlib rigs on startup and uses this list for ID lookups instead, preventing crashes on FreeDV's side.