### PR TITLE
Fix crash on FreeDV Reporter connection failure

### DIFF
--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -56,16 +56,6 @@ FreeDVReporter::~FreeDVReporter()
         isExiting_ = true;
         fnQueueConditionVariable_.notify_one();
         fnQueueThread_.join();
-    
-        // Workaround for race condition in sioclient.
-        // However, we shouldn't wait forever in case something goes
-        // wrong during disconnect; the loop below will only wait a 
-        // maximum of 5 seconds (250 * 20ms = 5000ms).
-        int count = 0;
-        while (isConnecting_ && count++ < 250)
-        {
-            std::this_thread::sleep_for(20ms);
-        }
     }
     
     delete sioClient_;

--- a/src/util/TcpConnectionHandler.cpp
+++ b/src/util/TcpConnectionHandler.cpp
@@ -669,13 +669,13 @@ socket_error:
 #else
                 close(sock);
 #endif // defined(WIN32)
-                socketsToDelete.push_back(socket_);
+                socketsToDelete.push_back(sock);
             }
         }
         
         for (auto& toDelete : socketsToDelete)
         {
-            sockets.erase(std::find(socketsToDelete.begin(), socketsToDelete.end(), toDelete));
+            sockets.erase(std::find(sockets.begin(), sockets.end(), toDelete));
         }
     }
 }

--- a/src/util/TcpConnectionHandler.h
+++ b/src/util/TcpConnectionHandler.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <future>
+#include <atomic>
 
 class TcpConnectionHandler : public ThreadedObject
 {
@@ -55,6 +56,7 @@ private:
     int socket_;
     std::atomic<bool> ipv4Complete_;
     std::atomic<bool> ipv6Complete_;
+    std::atomic<bool> cancelConnect_;
     
     void connectImpl_();
     void disconnectImpl_();


### PR DESCRIPTION
Followup fix for #846 to handle issue where FreeDV crashes if unable to reach the FreeDV Reporter server. To test:

1. Go to Tools->Options->Reporting and enter an IP address that's not being used by anything else on your local network (i.e. 10.0.1.2).
2. Note in logs that it's trying to connect to 10.0.1.2 (or whatever IP you configured). Wait until the connection times out.
4. Repeat (1) but use `qso.freedv.org` instead. It should stop the pending (re)connection and immediately reconnect to the regular FreeDV Reporter server.