### PR TITLE
sioclient-disabled build (cmake -DUSE_SIOCLIENT=0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,20 +466,23 @@ endif(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
 
 
 # sioclient library
-message(STATUS "Looking for sioclient...")
-find_path(SIOCLIENT_INCLUDE_DIR sio_client.h)
-find_library(SIOCLIENT_LIBRARY sioclient)
-message(STATUS "  Socket.io library: ${SIOCLIENT_LIBRARY}")
-message(STATUS "  Socket.io headers: ${SIOCLIENT_INCLUDE_DIR}")
-if(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
-    message(STATUS "Socket.io library found.")
-    include_directories(${SIOCLIENT_INCLUDE_DIR})
-    list(APPEND FREEDV_LINK_LIBS ${SIOCLIENT_LIBRARY})
-else(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
-    message(STATUS "Using static sioclient build")
-    include(cmake/BuildSocketIo.cmake)
-endif(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
-
+option(USE_SIOCLIENT "Report using sioclient." ON)
+if(USE_SIOCLIENT)
+    message(STATUS "Looking for sioclient...")
+    find_path(SIOCLIENT_INCLUDE_DIR sio_client.h)
+    find_library(SIOCLIENT_LIBRARY sioclient)
+    message(STATUS "  Socket.io library: ${SIOCLIENT_LIBRARY}")
+    message(STATUS "  Socket.io headers: ${SIOCLIENT_INCLUDE_DIR}")
+    if(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
+        message(STATUS "Socket.io library found.")
+        include_directories(${SIOCLIENT_INCLUDE_DIR})
+        list(APPEND FREEDV_LINK_LIBS ${SIOCLIENT_LIBRARY})
+    else(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
+        message(STATUS "Using static sioclient build")
+        include(cmake/BuildSocketIo.cmake)
+    endif(SIOCLIENT_LIBRARY AND SIOCLIENT_INCLUDE_DIR)
+    add_definitions(-DUSE_SIOCLIENT)
+endif(USE_SIOCLIENT)
 
 #
 # Samplerate Library

--- a/src/reporting/CMakeLists.txt
+++ b/src/reporting/CMakeLists.txt
@@ -1,10 +1,19 @@
-add_library(fdv_reporting STATIC
-    pskreporter.cpp
-    pskreporter.h
-    FreeDVReporter.cpp
-    FreeDVReporter.h
-)
-
+message(STATUS "Reporting...")
 if(SIOCLIENT_ADD_DEPENDENCY)
-add_dependencies(fdv_reporting sioclient)
+    add_library(fdv_reporting STATIC
+        pskreporter.cpp
+        pskreporter.h
+        FreeDVReporter.cpp
+        FreeDVReporter.h
+    )
+    add_dependencies(fdv_reporting sioclient)
+    message(STATUS "Reporting via pskreporter and FreeDVReporter.")
+else(SIOCLIENT_ADD_DEPENDENCY)
+    add_library(fdv_reporting STATIC
+        pskreporter.cpp
+        pskreporter.h
+        FreeDVReporter_dummy.cpp
+        FreeDVReporter.h
+    )
+    message(STATUS "Reporting via pskreporter only.")
 endif(SIOCLIENT_ADD_DEPENDENCY)

--- a/src/reporting/FreeDVReporter_dummy.cpp
+++ b/src/reporting/FreeDVReporter_dummy.cpp
@@ -1,0 +1,154 @@
+//=========================================================================
+// Name:            FreeDVReporter.h
+// Purpose:         Implementation of interface to freedv-reporter
+//
+// Authors:         Mooneer Salem
+// License:
+//
+//  All rights reserved.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//=========================================================================
+
+#include "FreeDVReporter.h"
+#include "../os/os_interface.h"
+
+FreeDVReporter::FreeDVReporter(std::string hostname, std::string callsign, std::string gridSquare, std::string software, bool rxOnly)
+    : isExiting_(false)
+    , isConnecting_(false)
+    , hostname_(hostname)
+    , callsign_(callsign)
+    , gridSquare_(gridSquare)
+    , software_(software)
+    , lastFrequency_(0)
+    , tx_(false)
+    , rxOnly_(rxOnly)
+    , hidden_(false)
+{
+    // do nothing
+}
+
+FreeDVReporter::~FreeDVReporter()
+{
+    // do nothing
+}
+
+void FreeDVReporter::connect()
+{    
+    // do nothing
+}
+
+void FreeDVReporter::requestQSY(std::string sid, uint64_t frequencyHz, std::string message)
+{
+    // do nothing
+}
+
+void FreeDVReporter::updateMessage(std::string message)
+{
+    // do nothing
+}
+
+void FreeDVReporter::inAnalogMode(bool inAnalog)
+{
+    // do nothing
+}
+
+void FreeDVReporter::freqChange(uint64_t frequency)
+{
+    // do nothing
+}
+
+void FreeDVReporter::transmit(std::string mode, bool tx)
+{
+    // do nothing
+}
+
+void FreeDVReporter::hideFromView()
+{
+    // do nothing
+}
+
+void FreeDVReporter::showOurselves()
+{
+    // do nothing
+}
+    
+void FreeDVReporter::addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr)
+{
+    // do nothing
+}
+
+void FreeDVReporter::send()
+{
+    // No implementation needed, we send RX/TX reports live.
+}
+
+void FreeDVReporter::setOnReporterConnectFn(ReporterConnectionFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnReporterDisconnectFn(ReporterConnectionFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnUserConnectFn(ConnectionDataFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnUserDisconnectFn(ConnectionDataFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnFrequencyChangeFn(FrequencyChangeFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnTransmitUpdateFn(TxUpdateFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnReceiveUpdateFn(RxUpdateFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setOnQSYRequestFn(QsyRequestFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setMessageUpdateFn(MessageUpdateFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setConnectionSuccessfulFn(ConnectionSuccessfulFn fn)
+{
+    // do nothing
+}
+
+void FreeDVReporter::setAboutToShowSelfFn(AboutToShowSelfFn fn)
+{
+    // do nothing
+}
+
+bool FreeDVReporter::isValidForReporting()
+{
+    return false;
+}

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -354,6 +354,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     wxMenuItem* m_menuItemFreeDVReporter;
     m_menuItemFreeDVReporter = new wxMenuItem(tools, wxID_ANY, wxString(_("FreeDV R&eporter")) , _("Opens browser window and displays FreeDV Reporter service."), wxITEM_NORMAL);
     tools->Append(m_menuItemFreeDVReporter);
+    m_menuItemFreeDVReporter->Enable(false);
     
     wxMenuItem* toolsSeparator1 = new wxMenuItem(tools, wxID_SEPARATOR);
     tools->Append(toolsSeparator1);
@@ -804,8 +805,10 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     this->Connect(m_menuItemEasySetup->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnToolsEasySetup));
     this->Connect(m_menuItemEasySetup->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(TopFrame::OnToolsEasySetupUI));
+#if USE_SIOCLIENT
     this->Connect(m_menuItemFreeDVReporter->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnToolsFreeDVReporter));
     this->Connect(m_menuItemFreeDVReporter->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(TopFrame::OnToolsFreeDVReporterUI));
+#endif
     this->Connect(m_menuItemAudio->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnToolsAudio));
     this->Connect(m_menuItemAudio->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(TopFrame::OnToolsAudioUI));
     this->Connect(m_menuItemFilter->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnToolsFilter));


### PR DESCRIPTION
Debian has [optional-sio-client](https://sources.debian.org/src/freedv/1.8.11-1/debian/patches/optional-sio-client/) patch, to build without sioclient library.

Debian has this patch due to sioclient is not packaged, but it cannot apply to current build.
Here is an alternative.

And, this might be useful for building-sioclient-is-difficult environments.
