### PR TITLE
Zero out invalid socket ID on disconnect to avoid repeatedly erroring on read/write.

### DIFF
--- a/src/util/TcpConnectionHandler.cpp
+++ b/src/util/TcpConnectionHandler.cpp
@@ -471,7 +471,8 @@ void TcpConnectionHandler::disconnectImpl_()
 #else
         close(socket_);
 #endif // defined(WIN32)
-        
+        socket_ = -1;
+
         onDisconnect_();
         
         if (enableReconnect_)


### PR DESCRIPTION
Hopefully resolves #846.