### PR TITLE
Shorten PulseAudio/pipewire app name.

### DIFF
--- a/src/audio/PulseAudioEngine.cpp
+++ b/src/audio/PulseAudioEngine.cpp
@@ -52,7 +52,7 @@ void PulseAudioEngine::start()
     }
     
     mainloopApi_ = pa_threaded_mainloop_get_api(mainloop_);
-    context_ = pa_context_new(mainloopApi_, "FreeDV HF Digital Voice");
+    context_ = pa_context_new(mainloopApi_, "FreeDV");
     
     if (context_ == nullptr)
     {


### PR DESCRIPTION
Per request in #841, this PR shortens the app name given to PulseAudio/pipewire such that spaces aren't required.