### PR TITLE
We should be logging getaddrinfo failures as warn, not debug.

### DIFF
--- a/src/util/TcpConnectionHandler.cpp
+++ b/src/util/TcpConnectionHandler.cpp
@@ -701,7 +701,7 @@ void TcpConnectionHandler::resolveAddresses_(int addressFamily, const char* host
     int err = getaddrinfo(host, port, &hints, result);
     if (err != 0) 
     {
-        log_debug("cannot resolve %s:%s using family %d (err=%d)", host, port, addressFamily, err);
+        log_warn("cannot resolve %s:%s using family %d (err=%d)", host, port, addressFamily, err);
     }
     
     log_info("resolution of %s:%s using family %d complete", host, port, addressFamily);


### PR DESCRIPTION
Observed on code inspection due to lack of errors in https://github.com/drowe67/freedv-gui/pull/849#issuecomment-2761173385. This PR uses warn instead of debug so we can actually log DNS failures.