### PR TITLE
Report "unk" for mode on Hamlib disconnect

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -901,6 +901,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue preventing suppression of the Msg tooltip for non-truncated messages. (PR #829)
     * Preserve Hamlib rig names on startup to guard against changes by Hamlib during execution. (PR #834)
     * Fix dropouts related to virtual audio cables. (PR #840)
+    * Report "unk" for mode on Hamlib disconnect. (PR #851)
 2. Enhancements:
     * Show green line indicating RX frequency. (PR #725)
     * Update configuration of the Voice Keyer feature based on user feedback. (PR #730, #746, #793)

--- a/src/main.h
+++ b/src/main.h
@@ -518,6 +518,8 @@ class MainFrame : public TopFrame
         void updateReportingFreqList_();
         
         void initializeFreeDVReporter_();
+        
+        void onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode);
 };
 
 void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);

--- a/src/main.h
+++ b/src/main.h
@@ -521,7 +521,7 @@ class MainFrame : public TopFrame
         
         void onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode);
         void onRadioConnected_(IRigController* ptr);
-        void onRadioDisconnect_(IRigController* ptr);
+        void onRadioDisconnected_(IRigController* ptr);
 };
 
 void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);

--- a/src/main.h
+++ b/src/main.h
@@ -520,6 +520,8 @@ class MainFrame : public TopFrame
         void initializeFreeDVReporter_();
         
         void onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode);
+        void onRadioConnected_(IRigController* ptr);
+        void onRadioDisconnect_(IRigController* ptr);
 };
 
 void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -486,7 +486,7 @@ void MainFrame::onRadioConnected_(IRigController* ptr)
     }
 }
 
