### PR TITLE
Increase short RX coloring timeout to 5 seconds.

### DIFF
--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -52,7 +52,7 @@ extern FreeDVInterface freedvInterface;
 #endif // defined(WIN32)
 #define RX_ONLY_STATUS "RX Only"
 #define RX_COLORING_LONG_TIMEOUT_SEC (20)
-#define RX_COLORING_SHORT_TIMEOUT_SEC (2)
+#define RX_COLORING_SHORT_TIMEOUT_SEC (5)
 #define MSG_COLORING_TIMEOUT_SEC (5)
 #define STATUS_MESSAGE_MRU_MAX_SIZE (10)
 #define MESSAGE_COLUMN_ID (6)


### PR DESCRIPTION
Resolves #833 by increasing the "short" RX coloring timeout (i.e. when a callsign hasn't been received yet) to 5 seconds from the 2 seconds that it was before.