### PR TITLE
Clear connect cancellation after finishing disconnect.

### DIFF
--- a/src/util/TcpConnectionHandler.cpp
+++ b/src/util/TcpConnectionHandler.cpp
@@ -116,6 +116,7 @@ std::future<void> TcpConnectionHandler::disconnect()
     
     enqueue_([&, prom]() {
         disconnectImpl_();
+        cancelConnect_ = false;
         prom->set_value();
     });
     return fut;


### PR DESCRIPTION
`cancelConnect_` in FreeDV Reporter code (used to abort connection attempts during disconnect) wasn't getting reset to `false` after the completion of the disconnect. This was preventing reconnections to FreeDV Reporter, even with valid DNS results. This PR adds the missing reset, permitting reconnections as long as the connection object is valid.

(Originally reported in https://github.com/drowe67/freedv-gui/pull/849#issuecomment-2761173385).