-void MainFrame::onRadioDisconnect_(IRigController* ptr)
+void MainFrame::onRadioDisconnected_(IRigController* ptr)
 {
     CallAfter([&]() {
         m_txtModeStatus->SetLabel(wxT("unk"));

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -375,6 +375,96 @@ void MainFrame::OnHelpAbout(wxCommandEvent& event)
     wxMessageBox(msg, wxT("About"), wxOK | wxICON_INFORMATION, this);
 }
 
+void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode)
+{
+    CallAfter([&, mode, freq]() {
+        if (firstFreqUpdateOnConnect_)
+        {
+            firstFreqUpdateOnConnect_ = false;
+            return;
+        }
+
+        // Update string value.
+        switch(mode)
+        {
+            case IRigFrequencyController::USB:
+                m_txtModeStatus->SetLabel(wxT("USB"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::DIGU:
+                m_txtModeStatus->SetLabel(wxT("USB-D"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::LSB:
+                m_txtModeStatus->SetLabel(wxT("LSB"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::DIGL:
+                m_txtModeStatus->SetLabel(wxT("LSB-D"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::FM:
+                m_txtModeStatus->SetLabel(wxT("FM"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::DIGFM:
+                m_txtModeStatus->SetLabel(wxT("FM-D"));
+                m_txtModeStatus->Enable(true);
+                break;
+            case IRigFrequencyController::AM:
+                m_txtModeStatus->SetLabel(wxT("AM"));
+                m_txtModeStatus->Enable(true);
+                break;
+            default:
+                m_txtModeStatus->SetLabel(wxT("unk"));
+                m_txtModeStatus->Enable(false);
+                break;
+        }
+
+        // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
+        bool is60MeterBand = freq >= 5250000 && freq <= 5450000;
+
+        // Update color based on the mode and current frequency.
+        bool isUsbFreq = freq >= 10000000 || is60MeterBand;
+        bool isLsbFreq = freq < 10000000 && !is60MeterBand;
+
+        bool isMatchingMode = 
+            (isUsbFreq && (mode == IRigFrequencyController::USB || mode == IRigFrequencyController::DIGU)) ||
+            (isLsbFreq && (mode == IRigFrequencyController::LSB || mode == IRigFrequencyController::DIGL));
+
+        if (isMatchingMode)
+        {
+            m_txtModeStatus->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+        }
+        else
+        {
+            m_txtModeStatus->SetForegroundColour(wxColor(*wxRED));
+        }
+
+        // Update frequency box
+        if (!suppressFreqModeUpdates_ && (
+            !wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||
+            !wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting))
+        {
+            // wxString::Format() doesn't respect locale but C++ iomanip should. Use the latter instead.
+            std::stringstream ss;
+            std::locale loc("");
+            ss.imbue(loc);
+            
+            if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
+            {
+                ss << std::fixed << std::setprecision(1) << (freq / 1000.0);
+            }
+            else
+            {
+                ss << std::fixed << std::setprecision(4) << (freq / 1000.0 / 1000.0);
+            }
+            
+            m_cboReportFrequency->SetValue(ss.str());
+        }
+        m_txtModeStatus->Refresh();
+    });
+}
 
 // Attempt to talk to rig using Hamlib
 
@@ -438,97 +528,9 @@ bool MainFrame::OpenHamlibRig() {
             });
         };
 
-        wxGetApp().rigFrequencyController->onFreqModeChange += [&](IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode)
-        {
-            CallAfter([&, mode, freq]() {
-                if (firstFreqUpdateOnConnect_)
-                {
-                    firstFreqUpdateOnConnect_ = false;
-                    return;
-                }
-
-                // Update string value.
-                switch(mode)
-                {
-                    case IRigFrequencyController::USB:
-                        m_txtModeStatus->SetLabel(wxT("USB"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::DIGU:
-                        m_txtModeStatus->SetLabel(wxT("USB-D"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::LSB:
-                        m_txtModeStatus->SetLabel(wxT("LSB"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::DIGL:
-                        m_txtModeStatus->SetLabel(wxT("LSB-D"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::FM:
-                        m_txtModeStatus->SetLabel(wxT("FM"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::DIGFM:
-                        m_txtModeStatus->SetLabel(wxT("FM-D"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    case IRigFrequencyController::AM:
-                        m_txtModeStatus->SetLabel(wxT("AM"));
-                        m_txtModeStatus->Enable(true);
-                        break;
-                    default:
-                        m_txtModeStatus->SetLabel(wxT("unk"));
-                        m_txtModeStatus->Enable(false);
-                        break;
-                }
-
-                // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
-                bool is60MeterBand = freq >= 5250000 && freq <= 5450000;
-    
-                // Update color based on the mode and current frequency.
-                bool isUsbFreq = freq >= 10000000 || is60MeterBand;
-                bool isLsbFreq = freq < 10000000 && !is60MeterBand;
-    
-                bool isMatchingMode = 
-                    (isUsbFreq && (mode == IRigFrequencyController::USB || mode == IRigFrequencyController::DIGU)) ||
-                    (isLsbFreq && (mode == IRigFrequencyController::LSB || mode == IRigFrequencyController::DIGL));
-    
-                if (isMatchingMode)
-                {
-                    m_txtModeStatus->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-                }
-                else
-                {
-                    m_txtModeStatus->SetForegroundColour(wxColor(*wxRED));
-                }
-
-                // Update frequency box
-                if (!suppressFreqModeUpdates_ && (
-                    !wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||
-                    !wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting))
-                {
-                    // wxString::Format() doesn't respect locale but C++ iomanip should. Use the latter instead.
-                    std::stringstream ss;
-                    std::locale loc("");
-                    ss.imbue(loc);
-                    
-                    if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
-                    {
-                        ss << std::fixed << std::setprecision(1) << (freq / 1000.0);
-                    }
-                    else
-                    {
-                        ss << std::fixed << std::setprecision(4) << (freq / 1000.0 / 1000.0);
-                    }
-                    
-                    m_cboReportFrequency->SetValue(ss.str());
-                }
-                m_txtModeStatus->Refresh();
-            });
+        wxGetApp().rigFrequencyController->onFreqModeChange += [&](IRigFrequencyController* ptr, uint64_t freq, IRigFrequencyController::Mode mode) {
+            onFrequencyModeChange_(ptr, freq, mode);
         };
-
         wxGetApp().rigFrequencyController->connect();
         return true;
     }
@@ -580,84 +582,8 @@ void MainFrame::OpenOmniRig()
         });
     };
 
-    wxGetApp().rigFrequencyController->onFreqModeChange += [&](IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode)
-    {
-        CallAfter([&, mode, freq]() {
-            // Update string value.
-            switch(mode)
-            {
-                case IRigFrequencyController::USB:
-                    m_txtModeStatus->SetLabel(wxT("USB"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::DIGU:
-                    m_txtModeStatus->SetLabel(wxT("USB-D"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::LSB:
-                    m_txtModeStatus->SetLabel(wxT("LSB"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::DIGL:
-                    m_txtModeStatus->SetLabel(wxT("LSB-D"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::FM:
-                    m_txtModeStatus->SetLabel(wxT("FM"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::DIGFM:
-                    m_txtModeStatus->SetLabel(wxT("FM-D"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                case IRigFrequencyController::AM:
-                    m_txtModeStatus->SetLabel(wxT("AM"));
-                    m_txtModeStatus->Enable(true);
-                    break;
-                default:
-                    m_txtModeStatus->SetLabel(wxT("unk"));
-                    m_txtModeStatus->Enable(false);
-                    break;
-            }
-
-            // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
-            bool is60MeterBand = freq >= 5250000 && freq <= 5450000;
-
-            // Update color based on the mode and current frequency.
-            bool isUsbFreq = freq >= 10000000 || is60MeterBand;
-            bool isLsbFreq = freq < 10000000 && !is60MeterBand;
-
-            bool isMatchingMode = 
-                (isUsbFreq && (mode == IRigFrequencyController::USB || mode == IRigFrequencyController::DIGU)) ||
-                (isLsbFreq && (mode == IRigFrequencyController::LSB || mode == IRigFrequencyController::DIGL));
-
-            if (isMatchingMode)
-            {
-                m_txtModeStatus->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-            }
-            else
-            {
-                m_txtModeStatus->SetForegroundColour(wxColor(*wxRED));
-            }
-
-            // Update frequency box
-            if (!wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled ||
-                !wxGetApp().appConfiguration.reportingConfiguration.manualFrequencyReporting)
-            {
-                if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
-                {
-                    m_cboReportFrequency->SetValue(wxString::Format("%.1f", freq / 1000.0));
-                }
-                else
-                {
-                    m_cboReportFrequency->SetValue(wxString::Format("%.4f", freq / 1000.0 / 1000.0));
-                }
-            }
-            m_txtModeStatus->Refresh();
-
-            // Suppress updates if the Report Frequency box has focus.
-            suppressFreqModeUpdates_ = m_cboReportFrequency->HasFocus();
-        });
+    wxGetApp().rigFrequencyController->onFreqModeChange += [&](IRigFrequencyController* ptr, uint64_t freq, IRigFrequencyController::Mode mode) {
+        onFrequencyModeChange_(ptr, freq, mode);
     };
 
     // Temporarily suppress frequency updates until we're fully connected.

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -396,6 +396,8 @@ void HamlibRigController::disconnectImpl_()
         rig_close(rig_);
         rig_cleanup(rig_);
         rig_ = nullptr;
+        
+        onRigDisconnected(this);
     }
 }
 


### PR DESCRIPTION
Resolves #850 by adding missed event handler call on Hamlib disconnect, which was supposed to auto-reset the displayed mode back to "unk". This PR also contains some cleanup of duplicated code between OmniRig and Hamlib.