### PR TITLE
Request real-time priority from the operating system for audio pipeline

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -29,7 +29,7 @@ jobs:
             
     - name: Spellcheck codebase
       shell: bash
-      run: codespell --ignore-words-list=caf,radae,rade,inout,nin,ontop,parm,tthe,ue `find src -name '*.c*' -o -name '*.h' -o -name '*.mm' | grep -v 3rdparty`
+      run: codespell --ignore-words-list=caf,radae,rade,inout,nin,ontop,parm,tthe,ue `find src -name '*.c*' -o -name '*.h' | grep -v 3rdparty`
 
     - name: Install Python required modules
       shell: bash

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get upgrade -y
-           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal
+           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal libdbus-1-dev
             
     - name: Spellcheck codebase
       shell: bash

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get upgrade -y
-           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal libdbus-1-dev
+           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal libdbus-1-dev rtkit
             
     - name: Spellcheck codebase
       shell: bash

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -25,7 +25,8 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get upgrade -y
-           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal libdbus-1-dev rtkit
+           sudo apt-get install codespell libpulse-dev libspeexdsp-dev libsamplerate0-dev sox git libwxgtk3.2-dev portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pipewire pulseaudio-utils pipewire-pulse wireplumber metacity dbus-x11 at-spi2-core rtkit octave octave-signal libdbus-1-dev
+           sudo usermod -a -G rtkit $(whoami)
             
     - name: Spellcheck codebase
       shell: bash

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -17,7 +17,6 @@ jobs:
         os: [macos-13, macos-latest]  # x86_64, ARM64
 
     runs-on: ${{ matrix.os }}
-    needs: dist
 
     steps:
     - uses: actions/checkout@v4
@@ -85,6 +84,7 @@ jobs:
   # x86 and ARM. No point in doing so if there's a failure on either.
   dist:
     runs-on: macos-latest
+    needs: test
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -17,6 +17,7 @@ jobs:
         os: [macos-13, macos-latest]  # x86_64, ARM64
 
     runs-on: ${{ matrix.os }}
+    needs: dist
 
     steps:
     - uses: actions/checkout@v4
@@ -84,7 +85,6 @@ jobs:
   # x86 and ARM. No point in doing so if there's a failure on either.
   dist:
     runs-on: macos-latest
-    needs: test
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,7 +728,7 @@ DefineAudioTest(RADEV1)
 add_test(NAME fullduplex_RADEV1_repeated
          COMMAND sh -c " ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1")
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES FAIL_REGULAR_EXPRESSION "Sync changed from 1 to 0")
-set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES DISABLED TRUE)
+#set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES DISABLED TRUE)
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES LABELS stress_test)
 
 DefineAudioTest(700D)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,18 @@ if(USE_STATIC_DEPS)
 endif(USE_STATIC_DEPS)
 
 #
+# Find DBus (Linux only)--this is so that we can use
+# rtkit to request real-time scheduling for our audio 
+# threads.
+if (LINUX)
+    message(STATUS "Looking for DBus...")
+    find_package(DBus)
+    if (DBUS_FOUND)
+        message(STATUS "Found DBus, will attempt to use rtkit for real-time threading")
+    endif (DBUS_FOUND)
+endif (LINUX)
+
+#
 # Find wxWidgets
 #
 set(DARK_MODE_DISABLE "false")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,7 +728,7 @@ DefineAudioTest(RADEV1)
 add_test(NAME fullduplex_RADEV1_repeated
          COMMAND sh -c " ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1 && ${CMAKE_CURRENT_SOURCE_DIR}/test/test_zeros.sh txrx RADEV1")
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES FAIL_REGULAR_EXPRESSION "Sync changed from 1 to 0")
-#set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES DISABLED TRUE)
+set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES DISABLED TRUE)
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES LABELS stress_test)
 
 DefineAudioTest(700D)

--- a/cmake/FindDBus.cmake
+++ b/cmake/FindDBus.cmake
@@ -1,0 +1,59 @@
+# - Try to find DBus
+# Once done, this will define
+#
+#  DBUS_FOUND - system has DBus
+#  DBUS_INCLUDE_DIRS - the DBus include directories
+#  DBUS_LIBRARIES - link these to use DBus
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FIND_PACKAGE(PkgConfig)
+PKG_CHECK_MODULES(PC_DBUS QUIET dbus-1)
+
+FIND_LIBRARY(DBUS_LIBRARIES
+    NAMES dbus-1
+    HINTS ${PC_DBUS_LIBDIR}
+          ${PC_DBUS_LIBRARY_DIRS}
+)
+
+FIND_PATH(DBUS_INCLUDE_DIR
+    NAMES dbus/dbus.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+)
+
+GET_FILENAME_COMPONENT(_DBUS_LIBRARY_DIR ${DBUS_LIBRARIES} PATH)
+FIND_PATH(DBUS_ARCH_INCLUDE_DIR
+    NAMES dbus/dbus-arch-deps.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+          ${_DBUS_LIBRARY_DIR}
+          ${DBUS_INCLUDE_DIR}
+    PATH_SUFFIXES include
+)
+
+SET(DBUS_INCLUDE_DIRS ${DBUS_INCLUDE_DIR} ${DBUS_ARCH_INCLUDE_DIR})
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DBUS REQUIRED_VARS DBUS_INCLUDE_DIRS DBUS_LIBRARIES)

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -10,9 +10,14 @@ if(NATIVE_AUDIO_AVAILABLE)
             WASAPIAudioDevice.cpp
         )
     elseif(LINUX)
+        if (DBUS_FOUND)
+            set(RTKIT_FILES rtkit.c)
+        endif (DBUS_FOUND)
+
         set(AUDIO_ENGINE_LIBRARY_SPECIFIC_FILES
             PulseAudioDevice.cpp
             PulseAudioEngine.cpp
+	    ${RTKIT_FILES}
         )
     endif()
 else()
@@ -37,6 +42,10 @@ if(APPLE AND NATIVE_AUDIO_AVAILABLE)
         "-framework CoreAudio")
 elseif(WIN32 AND NATIVE_AUDIO_AVAILABLE)
     target_link_libraries(fdv_audio PRIVATE uuid avrt)
+elseif(LINUX AND NATIVE_AUDIO_AVAILABLE AND DBUS_FOUND)
+    target_include_directories(fdv_audio PRIVATE ${DBUS_INCLUDE_DIRS})
+    target_compile_definitions(fdv_audio PRIVATE -DUSE_RTKIT)
+    target_link_libraries(fdv_audio PRIVATE ${DBUS_LIBRARIES})
 endif()
 
 if(BOOTSTRAP_WXWIDGETS)

--- a/src/audio/IAudioDevice.h
+++ b/src/audio/IAudioDevice.h
@@ -30,10 +30,11 @@
 #include <chrono>
 
 #include "AudioDeviceSpecification.h"
+#include "../util/IRealtimeHelper.h"
 
 using namespace std::chrono_literals;
 
-class IAudioDevice
+class IAudioDevice : public IRealtimeHelper
 {
 public:
     typedef std::function<void(IAudioDevice&, void*, size_t, void*)> AudioDataCallbackFn;
@@ -54,18 +55,18 @@ public:
     
     // Configures current thread for real-time priority. This should be
     // called from the thread that will be operating on received audio.
-    virtual void setHelperRealTime() { /* empty */ }
+    virtual void setHelperRealTime() override { /* empty */ }
     
     // Lets audio system know that we're beginning to do work with the
     // received audio.
-    virtual void startRealTimeWork() { /* empty */ }
+    virtual void startRealTimeWork() override { /* empty */ }
     
     // Lets audio system know that we're done with the work on the received
     // audio.
-    virtual void stopRealTimeWork() { std::this_thread::sleep_for(10ms); }
+    virtual void stopRealTimeWork() override { std::this_thread::sleep_for(10ms); }
     
     // Reverts real-time priority for current thread.
-    virtual void clearHelperRealTime() { /* empty */ }
+    virtual void clearHelperRealTime() override { /* empty */ }
 
     // Sets user friendly description of device. Not used by all engines.
     void setDescription(std::string desc);

--- a/src/audio/IAudioDevice.h
+++ b/src/audio/IAudioDevice.h
@@ -46,6 +46,21 @@ public:
     virtual bool isRunning() = 0;
     
     virtual int getLatencyInMicroseconds() = 0;
+    
+    // Configures current thread for real-time priority. This should be
+    // called from the thread that will be operating on received audio.
+    virtual void setHelperRealTime() { /* empty */ }
+    
+    // Lets audio system know that we're beginning to do work with the
+    // received audio.
+    virtual void startRealTimeWork() { /* empty */ }
+    
+    // Lets audio system know that we're done with the work on the received
+    // audio.
+    virtual void stopRealTimeWork() { /* empty */ }
+    
+    // Reverts real-time priority for current thread.
+    virtual void clearHelperRealTime() { /* empty */ }
 
     // Sets user friendly description of device. Not used by all engines.
     void setDescription(std::string desc);

--- a/src/audio/IAudioDevice.h
+++ b/src/audio/IAudioDevice.h
@@ -26,7 +26,12 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <thread>
+#include <chrono>
+
 #include "AudioDeviceSpecification.h"
+
+using namespace std::chrono_literals;
 
 class IAudioDevice
 {
@@ -57,7 +62,7 @@ public:
     
     // Lets audio system know that we're done with the work on the received
     // audio.
-    virtual void stopRealTimeWork() { /* empty */ }
+    virtual void stopRealTimeWork() { std::this_thread::sleep_for(10ms); }
     
     // Reverts real-time priority for current thread.
     virtual void clearHelperRealTime() { /* empty */ }

--- a/src/audio/MacAudioDevice.h
+++ b/src/audio/MacAudioDevice.h
@@ -23,6 +23,8 @@
 #ifndef MAC_AUDIO_DEVICE_H
 #define MAC_AUDIO_DEVICE_H
 
+#include <dispatch/dispatch.h>
+
 #include "../util/ThreadedObject.h"
 #include "IAudioEngine.h"
 #include "IAudioDevice.h"
@@ -74,6 +76,8 @@ private:
     
     void* workgroup_;
     void* joinToken_;
+    
+    dispatch_semaphore_t sem_;
 };
 
 #endif // MAC_AUDIO_DEVICE_H

--- a/src/audio/MacAudioDevice.h
+++ b/src/audio/MacAudioDevice.h
@@ -41,6 +41,21 @@ public:
     virtual bool isRunning() override;
     
     virtual int getLatencyInMicroseconds() override;
+    
+    // Configures current thread for real-time priority. This should be
+    // called from the thread that will be operating on received audio.
+    virtual void setHelperRealTime() override;
+
+    // Lets audio system know that we're beginning to do work with the
+    // received audio.
+    virtual void startRealTimeWork() override;
+
+    // Lets audio system know that we're done with the work on the received
+    // audio.
+    virtual void stopRealTimeWork() override;
+
+    // Reverts real-time priority for current thread.
+    virtual void clearHelperRealTime() override;
 
 protected:
     friend class MacAudioEngine;
@@ -56,6 +71,9 @@ private:
     int sampleRate_;
     void* engine_; // actually AVAudioEngine but this file is shared with C++ code
     void* player_; // actually AVAudioPlayerNode
+    
+    void* workgroup_;
+    void* joinToken_;
 };
 
 #endif // MAC_AUDIO_DEVICE_H

--- a/src/audio/MacAudioDevice.h
+++ b/src/audio/MacAudioDevice.h
@@ -23,6 +23,7 @@
 #ifndef MAC_AUDIO_DEVICE_H
 #define MAC_AUDIO_DEVICE_H
 
+#include <thread>
 #include <dispatch/dispatch.h>
 
 #include "../util/ThreadedObject.h"
@@ -74,8 +75,8 @@ private:
     void* engine_; // actually AVAudioEngine but this file is shared with C++ code
     void* player_; // actually AVAudioPlayerNode
     
-    void* workgroup_;
-    void* joinToken_;
+    static thread_local void* workgroup_;
+    static thread_local void* joinToken_;
     
     dispatch_semaphore_t sem_;
 };

--- a/src/audio/MacAudioDevice.h
+++ b/src/audio/MacAudioDevice.h
@@ -66,15 +66,15 @@ protected:
     MacAudioDevice(int coreAudioId, IAudioEngine::AudioDirection direction, int numChannels, int sampleRate);
     
 private:
-    const double FRAME_TIME_SEC_ = 0.01;
-    
     int coreAudioId_;
     IAudioEngine::AudioDirection direction_;
     int numChannels_;
     int sampleRate_;
     void* engine_; // actually AVAudioEngine but this file is shared with C++ code
     void* player_; // actually AVAudioPlayerNode
-    
+
+    short* inputFrames_;
+
     static thread_local void* workgroup_;
     static thread_local void* joinToken_;
     

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -131,7 +131,7 @@ void MacAudioDevice::start()
         // reduces dropouts on marginal hardware.
         UInt32 minFrameSize = 0;
         UInt32 maxFrameSize = 0;
-        UInt32 desiredFrameSize = sampleRate_ * 0.005; // Ask for 5ms blocks so we're able to fill the buffer prior to being processed.
+        UInt32 desiredFrameSize = sampleRate_ * 0.011; // Ask for 11ms blocks so we're able to fill the buffer prior to being processed.
         GetIOBufferFrameSizeRange(coreAudioId_, &minFrameSize, &maxFrameSize);
         if (minFrameSize != 0 && maxFrameSize != 0)
         {

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -487,8 +487,8 @@ void MacAudioDevice::setHelperRealTime()
     // means the scheduler would give half the time to the thread.
     // These values have empirically been found to yield good behavior.
     // Good means that audio performance is high and other threads won't starve.
-    const double kGuaranteedAudioDutyCycle = 0.75;
-    const double kMaxAudioDutyCycle = 0.85;
+    const double kGuaranteedAudioDutyCycle = 0.75 / 2;
+    const double kMaxAudioDutyCycle = 0.85 / 2;
     
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -480,14 +480,13 @@ void MacAudioDevice::setHelperRealTime()
     // means the scheduler would give half the time to the thread.
     // These values have empirically been found to yield good behavior.
     // Good means that audio performance is high and other threads won't starve.
-    const double kGuaranteedAudioDutyCycle = 0.25;
-    const double kMaxAudioDutyCycle = 0.5;
+    const double kGuaranteedAudioDutyCycle = 0.8;
+    const double kMaxAudioDutyCycle = 0.95;
     
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
-    // About 512 frames @48KHz
-    auto sampleBuffer = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two
-    const double kTimeQuantum = sampleBuffer * 1000 / sampleRate_;
+    //auto sampleBuffer = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two
+    const double kTimeQuantum = 10; //sampleBuffer * 1000 / sampleRate_;
     
     // Time guaranteed each quantum.
     const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -506,7 +506,7 @@ void MacAudioDevice::setHelperRealTime()
     timeConstraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
     timeConstraints.preemptible = 1;
     
-    result =
+    auto result =
         thread_policy_set(currentThreadId,
                           THREAD_TIME_CONSTRAINT_POLICY,
                           reinterpret_cast<thread_policy_t>(&timeConstraints),

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -38,7 +38,7 @@ constexpr static double kOneNanosecond = 1.0e9;
 // The I/O interval time in seconds.
 constexpr static double kIOIntervalTime = 0.010;
 
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.0025;
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,
@@ -488,7 +488,7 @@ void MacAudioDevice::setHelperRealTime()
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
     //auto sampleBuffer = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two
-    const double kTimeQuantum = AUDIO_SAMPLE_BLOCK_SEC * 1000; //sampleBuffer * 1000 / sampleRate_;
+    const double kTimeQuantum = 2.9; //AUDIO_SAMPLE_BLOCK_SEC * 1000; //sampleBuffer * 1000 / sampleRate_;
     
     // Time guaranteed each quantum.
     const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -31,6 +31,7 @@
 #include <mach/mach_init.h>
 #include <mach/thread_policy.h>
 #include <sched.h>
+#include <pthread.h>
 
 thread_local void* MacAudioDevice::workgroup_ = nullptr;
 thread_local void* MacAudioDevice::joinToken_ = nullptr;
@@ -459,6 +460,9 @@ int MacAudioDevice::getLatencyInMicroseconds()
 
 void MacAudioDevice::setHelperRealTime()
 {
+    // Set thread QoS to "user interactive"
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+
     // Adapted from Chromium project. May need to adjust parameters
     // depending on behavior.
     

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -192,22 +192,6 @@ void MacAudioDevice::start()
             (direction_ == IAudioEngine::AUDIO_ENGINE_OUT) ?
             [engine mainMixerNode] :
             nil;
-            
-        // Create sample rate converter
-        AVAudioFormat* nativeFormat = nil;    
-        if (direction_ == IAudioEngine::AUDIO_ENGINE_IN)
-        {
-            nativeFormat = [[engine inputNode] outputFormatForBus:0];
-        }
-        else
-        {
-            // Audio nodes only accept non-interleaved float samples for some reason, but can handle sample
-            // rate conversions no problem.
-            nativeFormat = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
-                                   sampleRate:sampleRate_
-                                   channels:numChannels_
-                                   interleaved:NO];
-        }
     
         // Create nodes and links
         AVAudioPlayerNode *player = nil;
@@ -240,7 +224,7 @@ void MacAudioDevice::start()
             
             AVAudioSinkNode* sinkNode = [[AVAudioSinkNode alloc] initWithReceiverBlock:block];
             [engine attachNode:sinkNode];    
-            [engine connect:[engine inputNode] to:sinkNode format:nativeFormat]; 
+            [engine connect:[engine inputNode] to:sinkNode format:nil]; 
         }
         else
         {
@@ -266,10 +250,17 @@ void MacAudioDevice::start()
                 
                 return OSStatus(noErr);
             };
+
+            // Audio nodes only accept non-interleaved float samples for some reason, but can handle sample
+            // rate conversions no problem.
+            AVAudioFormat* nativeFormat = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
+                                   sampleRate:sampleRate_
+                                   channels:numChannels_
+                                   interleaved:NO];
             
             AVAudioSourceNode* sourceNode = [[AVAudioSourceNode alloc] initWithFormat:nativeFormat renderBlock:block];
             [engine attachNode:sourceNode];
-            [engine connect:sourceNode to:mixer format:nativeFormat];
+            [engine connect:sourceNode to:mixer format:nil];
         }
     
         log_info("Start engine for device %d", coreAudioId_);

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -433,7 +433,7 @@ int MacAudioDevice::getLatencyInMicroseconds()
                       0,
                       nullptr, 
                       &size, 
-                      &streams);
+                      streams);
             if (result == noErr)
             {
                 propertyAddress.mSelector = kAudioStreamPropertyLatency;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -39,7 +39,11 @@ thread_local void* MacAudioDevice::joinToken_ = nullptr;
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
+#if __aarch64__
 constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
+#else
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.020;
+#endif // __aarch64__
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -480,8 +480,8 @@ void MacAudioDevice::setHelperRealTime()
     // means the scheduler would give half the time to the thread.
     // These values have empirically been found to yield good behavior.
     // Good means that audio performance is high and other threads won't starve.
-    const double kGuaranteedAudioDutyCycle = 0.8;
-    const double kMaxAudioDutyCycle = 0.95;
+    const double kGuaranteedAudioDutyCycle = 0.75;
+    const double kMaxAudioDutyCycle = 0.85;
     
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
@@ -501,7 +501,7 @@ void MacAudioDevice::setHelperRealTime()
     double ms_to_abs_time =
         (static_cast<double>(tbInfo.denom) / tbInfo.numer) * 1000000;
     thread_time_constraint_policy_data_t timeConstraints;
-    timeConstraints.period = 0;
+    timeConstraints.period = kTimeQuantum * ms_to_abs_time;
     timeConstraints.computation = kAudioTimeNeeded * ms_to_abs_time;
     timeConstraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
     timeConstraints.preemptible = 1;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -32,6 +32,9 @@
 #include <mach/thread_policy.h>
 #include <sched.h>
 
+thread_local void* MacAudioDevice::workgroup_ = nullptr;
+thread_local void* MacAudioDevice::joinToken_ = nullptr;
+    
 // One nanosecond in seconds.
 constexpr static double kOneNanosecond = 1.0e9;
 
@@ -83,8 +86,6 @@ MacAudioDevice::MacAudioDevice(int coreAudioId, IAudioEngine::AudioDirection dir
     , sampleRate_(sampleRate)
     , engine_(nil)
     , player_(nil)
-    , workgroup_(nullptr)
-    , joinToken_(nullptr)
 {
     log_info("Create MacAudioDevice with ID %d, channels %d and sample rate %d", coreAudioId, numChannels, sampleRate);
     

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -131,7 +131,7 @@ void MacAudioDevice::start()
         // reduces dropouts on marginal hardware.
         UInt32 minFrameSize = 0;
         UInt32 maxFrameSize = 0;
-        UInt32 desiredFrameSize = sampleRate_ * 0.011; // Ask for 11ms blocks so we're able to fill the buffer prior to being processed.
+        UInt32 desiredFrameSize = 2048;
         GetIOBufferFrameSizeRange(coreAudioId_, &minFrameSize, &maxFrameSize);
         if (minFrameSize != 0 && maxFrameSize != 0)
         {

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -131,7 +131,7 @@ void MacAudioDevice::start()
         // reduces dropouts on marginal hardware.
         UInt32 minFrameSize = 0;
         UInt32 maxFrameSize = 0;
-        UInt32 desiredFrameSize = 512;
+        UInt32 desiredFrameSize = sampleRate_ * 0.005; // Ask for 5ms blocks so we're able to fill the buffer prior to being processed.
         GetIOBufferFrameSizeRange(coreAudioId_, &minFrameSize, &maxFrameSize);
         if (minFrameSize != 0 && maxFrameSize != 0)
         {

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -39,7 +39,7 @@ thread_local void* MacAudioDevice::joinToken_ = nullptr;
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.005;
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -36,9 +36,7 @@
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
-constexpr static double kIOIntervalTime = 0.010;
-
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.020;
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -39,7 +39,7 @@ thread_local void* MacAudioDevice::joinToken_ = nullptr;
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.005;
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -36,7 +36,7 @@
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.020;
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.0025;
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,
@@ -486,7 +486,7 @@ void MacAudioDevice::setHelperRealTime()
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
     //auto sampleBuffer = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two
-    const double kTimeQuantum = 2.9; //AUDIO_SAMPLE_BLOCK_SEC * 1000; //sampleBuffer * 1000 / sampleRate_;
+    const double kTimeQuantum = 10; //AUDIO_SAMPLE_BLOCK_SEC * 1000; //sampleBuffer * 1000 / sampleRate_;
     
     // Time guaranteed each quantum.
     const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -440,7 +440,7 @@ void MacAudioDevice::setHelperRealTime()
     // Get current thread ID
     auto currentThreadId = pthread_mach_thread_np(pthread_self());
     
-#if 1
+#if 0
     // Increase thread priority to real-time.
     // Please note that the thread_policy_set() calls may fail in
     // rare cases if the kernel decides the system is under heavy load
@@ -501,7 +501,7 @@ void MacAudioDevice::setHelperRealTime()
     double ms_to_abs_time =
         (static_cast<double>(tbInfo.denom) / tbInfo.numer) * 1000000;
     thread_time_constraint_policy_data_t timeConstraints;
-    timeConstraints.period = kTimeQuantum * ms_to_abs_time;
+    timeConstraints.period = 0;
     timeConstraints.computation = kAudioTimeNeeded * ms_to_abs_time;
     timeConstraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
     timeConstraints.preemptible = 1;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -40,11 +40,11 @@ thread_local void* MacAudioDevice::joinToken_ = nullptr;
 constexpr static double kOneNanosecond = 1.0e9;
 
 // The I/O interval time in seconds.
-#if __aarch64__
+//#if __aarch64__
 constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.010;
-#else
-constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.020;
-#endif // __aarch64__
+//#else
+//constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.020;
+//#endif // __aarch64__
 
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -86,6 +86,7 @@ MacAudioDevice::MacAudioDevice(int coreAudioId, IAudioEngine::AudioDirection dir
     , sampleRate_(sampleRate)
     , engine_(nil)
     , player_(nil)
+    , inputFrames_(nullptr)
 {
     log_info("Create MacAudioDevice with ID %d, channels %d and sample rate %d", coreAudioId, numChannels, sampleRate);
     
@@ -162,6 +163,11 @@ void MacAudioDevice::start()
                 log_warn("Could not set IO frame size to %d for audio device ID %d", desiredFrameSize, coreAudioId_);
             }
         }
+        else
+        {
+            // Set maxFrameSize to something reasonable for further down.
+            maxFrameSize = 4096;
+        }
         
         // Initialize audio engine.
         AVAudioEngine* engine = [[AVAudioEngine alloc] init];
@@ -215,29 +221,28 @@ void MacAudioDevice::start()
     
         // Create nodes and links
         AVAudioPlayerNode *player = nil;
+        inputFrames_ = new short[maxFrameSize * numChannels_];
+        assert(inputFrames_ != nullptr);
+
         if (direction_ == IAudioEngine::AUDIO_ENGINE_IN)
         {
             log_info("Create mixer node for input device %d", coreAudioId_);
         
             AVAudioInputNode* inNode = [engine inputNode];
-            const int NUM_FRAMES = FRAME_TIME_SEC_ * sampleRate_;
-            
+
             AVAudioSinkNodeReceiverBlock block = ^(const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount, const AudioBufferList* inputData) 
             {
-                short inputFrames[frameCount * numChannels_];
-                memset(inputFrames, 0, sizeof(inputFrames));
-                
                 if (onAudioDataFunction)
                 {
                     for (int index = 0; index < frameCount; index++)
                     {
                         for (int chan = 0; chan < inputData->mNumberBuffers; chan++)
                         {
-                            inputFrames[numChannels_ * index + chan] = ((float*)inputData->mBuffers[chan].mData)[index] * 32767;
+                            inputFrames_[numChannels_ * index + chan] = ((float*)inputData->mBuffers[chan].mData)[index] * 32767;
                         }
                     }
                     
-                    onAudioDataFunction(*this, inputFrames, frameCount, onAudioDataState);
+                    onAudioDataFunction(*this, inputFrames_, frameCount, onAudioDataState);
                 }
                 
                 dispatch_semaphore_signal(sem_);
@@ -255,18 +260,17 @@ void MacAudioDevice::start()
 
             AVAudioSourceNodeRenderBlock block = ^(BOOL *, const AudioTimeStamp *, AVAudioFrameCount frameCount, AudioBufferList *outputData)
             {
-                short outputFrames[frameCount * numChannels_];
-                memset(outputFrames, 0, sizeof(outputFrames));
+                memset(inputFrames_, 0, sizeof(short) * numChannels_ * frameCount);
                 
                 if (onAudioDataFunction)
                 {
-                    onAudioDataFunction(*this, (void*)outputFrames, frameCount, onAudioDataState);
+                    onAudioDataFunction(*this, inputFrames_, frameCount, onAudioDataState);
                     
                     for (int index = 0; index < frameCount; index++)
                     {
                         for (int chan = 0; chan < outputData->mNumberBuffers; chan++)
                         {
-                            ((float*)outputData->mBuffers[chan].mData)[index] = outputFrames[numChannels_ * index + chan] / 32767.0;
+                            ((float*)outputData->mBuffers[chan].mData)[index] = inputFrames_[numChannels_ * index + chan] / 32767.0;
                         }
                     }
                 }
@@ -333,10 +337,15 @@ void MacAudioDevice::stop()
             AVAudioEngine* engine = (AVAudioEngine*)engine_;
             [engine stop];
             [engine release];
+
         }
+
         engine_ = nil;
         player_ = nil;
-        
+
+        delete[] inputFrames_;
+        inputFrames_ = nullptr;
+
         prom->set_value();
     });
     

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -38,6 +38,8 @@ constexpr static double kOneNanosecond = 1.0e9;
 // The I/O interval time in seconds.
 constexpr static double kIOIntervalTime = 0.010;
 
+constexpr static double AUDIO_SAMPLE_BLOCK_SEC = 0.0025;
+
 static OSStatus GetIOBufferFrameSizeRange(AudioObjectID inDeviceID,
                                           UInt32* outMinimum,
                                           UInt32* outMaximum)
@@ -145,7 +147,7 @@ void MacAudioDevice::start()
         // reduces dropouts on marginal hardware.
         UInt32 minFrameSize = 0;
         UInt32 maxFrameSize = 0;
-        UInt32 desiredFrameSize = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two 
+        UInt32 desiredFrameSize = pow(2, ceil(log(AUDIO_SAMPLE_BLOCK_SEC * sampleRate_) / log(2))); // next power of two 
         GetIOBufferFrameSizeRange(coreAudioId_, &minFrameSize, &maxFrameSize);
         if (minFrameSize != 0 && maxFrameSize != 0)
         {
@@ -486,7 +488,7 @@ void MacAudioDevice::setHelperRealTime()
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
     //auto sampleBuffer = pow(2, ceil(log(0.01 * sampleRate_) / log(2))); // next power of two
-    const double kTimeQuantum = 10; //sampleBuffer * 1000 / sampleRate_;
+    const double kTimeQuantum = AUDIO_SAMPLE_BLOCK_SEC * 1000; //sampleBuffer * 1000 / sampleRate_;
     
     // Time guaranteed each quantum.
     const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -136,7 +136,8 @@ void MacAudioDevice::start()
         if (minFrameSize != 0 && maxFrameSize != 0)
         {
             log_info("Frame sizes of %d to %d are supported for audio device ID %d", minFrameSize, maxFrameSize, coreAudioId_);
-            desiredFrameSize = std::min(maxFrameSize, (UInt32)2048); // TBD: investigate why we need a significantly higher than default.
+            desiredFrameSize = std::min(maxFrameSize, desiredFrameSize);
+            desiredFrameSize = std::max(minFrameSize, desiredFrameSize);
             if (SetCurrentIOBufferFrameSize(coreAudioId_, desiredFrameSize) != noErr)
             {
                 log_warn("Could not set IO frame size to %d for audio device ID %d", desiredFrameSize, coreAudioId_);

--- a/src/audio/PulseAudioDevice.cpp
+++ b/src/audio/PulseAudioDevice.cpp
@@ -387,15 +387,19 @@ void PulseAudioDevice::stopRealTimeWork()
 
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1)
     {
-        log_warn("Could not get current time (errno = %d)", errno);
+        // Fallback to simple sleep.
+        IAudioDevice::stopRealTimeWork();
+        return;
     }
+    
     ts.tv_nsec += 10000000;
     ts.tv_sec += (ts.tv_nsec / 1000000000);
     ts.tv_nsec = ts.tv_nsec % 1000000000;
 
     if (sem_timedwait(&sem_, &ts) < 0 && errno != ETIMEDOUT)
     {
-        log_warn("Could not time wait on semaphore (errno = %d)", errno);
+        // Fallback to simple sleep.
+        IAudioDevice::stopRealTimeWork();
     }
 }
 

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -308,8 +308,9 @@ void WASAPIAudioDevice::start()
                 log_warn("Could not increase thread priority");
             }
 
-            while (isRenderCaptureRunning_ && WaitForSingleObject(renderCaptureEvent_, 100) == WAIT_OBJECT_0)
+            while (isRenderCaptureRunning_)
             {
+                WaitForSingleObject(renderCaptureEvent_, 100);
                 if (direction_ == IAudioEngine::AUDIO_ENGINE_OUT)
                 {
                     renderAudio_();

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -424,8 +424,8 @@ void WASAPIAudioDevice::stopRealTimeWork()
         return;
     }
 
-    // Wait a maximum of 10ms for the semaphore to return
-    DWORD result = WaitForSingleObject(semaphore_, 10);
+    // Wait a maximum of (bufferSize / sampleRate) seconds for the semaphore to return
+    DWORD result = WaitForSingleObject(semaphore_, (1000 * bufferFrameCount_) / sampleRate_);
 
     if (result != WAIT_TIMEOUT && result != WAIT_OBJECT_0)
     {

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -429,7 +429,8 @@ void WASAPIAudioDevice::stopRealTimeWork()
 
     if (result != WAIT_TIMEOUT && result != WAIT_OBJECT_0)
     {
-        log_warn("Could not wait on semaphore (err = %d)", GetLastError());
+        // Fallback to a simple sleep.
+        IAudioDevice::stopRealTimeWork();
     }
 }
 

--- a/src/audio/WASAPIAudioDevice.h
+++ b/src/audio/WASAPIAudioDevice.h
@@ -84,10 +84,12 @@ private:
     std::thread renderCaptureThread_;
     HANDLE renderCaptureEvent_;
     bool isRenderCaptureRunning_;
-    HANDLE helperTask_;
+    HANDLE semaphore_;
 
     void renderAudio_();
     void captureAudio_();
+    
+    static thread_local HANDLE helperTask_;
 };
 
 #endif // WASAPI_AUDIO_DEVICE_H

--- a/src/audio/rtkit.c
+++ b/src/audio/rtkit.c
@@ -1,0 +1,308 @@
+/*-*- Mode: C; c-basic-offset: 8 -*-*/
+
+/***
+        Copyright 2009 Lennart Poettering
+        Copyright 2010 David Henningsson <diwic@ubuntu.com>
+
+        Permission is hereby granted, free of charge, to any person
+        obtaining a copy of this software and associated documentation files
+        (the "Software"), to deal in the Software without restriction,
+        including without limitation the rights to use, copy, modify, merge,
+        publish, distribute, sublicense, and/or sell copies of the Software,
+        and to permit persons to whom the Software is furnished to do so,
+        subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be
+        included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+***/
+
+#include <errno.h>
+
+#include "rtkit.h"
+
+#ifdef __linux__
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+
+static pid_t _gettid(void) {
+        return (pid_t) syscall(SYS_gettid);
+}
+
+static int translate_error(const char *name) {
+        if (strcmp(name, DBUS_ERROR_NO_MEMORY) == 0)
+                return -ENOMEM;
+        if (strcmp(name, DBUS_ERROR_SERVICE_UNKNOWN) == 0 ||
+            strcmp(name, DBUS_ERROR_NAME_HAS_NO_OWNER) == 0)
+                return -ENOENT;
+        if (strcmp(name, DBUS_ERROR_ACCESS_DENIED) == 0 ||
+            strcmp(name, DBUS_ERROR_AUTH_FAILED) == 0)
+                return -EACCES;
+
+        return -EIO;
+}
+
+static long long rtkit_get_int_property(DBusConnection *connection, const char* propname, long long* propval) {
+        DBusMessage *m = NULL, *r = NULL;
+        DBusMessageIter iter, subiter;
+        dbus_int64_t i64;
+        dbus_int32_t i32;
+        DBusError error;
+        int current_type;
+        long long ret;
+        const char * interfacestr = "org.freedesktop.RealtimeKit1";
+
+        dbus_error_init(&error);
+
+        if (!(m = dbus_message_new_method_call(
+                              RTKIT_SERVICE_NAME,
+                              RTKIT_OBJECT_PATH,
+                              "org.freedesktop.DBus.Properties",
+                              "Get"))) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+        if (!dbus_message_append_args(
+                            m,
+                            DBUS_TYPE_STRING, &interfacestr,
+                            DBUS_TYPE_STRING, &propname,
+                            DBUS_TYPE_INVALID)) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+        if (!(r = dbus_connection_send_with_reply_and_block(connection, m, -1, &error))) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+        if (dbus_set_error_from_message(&error, r)) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+        ret = -EBADMSG;
+        dbus_message_iter_init(r, &iter);
+        while ((current_type = dbus_message_iter_get_arg_type (&iter)) != DBUS_TYPE_INVALID) {
+
+                if (current_type == DBUS_TYPE_VARIANT) {
+                        dbus_message_iter_recurse(&iter, &subiter);
+
+                        while ((current_type = dbus_message_iter_get_arg_type (&subiter)) != DBUS_TYPE_INVALID) {
+
+                                if (current_type == DBUS_TYPE_INT32) {
+                                        dbus_message_iter_get_basic(&subiter, &i32);
+                                        *propval = i32;
+                                        ret = 0;
+                                }
+
+                                if (current_type == DBUS_TYPE_INT64) {
+                                        dbus_message_iter_get_basic(&subiter, &i64);
+                                        *propval = i64;
+                                        ret = 0;
+                                }
+
+                                dbus_message_iter_next (&subiter);
+                         }
+                }
+                dbus_message_iter_next (&iter);
+        }
+
+finish:
+
+        if (m)
+                dbus_message_unref(m);
+
+        if (r)
+                dbus_message_unref(r);
+
+        dbus_error_free(&error);
+
+        return ret;
+}
+
+int rtkit_get_max_realtime_priority(DBusConnection *connection) {
+        long long retval;
+        int err;
+
+        err = rtkit_get_int_property(connection, "MaxRealtimePriority", &retval);
+        return err < 0 ? err : retval;
+}
+
+int rtkit_get_min_nice_level(DBusConnection *connection, int* min_nice_level) {
+        long long retval;
+        int err;
+
+        err = rtkit_get_int_property(connection, "MinNiceLevel", &retval);
+        if (err >= 0)
+                *min_nice_level = retval;
+        return err;
+}
+
+long long rtkit_get_rttime_usec_max(DBusConnection *connection) {
+        long long retval;
+        int err;
+
+        err = rtkit_get_int_property(connection, "RTTimeUSecMax", &retval);
+        return err < 0 ? err : retval;
+}
+
+int rtkit_make_realtime(DBusConnection *connection, pid_t thread, int priority) {
+        DBusMessage *m = NULL, *r = NULL;
+        dbus_uint64_t u64;
+        dbus_uint32_t u32;
+        DBusError error;
+        int ret;
+
+        dbus_error_init(&error);
+
+        if (thread == 0)
+                thread = _gettid();
+
+        if (!(m = dbus_message_new_method_call(
+                              RTKIT_SERVICE_NAME,
+                              RTKIT_OBJECT_PATH,
+                              "org.freedesktop.RealtimeKit1",
+                              "MakeThreadRealtime"))) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+        u64 = (dbus_uint64_t) thread;
+        u32 = (dbus_uint32_t) priority;
+
+        if (!dbus_message_append_args(
+                            m,
+                            DBUS_TYPE_UINT64, &u64,
+                            DBUS_TYPE_UINT32, &u32,
+                            DBUS_TYPE_INVALID)) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+        if (!(r = dbus_connection_send_with_reply_and_block(connection, m, -1, &error))) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+
+        if (dbus_set_error_from_message(&error, r)) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+        ret = 0;
+
+finish:
+
+        if (m)
+                dbus_message_unref(m);
+
+        if (r)
+                dbus_message_unref(r);
+
+        dbus_error_free(&error);
+
+        return ret;
+}
+
+int rtkit_make_high_priority(DBusConnection *connection, pid_t thread, int nice_level) {
+        DBusMessage *m = NULL, *r = NULL;
+        dbus_uint64_t u64;
+        dbus_int32_t s32;
+        DBusError error;
+        int ret;
+
+        dbus_error_init(&error);
+
+        if (thread == 0)
+                thread = _gettid();
+
+        if (!(m = dbus_message_new_method_call(
+                              RTKIT_SERVICE_NAME,
+                              RTKIT_OBJECT_PATH,
+                              "org.freedesktop.RealtimeKit1",
+                              "MakeThreadHighPriority"))) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+        u64 = (dbus_uint64_t) thread;
+        s32 = (dbus_int32_t) nice_level;
+
+        if (!dbus_message_append_args(
+                            m,
+                            DBUS_TYPE_UINT64, &u64,
+                            DBUS_TYPE_INT32, &s32,
+                            DBUS_TYPE_INVALID)) {
+                ret = -ENOMEM;
+                goto finish;
+        }
+
+
+
+        if (!(r = dbus_connection_send_with_reply_and_block(connection, m, -1, &error))) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+
+        if (dbus_set_error_from_message(&error, r)) {
+                ret = translate_error(error.name);
+                goto finish;
+        }
+
+        ret = 0;
+
+finish:
+
+        if (m)
+                dbus_message_unref(m);
+
+        if (r)
+                dbus_message_unref(r);
+
+        dbus_error_free(&error);
+
+        return ret;
+}
+
+#else
+
+int rtkit_make_realtime(DBusConnection *connection, pid_t thread, int priority) {
+        return -ENOTSUP;
+}
+
+int rtkit_make_high_priority(DBusConnection *connection, pid_t thread, int nice_level) {
+        return -ENOTSUP;
+}
+
+int rtkit_get_max_realtime_priority(DBusConnection *connection) {
+        return -ENOTSUP;
+}
+
+int rtkit_get_min_nice_level(DBusConnection *connection, int* min_nice_level) {
+        return -ENOTSUP;
+}
+
+long long rtkit_get_rttime_usec_max(DBusConnection *connection) {
+        return -ENOTSUP;
+}
+
+#endif

--- a/src/audio/rtkit.h
+++ b/src/audio/rtkit.h
@@ -61,7 +61,7 @@ int rtkit_make_high_priority(DBusConnection *system_bus, pid_t thread, int nice_
  */
 int rtkit_get_max_realtime_priority(DBusConnection *system_bus);
 
-/* Retreive the minimum value of nice level available. High prio requests
+/* Retrieve the minimum value of nice level available. High prio requests
  * below this value will fail. The returned value is a negative errno
  * style error code, or 0 on success.*/
 int rtkit_get_min_nice_level(DBusConnection *system_bus, int* min_nice_level);

--- a/src/audio/rtkit.h
+++ b/src/audio/rtkit.h
@@ -1,0 +1,79 @@
+/*-*- Mode: C; c-basic-offset: 8 -*-*/
+
+#ifndef foortkithfoo
+#define foortkithfoo
+
+/***
+        Copyright 2009 Lennart Poettering
+        Copyright 2010 David Henningsson <diwic@ubuntu.com>
+
+        Permission is hereby granted, free of charge, to any person
+        obtaining a copy of this software and associated documentation files
+        (the "Software"), to deal in the Software without restriction,
+        including without limitation the rights to use, copy, modify, merge,
+        publish, distribute, sublicense, and/or sell copies of the Software,
+        and to permit persons to whom the Software is furnished to do so,
+        subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be
+        included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+***/
+
+#include <sys/types.h>
+#include <dbus/dbus.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* This is the reference implementation for a client for
+ * RealtimeKit. You don't have to use this, but if do, just copy these
+ * sources into your repository */
+
+#define RTKIT_SERVICE_NAME "org.freedesktop.RealtimeKit1"
+#define RTKIT_OBJECT_PATH "/org/freedesktop/RealtimeKit1"
+
+/* This is mostly equivalent to sched_setparam(thread, SCHED_RR, {
+ * .sched_priority = priority }). 'thread' needs to be a kernel thread
+ * id as returned by gettid(), not a pthread_t! If 'thread' is 0 the
+ * current thread is used. The returned value is a negative errno
+ * style error code, or 0 on success. */
+int rtkit_make_realtime(DBusConnection *system_bus, pid_t thread, int priority);
+
+/* This is mostly equivalent to setpriority(PRIO_PROCESS, thread,
+ * nice_level). 'thread' needs to be a kernel thread id as returned by
+ * gettid(), not a pthread_t! If 'thread' is 0 the current thread is
+ * used. The returned value is a negative errno style error code, or 0
+ * on success.*/
+int rtkit_make_high_priority(DBusConnection *system_bus, pid_t thread, int nice_level);
+
+/* Return the maximum value of realtime priority available. Realtime requests
+ * above this value will fail. A negative value is an errno style error code.
+ */
+int rtkit_get_max_realtime_priority(DBusConnection *system_bus);
+
+/* Retreive the minimum value of nice level available. High prio requests
+ * below this value will fail. The returned value is a negative errno
+ * style error code, or 0 on success.*/
+int rtkit_get_min_nice_level(DBusConnection *system_bus, int* min_nice_level);
+
+/* Return the maximum value of RLIMIT_RTTIME to set before attempting a
+ * realtime request. A negative value is an errno style error code.
+ */
+long long rtkit_get_rttime_usec_max(DBusConnection *system_bus);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -146,7 +146,7 @@ float FreeDVInterface::GetMinimumSNR_(int mode)
 void FreeDVInterface::start(int txMode, int fifoSizeMs, bool singleRxThread, bool usingReliableText)
 {
     sync_ = 0;
-    singleRxThread_ = singleRxThread;
+    singleRxThread_ = enabledModes_.size() > 1 ? singleRxThread : true;
 
     modemStatsList_ = new MODEM_STATS[enabledModes_.size()];
     for (int index = 0; index < (int)enabledModes_.size(); index++)

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -753,6 +753,7 @@ IPipelineStep* FreeDVInterface::createTransmitPipeline(int inputSampleRate, int 
         modeFn,
         modeFn,
         parallelSteps,
+        nullptr,
         nullptr
     );
     
@@ -765,7 +766,8 @@ IPipelineStep* FreeDVInterface::createReceivePipeline(
     std::function<int()> getChannelNoiseFn,
     std::function<int()> getChannelNoiseSnrFn,
     std::function<float()> getFreqOffsetFn,
-    std::function<float*()> getSigPwrAvgFn)
+    std::function<float*()> getSigPwrAvgFn,
+    std::shared_ptr<IRealtimeHelper> realtimeHelper)
 {
     std::vector<IPipelineStep*> parallelSteps;
 
@@ -807,7 +809,8 @@ IPipelineStep* FreeDVInterface::createReceivePipeline(
         state->preProcessFn,
         state->postProcessFn,
         parallelSteps,
-        state
+        state,
+        realtimeHelper
     );
     
     return parallelStep;

--- a/src/freedv_interface.h
+++ b/src/freedv_interface.h
@@ -52,6 +52,8 @@ extern "C"
     #include "lpcnet.h"
 }
 
+#include "util/IRealtimeHelper.h"
+
 #include <samplerate.h>
 
 class IPipelineStep;
@@ -131,7 +133,8 @@ public:
         std::function<int()> getChannelNoiseFn,
         std::function<int()> getChannelNoiseSnrFn,
         std::function<float()> getFreqOffsetFn,
-        std::function<float*()> getSigPwrAvgFn
+        std::function<float*()> getSigPwrAvgFn,
+        std::shared_ptr<IRealtimeHelper> realtimeHelper
     );
 
     void restartTxVocoder();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3124,7 +3124,7 @@ void MainFrame::startRxStream()
         // loop.
 
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
-        int soundCard1InFifoSizeSamples = m_fifoSize_mswxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
+        int soundCard1InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
         int soundCard1OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000;
 
         if (txInSoundDevice && txOutSoundDevice)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3121,10 +3121,10 @@ void MainFrame::startRxStream()
         g_rxUserdata = new paCallBackData;
                 
         // create FIFOs used to interface between IAudioEngine and txRx
-        // processing loop, which iterates about once every 20ms.
-        // Sample rate conversion, stats for spectral plots, and
-        // transmit processng are all performed in the tx/rxProcessing
-        // loop.
+        // processing loop, which iterates about once every 10-40ms
+        // (depending on platform/audio library). Sample rate conversion, 
+        // stats for spectral plots, and transmit processng are all performed 
+        // in the tx/rxProcessing loop.
 
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
         int soundCard1InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3124,13 +3124,13 @@ void MainFrame::startRxStream()
         // loop.
 
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
-        int soundCard1InFifoSizeSamples = /*m_fifoSize_ms*/wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate /*/ 1000*/;
+        int soundCard1InFifoSizeSamples = m_fifoSize_mswxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
         int soundCard1OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000;
 
         if (txInSoundDevice && txOutSoundDevice)
         {
             int soundCard2InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate / 1000;
-            int soundCard2OutFifoSizeSamples = /*m_fifoSize_ms**/wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate /*/ 1000*/;
+            int soundCard2OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000;
             g_rxUserdata->outfifo1 = codec2_fifo_create(soundCard1OutFifoSizeSamples);
             g_rxUserdata->infifo2 = codec2_fifo_create(soundCard2InFifoSizeSamples);
             g_rxUserdata->infifo1 = codec2_fifo_create(soundCard1InFifoSizeSamples);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3124,13 +3124,13 @@ void MainFrame::startRxStream()
         // loop.
 
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
-        int soundCard1InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
+        int soundCard1InFifoSizeSamples = /*m_fifoSize_ms*/wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
         int soundCard1OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000;
 
         if (txInSoundDevice && txOutSoundDevice)
         {
             int soundCard2InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate / 1000;
-            int soundCard2OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000;
+            int soundCard2OutFifoSizeSamples = /*m_fifoSize_ms**/wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000;
             g_rxUserdata->outfifo1 = codec2_fifo_create(soundCard1OutFifoSizeSamples);
             g_rxUserdata->infifo2 = codec2_fifo_create(soundCard2InFifoSizeSamples);
             g_rxUserdata->infifo1 = codec2_fifo_create(soundCard1InFifoSizeSamples);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3422,7 +3422,7 @@ void MainFrame::startRxStream()
         // start tx/rx processing thread
         if (txInSoundDevice && txOutSoundDevice)
         {
-            m_txThread = new TxRxThread(true, txInSoundDevice->getSampleRate(), txOutSoundDevice->getSampleRate(), wxGetApp().linkStep.get());
+            m_txThread = new TxRxThread(true, txInSoundDevice->getSampleRate(), txOutSoundDevice->getSampleRate(), wxGetApp().linkStep.get(), txInSoundDevice);
             if ( m_txThread->Create() != wxTHREAD_NO_ERROR )
             {
                 wxLogError(wxT("Can't create TX thread!"));
@@ -3461,7 +3461,7 @@ void MainFrame::startRxStream()
             }
         }
 
-        m_rxThread = new TxRxThread(false, rxInSoundDevice->getSampleRate(), rxOutSoundDevice->getSampleRate(), wxGetApp().linkStep.get());
+        m_rxThread = new TxRxThread(false, rxInSoundDevice->getSampleRate(), rxOutSoundDevice->getSampleRate(), wxGetApp().linkStep.get(), rxInSoundDevice);
         if ( m_rxThread->Create() != wxTHREAD_NO_ERROR )
         {
             wxLogError(wxT("Can't create RX thread!"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3124,13 +3124,13 @@ void MainFrame::startRxStream()
         // loop.
 
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
-        int soundCard1InFifoSizeSamples = /*m_fifoSize_ms*/wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate / 1000;
+        int soundCard1InFifoSizeSamples = /*m_fifoSize_ms*/wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate /*/ 1000*/;
         int soundCard1OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000;
 
         if (txInSoundDevice && txOutSoundDevice)
         {
             int soundCard2InFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate / 1000;
-            int soundCard2OutFifoSizeSamples = /*m_fifoSize_ms**/wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000;
+            int soundCard2OutFifoSizeSamples = /*m_fifoSize_ms**/wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate /*/ 1000*/;
             g_rxUserdata->outfifo1 = codec2_fifo_create(soundCard1OutFifoSizeSamples);
             g_rxUserdata->infifo2 = codec2_fifo_create(soundCard2InFifoSizeSamples);
             g_rxUserdata->infifo1 = codec2_fifo_create(soundCard1InFifoSizeSamples);

--- a/src/os/os_interface.h
+++ b/src/os/os_interface.h
@@ -43,10 +43,4 @@ extern "C" void ResetMainWindowColorSpace();
 // This can be either "windows", "linux", "macos" or "other".
 std::string GetOperatingSystemString();
 
-// Requests real-time scheduling from the operating system. Used for audio threads.
-void RequestRealTimeScheduling();
-
-// Ends request for real-time scheduling.
-void RequestNormalScheduling();
-
 #endif // __OS_INTERFACE__

--- a/src/os/os_interface.h
+++ b/src/os/os_interface.h
@@ -43,4 +43,10 @@ extern "C" void ResetMainWindowColorSpace();
 // This can be either "windows", "linux", "macos" or "other".
 std::string GetOperatingSystemString();
 
+// Requests real-time scheduling from the operating system. Used for audio threads.
+void RequestRealTimeScheduling();
+
+// Ends request for real-time scheduling.
+void RequestNormalScheduling();
+
 #endif // __OS_INTERFACE__

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -142,8 +142,8 @@ void RequestRealTimeScheduling()
     
     // Define constants determining how much time the audio thread can
     // use in a given time quantum.  All times are in milliseconds.
-    // About 128 frames @44.1KHz
-    const double kTimeQuantum = 2.9;
+    // About 512 frames @48KHz
+    const double kTimeQuantum = 10.67;
     
     // Time guaranteed each quantum.
     const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -22,13 +22,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <AppKit/AppKit.h>
-#include <pthread.h>
-#include <mach/mach.h>
-#include <mach/mach_time.h>
-#include <mach/thread_policy.h>
-
 #include "os_interface.h"
-#include "../util/logging/ulog.h"
 
 void VerifyMicrophonePermissions(std::promise<bool>& microphonePromise)
 {
@@ -89,94 +83,4 @@ void ResetMainWindowColorSpace()
 std::string GetOperatingSystemString()
 {
     return "macos";
-}
-
-void RequestRealTimeScheduling()
-{
-    // Adapted from Chromium project. May need to adjust parameters
-    // depending on behavior.
-    
-    // Get current thread ID
-    auto currentThreadId = pthread_mach_thread_np(pthread_self());
-    
-    // Increase thread priority to real-time.
-    // Please note that the thread_policy_set() calls may fail in
-    // rare cases if the kernel decides the system is under heavy load
-    // and is unable to handle boosting the thread priority.
-    // In these cases we just return early and go on with life.
-    // Make thread fixed priority.
-    thread_extended_policy_data_t policy;
-    policy.timeshare = 0;  // Set to 1 for a non-fixed thread.
-    kern_return_t result =
-        thread_policy_set(currentThreadId,
-                          THREAD_EXTENDED_POLICY,
-                          reinterpret_cast<thread_policy_t>(&policy),
-                          THREAD_EXTENDED_POLICY_COUNT);
-    if (result != KERN_SUCCESS) 
-    {
-        log_warn("Could not set current thread to real-time: %d");
-        return;
-    }
-    
-    // Set to relatively high priority.
-    thread_precedence_policy_data_t precedence;
-    precedence.importance = 63;
-    result = thread_policy_set(currentThreadId,
-                               THREAD_PRECEDENCE_POLICY,
-                               reinterpret_cast<thread_policy_t>(&precedence),
-                               THREAD_PRECEDENCE_POLICY_COUNT);
-    if (result != KERN_SUCCESS)
-    {
-        log_warn("Could not increase thread priority");
-        return;
-    }
-    
-    // Most important, set real-time constraints.
-    // Define the guaranteed and max fraction of time for the audio thread.
-    // These "duty cycle" values can range from 0 to 1.  A value of 0.5
-    // means the scheduler would give half the time to the thread.
-    // These values have empirically been found to yield good behavior.
-    // Good means that audio performance is high and other threads won't starve.
-    const double kGuaranteedAudioDutyCycle = 0.75;
-    const double kMaxAudioDutyCycle = 0.85;
-    
-    // Define constants determining how much time the audio thread can
-    // use in a given time quantum.  All times are in milliseconds.
-    // About 512 frames @48KHz
-    const double kTimeQuantum = 10.67;
-    
-    // Time guaranteed each quantum.
-    const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;
-    
-    // Maximum time each quantum.
-    const double kMaxTimeAllowed = kMaxAudioDutyCycle * kTimeQuantum;
-    
-    // Get the conversion factor from milliseconds to absolute time
-    // which is what the time-constraints call needs.
-    mach_timebase_info_data_t tbInfo;
-    mach_timebase_info(&tbInfo);
-    double ms_to_abs_time =
-        (static_cast<double>(tbInfo.denom) / tbInfo.numer) * 1000000;
-    thread_time_constraint_policy_data_t timeConstraints;
-    timeConstraints.period = kTimeQuantum * ms_to_abs_time;
-    timeConstraints.computation = kAudioTimeNeeded * ms_to_abs_time;
-    timeConstraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
-    timeConstraints.preemptible = 0;
-    
-    result =
-        thread_policy_set(currentThreadId,
-                          THREAD_TIME_CONSTRAINT_POLICY,
-                          reinterpret_cast<thread_policy_t>(&timeConstraints),
-                          THREAD_TIME_CONSTRAINT_POLICY_COUNT);
-    if (result != KERN_SUCCESS)
-    {
-        log_warn("Could not set time constraint policy");
-    }
-    
-    return;
-}
-
-void RequestNormalScheduling()
-{
-    // TBD
 }

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -22,7 +22,13 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <AppKit/AppKit.h>
+#include <pthread.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#include <mach/thread_policy.h>
+
 #include "os_interface.h"
+#include "../util/logging/ulog.h"
 
 void VerifyMicrophonePermissions(std::promise<bool>& microphonePromise)
 {
@@ -83,4 +89,94 @@ void ResetMainWindowColorSpace()
 std::string GetOperatingSystemString()
 {
     return "macos";
+}
+
+void RequestRealTimeScheduling()
+{
+    // Adapted from Chromium project. May need to adjust parameters
+    // depending on behavior.
+    
+    // Get current thread ID
+    auto currentThreadId = pthread_mach_thread_np(pthread_self());
+    
+    // Increase thread priority to real-time.
+    // Please note that the thread_policy_set() calls may fail in
+    // rare cases if the kernel decides the system is under heavy load
+    // and is unable to handle boosting the thread priority.
+    // In these cases we just return early and go on with life.
+    // Make thread fixed priority.
+    thread_extended_policy_data_t policy;
+    policy.timeshare = 0;  // Set to 1 for a non-fixed thread.
+    kern_return_t result =
+        thread_policy_set(currentThreadId,
+                          THREAD_EXTENDED_POLICY,
+                          reinterpret_cast<thread_policy_t>(&policy),
+                          THREAD_EXTENDED_POLICY_COUNT);
+    if (result != KERN_SUCCESS) 
+    {
+        log_warn("Could not set current thread to real-time: %d");
+        return;
+    }
+    
+    // Set to relatively high priority.
+    thread_precedence_policy_data_t precedence;
+    precedence.importance = 63;
+    result = thread_policy_set(currentThreadId,
+                               THREAD_PRECEDENCE_POLICY,
+                               reinterpret_cast<thread_policy_t>(&precedence),
+                               THREAD_PRECEDENCE_POLICY_COUNT);
+    if (result != KERN_SUCCESS)
+    {
+        log_warn("Could not increase thread priority");
+        return;
+    }
+    
+    // Most important, set real-time constraints.
+    // Define the guaranteed and max fraction of time for the audio thread.
+    // These "duty cycle" values can range from 0 to 1.  A value of 0.5
+    // means the scheduler would give half the time to the thread.
+    // These values have empirically been found to yield good behavior.
+    // Good means that audio performance is high and other threads won't starve.
+    const double kGuaranteedAudioDutyCycle = 0.75;
+    const double kMaxAudioDutyCycle = 0.85;
+    
+    // Define constants determining how much time the audio thread can
+    // use in a given time quantum.  All times are in milliseconds.
+    // About 128 frames @44.1KHz
+    const double kTimeQuantum = 2.9;
+    
+    // Time guaranteed each quantum.
+    const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;
+    
+    // Maximum time each quantum.
+    const double kMaxTimeAllowed = kMaxAudioDutyCycle * kTimeQuantum;
+    
+    // Get the conversion factor from milliseconds to absolute time
+    // which is what the time-constraints call needs.
+    mach_timebase_info_data_t tbInfo;
+    mach_timebase_info(&tbInfo);
+    double ms_to_abs_time =
+        (static_cast<double>(tbInfo.denom) / tbInfo.numer) * 1000000;
+    thread_time_constraint_policy_data_t timeConstraints;
+    timeConstraints.period = kTimeQuantum * ms_to_abs_time;
+    timeConstraints.computation = kAudioTimeNeeded * ms_to_abs_time;
+    timeConstraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
+    timeConstraints.preemptible = 0;
+    
+    result =
+        thread_policy_set(currentThreadId,
+                          THREAD_TIME_CONSTRAINT_POLICY,
+                          reinterpret_cast<thread_policy_t>(&timeConstraints),
+                          THREAD_TIME_CONSTRAINT_POLICY_COUNT);
+    if (result != KERN_SUCCESS)
+    {
+        log_warn("Could not set time constraint policy");
+    }
+    
+    return;
+}
+
+void RequestNormalScheduling()
+{
+    // TBD
 }

--- a/src/os/osx_stubs.cpp
+++ b/src/os/osx_stubs.cpp
@@ -40,13 +40,3 @@ std::string GetOperatingSystemString()
     return "other";
 #endif // __linux__
 }
-
-void RequestRealTimeScheduling()
-{
-    // currently no-op on Linux and other platforms
-}
-
-void RequestNormalScheduling()
-{
-    // currently no-op on Linux and other platforms
-}

--- a/src/os/osx_stubs.cpp
+++ b/src/os/osx_stubs.cpp
@@ -40,3 +40,13 @@ std::string GetOperatingSystemString()
     return "other";
 #endif // __linux__
 }
+
+void RequestRealTimeScheduling()
+{
+    // currently no-op on Linux and other platforms
+}
+
+void RequestNormalScheduling()
+{
+    // currently no-op on Linux and other platforms
+}

--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -53,13 +53,3 @@ std::string GetOperatingSystemString()
 {
     return "windows";
 }
-
-void RequestRealTimeScheduling()
-{
-    // TBD
-}
-
-void RequestNormalScheduling()
-{
-    // TBD
-}

--- a/src/os/windows_interface.cpp
+++ b/src/os/windows_interface.cpp
@@ -53,3 +53,13 @@ std::string GetOperatingSystemString()
 {
     return "windows";
 }
+
+void RequestRealTimeScheduling()
+{
+    // TBD
+}
+
+void RequestNormalScheduling()
+{
+    // TBD
+}

--- a/src/pipeline/ComputeRfSpectrumStep.h
+++ b/src/pipeline/ComputeRfSpectrumStep.h
@@ -46,6 +46,8 @@ public:
 private:
     std::function<struct MODEM_STATS*()> modemStatsFn_;
     std::function<float*()> getAvMagFn_;
+    float* rxSpectrum_;
+    COMP* rxFdm_;
 };
 
 #endif // AUDIO_PIPELINE__COMPUTE_RF_SPECTRUM_STEP_H

--- a/src/pipeline/EqualizerStep.h
+++ b/src/pipeline/EqualizerStep.h
@@ -44,6 +44,7 @@ private:
     void** midFilter_;
     void** trebleFilter_;
     void** volFilter_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 

--- a/src/pipeline/FreeDVReceiveStep.h
+++ b/src/pipeline/FreeDVReceiveStep.h
@@ -63,6 +63,11 @@ private:
     bool channelNoiseEnabled_;
     int channelNoiseSnr_;
     float freqOffsetHz_;
+
+    std::shared_ptr<short> outputSamples_;
+    short* inputBuf_;
+    COMP* rxFdm_;
+    COMP* rxFdmOffset_;
 };
 
 #endif // AUDIO_PIPELINE__FREEDV_RECEIVE_STEP_H

--- a/src/pipeline/FreeDVTransmitStep.h
+++ b/src/pipeline/FreeDVTransmitStep.h
@@ -50,6 +50,12 @@ private:
     std::function<float()> getFreqOffsetFn_;
     struct FIFO* inputSampleFifo_;
     COMP txFreqOffsetPhaseRectObj_;
+
+    COMP* txFdm_;
+    COMP* txFdmOffset_;
+    short* codecInput_;
+    short* tmpOutput_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__FREEDV_TRANSMIT_STEP_H

--- a/src/pipeline/LevelAdjustStep.cpp
+++ b/src/pipeline/LevelAdjustStep.cpp
@@ -28,7 +28,12 @@ LevelAdjustStep::LevelAdjustStep(int sampleRate, std::function<double()> scaleFa
     : scaleFactorFn_(scaleFactorFn)
     , sampleRate_(sampleRate)
 {
-    // empty
+    // Pre-allocate buffers so we don't have to do so during real-time operation.
+    auto maxSamples = std::max(getInputSampleRate(), getOutputSampleRate());
+    outputSamples_ = std::shared_ptr<short>(
+        new short[maxSamples], 
+        std::default_delete<short[]>());
+    assert(outputSamples_ != nullptr);
 }
 
 LevelAdjustStep::~LevelAdjustStep()
@@ -48,14 +53,13 @@ int LevelAdjustStep::getOutputSampleRate() const
 
 std::shared_ptr<short> LevelAdjustStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    short* outputSamples = new short[numInputSamples];
     double scaleFactor = scaleFactorFn_();
 
     for (int index = 0; index < numInputSamples; index++)
     {
-        outputSamples[index] = inputSamples.get()[index] * scaleFactor;
+        outputSamples_.get()[index] = inputSamples.get()[index] * scaleFactor;
     }
     
     *numOutputSamples = numInputSamples;
-    return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
+    return outputSamples_;
 }

--- a/src/pipeline/LevelAdjustStep.h
+++ b/src/pipeline/LevelAdjustStep.h
@@ -40,6 +40,7 @@ public:
 private:
     std::function<double()> scaleFactorFn_;
     int sampleRate_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__LEVEL_ADJUST_STEP_H

--- a/src/pipeline/LinkStep.cpp
+++ b/src/pipeline/LinkStep.cpp
@@ -33,24 +33,25 @@ LinkStep::LinkStep(int outputSampleRate, size_t numSamples)
     // Create pipeline steps
     inputPipelineStep_ = std::make_shared<InputStep>(this);
     outputPipelineStep_ = std::make_shared<OutputStep>(this);
+
+    tmpBuffer_ = new short[numSamples];
+    assert(tmpBuffer_ != nullptr);
 }
 
 LinkStep::~LinkStep()
 {
     codec2_fifo_destroy(fifo_);
     fifo_ = nullptr;
+
+    delete[] tmpBuffer_;
 }
 
 void LinkStep::clearFifo()
 {
     int numUsed = codec2_fifo_used(fifo_);
-    short* tmp = new short[numUsed];
-    assert(tmp != nullptr);
     
     // Read data and then promptly throw it out.
-    codec2_fifo_read(fifo_, tmp, numUsed);
-
-    delete[] tmp;
+    codec2_fifo_read(fifo_, tmpBuffer_, numUsed);
 }
 
 std::shared_ptr<short> LinkStep::InputStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
@@ -74,11 +75,8 @@ std::shared_ptr<short> LinkStep::OutputStep::execute(std::shared_ptr<short> inpu
     
     if (*numOutputSamples > 0)
     {
-        short* outputSamples = new short[*numOutputSamples];
-        assert(outputSamples != nullptr);
-    
-        codec2_fifo_read(fifo, outputSamples, *numOutputSamples);
-        return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
+        codec2_fifo_read(fifo, outputSamples_.get(), *numOutputSamples);
+        return outputSamples_;
     }
     else
     {

--- a/src/pipeline/LinkStep.h
+++ b/src/pipeline/LinkStep.h
@@ -84,7 +84,12 @@ private:
         OutputStep(LinkStep* parent)
             : parent_(parent)
         {
-            // empty
+            // Pre-allocate buffers so we don't have to do so during real-time operation.
+            auto maxSamples = std::max(getInputSampleRate(), getOutputSampleRate());
+            outputSamples_ = std::shared_ptr<short>(
+                new short[maxSamples], 
+                std::default_delete<short[]>());
+            assert(outputSamples_ != nullptr);
         }
         
         virtual ~OutputStep() = default;
@@ -105,12 +110,15 @@ private:
         
     private:
         LinkStep* parent_;
+        std::shared_ptr<short> outputSamples_;
     };
     
     int sampleRate_;
     std::shared_ptr<IPipelineStep> inputPipelineStep_;
     std::shared_ptr<IPipelineStep> outputPipelineStep_;
-    FIFO* fifo_;    
+    FIFO* fifo_;
+
+    short* tmpBuffer_;
 };
 
 #endif // AUDIO_PIPELINE__LINK_STEP_H

--- a/src/pipeline/MuteStep.h
+++ b/src/pipeline/MuteStep.h
@@ -47,6 +47,7 @@ public:
 
 private:
     int sampleRate_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__MUTE_STEP_H

--- a/src/pipeline/ParallelStep.h
+++ b/src/pipeline/ParallelStep.h
@@ -32,6 +32,8 @@
 #include <queue>
 #include <map>
 
+#include "../util/IRealtimeHelper.h"
+
 class ParallelStep : public IPipelineStep
 {
 public:
@@ -41,7 +43,8 @@ public:
         std::function<int(ParallelStep*)> inputRouteFn,
         std::function<int(ParallelStep*)> outputRouteFn,
         std::vector<IPipelineStep*> parallelSteps,
-        std::shared_ptr<void> state);
+        std::shared_ptr<void> state,
+        std::shared_ptr<IRealtimeHelper> realtimeHelper);
     virtual ~ParallelStep();
     
     virtual int getInputSampleRate() const;
@@ -81,6 +84,7 @@ private:
     std::map<std::pair<int, int>, std::shared_ptr<ResampleStep>> resamplers_;
     std::vector<ThreadInfo*> threads_;
     std::shared_ptr<void> state_;
+    std::shared_ptr<IRealtimeHelper> realtimeHelper_;
 
     void executeRunnerThread_(ThreadInfo* threadState);
     std::future<TaskResult> enqueueTask_(ThreadInfo* taskQueueThread, IPipelineStep* step, std::shared_ptr<short> inputSamples, int numInputSamples);

--- a/src/pipeline/PlaybackStep.h
+++ b/src/pipeline/PlaybackStep.h
@@ -44,6 +44,7 @@ private:
     std::function<int()> fileSampleRateFn_;
     std::function<SNDFILE*()> getSndFileFn_;
     std::function<void()> fileCompleteFn_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__PLAYBACK_STEP_H

--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -67,6 +67,8 @@ RADEReceiveStep::RADEReceiveStep(struct rade* dv, FARGANState* fargan, rade_text
 
     eooOut_ = new float[rade_n_eoo_bits(dv_)];
     assert(eooOut_ != nullptr);
+
+    pendingFeatures_.reserve(rade_n_features_in_out(dv_));
 }
 
 RADEReceiveStep::~RADEReceiveStep()

--- a/src/pipeline/RADEReceiveStep.h
+++ b/src/pipeline/RADEReceiveStep.h
@@ -57,6 +57,12 @@ private:
     std::vector<float> pendingFeatures_;
     FILE* featuresFile_;
     rade_text_t textPtr_;
+
+    RADE_COMP* inputBufCplx_;
+    short* inputBuf_;
+    float* featuresOut_;
+    float* eooOut_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__RADE_RECEIVE_STEP_H

--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -72,6 +72,8 @@ RADETransmitStep::RADETransmitStep(struct rade* dv, LPCNetEncState* encState)
 
     eooOutShort_ = new short[numEOOSamples + NUM_SAMPLES_SILENCE];
     assert(eooOutShort_ != nullptr);
+
+    featureList_.reserve(rade_n_features_in_out(dv_));
 }
 
 RADETransmitStep::~RADETransmitStep()

--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -48,10 +48,39 @@ RADETransmitStep::RADETransmitStep(struct rade* dv, LPCNetEncState* encState)
         featuresFile_ = fopen((const char*)utTxFeatureFile.ToUTF8(), "wb");
         assert(featuresFile_ != nullptr);
     }
+
+    // Pre-allocate buffers so we don't have to do so during real-time operation.
+    auto maxSamples = std::max(getInputSampleRate(), getOutputSampleRate());
+    outputSamples_ = std::shared_ptr<short>(
+        new short[maxSamples], 
+        std::default_delete<short[]>());
+    assert(outputSamples_ != nullptr);
+
+    int numOutputSamples = rade_n_tx_out(dv_);
+
+    radeOut_ = new RADE_COMP[numOutputSamples];
+    assert(radeOut_ != nullptr);
+
+    radeOutShort_ = new short[numOutputSamples];
+    assert(radeOutShort_ != nullptr);
+
+    const int NUM_SAMPLES_SILENCE = 60 * getOutputSampleRate() / 1000;
+    int numEOOSamples = rade_n_tx_eoo_out(dv_);
+
+    eooOut_ = new RADE_COMP[numEOOSamples];
+    assert(eooOut_ != nullptr);
+
+    eooOutShort_ = new short[numEOOSamples + NUM_SAMPLES_SILENCE];
+    assert(eooOutShort_ != nullptr);
 }
 
 RADETransmitStep::~RADETransmitStep()
 {
+    delete[] radeOut_;
+    delete[] radeOutShort_;
+    delete[] eooOut_;
+    delete[] eooOutShort_;
+
     if (featuresFile_ != nullptr)
     {
         fclose(featuresFile_);
@@ -80,7 +109,6 @@ int RADETransmitStep::getOutputSampleRate() const
 
 std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    short* outputSamples = nullptr;
     *numOutputSamples = 0;
 
     if (numInputSamples == 0)
@@ -89,15 +117,12 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
         *numOutputSamples = std::min(codec2_fifo_used(outputSampleFifo_), (int)(RADE_MODEM_SAMPLE_RATE * .02));
         if (*numOutputSamples > 0)
         {
-            outputSamples = new short[*numOutputSamples];
-            assert(outputSamples != nullptr);
-
-            codec2_fifo_read(outputSampleFifo_, outputSamples, *numOutputSamples);
+            codec2_fifo_read(outputSampleFifo_, outputSamples_.get(), *numOutputSamples);
 
             log_info("Returning %d EOO samples (remaining in FIFO: %d)", *numOutputSamples, codec2_fifo_used(outputSampleFifo_));
         }
 
-        return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());;
+        return outputSamples_;
     }
     
     short* inputPtr = inputSamples.get();
@@ -112,12 +137,6 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
             int numOutputSamples = rade_n_tx_out(dv_);
             short pcm[LPCNET_FRAME_SIZE];
             float features[NB_TOTAL_FEATURES];
-
-            RADE_COMP* radeOut = new RADE_COMP[numOutputSamples];
-            assert(radeOut != nullptr);
-
-            short* radeOutShort = new short[numOutputSamples];
-            assert(radeOutShort != nullptr);
 
             int arch = opus_select_arch();
 
@@ -138,7 +157,7 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
             // RADE TX handling
             while (featureList_.size() >= numRequiredFeaturesForRADE)
             {
-                rade_tx(dv_, radeOut, &featureList_[0]);
+                rade_tx(dv_, radeOut_, &featureList_[0]);
                 for (unsigned int index = 0; index < numRequiredFeaturesForRADE; index++)
                 {
                     featureList_.erase(featureList_.begin());
@@ -146,26 +165,20 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
                 for (int index = 0; index < numOutputSamples; index++)
                 {
                     // We only need the real component for TX.
-                    radeOutShort[index] = radeOut[index].real * RADE_SCALING_FACTOR;
+                    radeOutShort_[index] = radeOut_[index].real * RADE_SCALING_FACTOR;
                 }
-                codec2_fifo_write(outputSampleFifo_, radeOutShort, numOutputSamples);
+                codec2_fifo_write(outputSampleFifo_, radeOutShort_, numOutputSamples);
             }
-
-            delete[] radeOutShort;
-            delete[] radeOut;
         }
     }
 
     *numOutputSamples = codec2_fifo_used(outputSampleFifo_);
     if (*numOutputSamples > 0)
     {
-        outputSamples = new short[*numOutputSamples];
-        assert(outputSamples != nullptr);
-
-        codec2_fifo_read(outputSampleFifo_, outputSamples, *numOutputSamples);
+        codec2_fifo_read(outputSampleFifo_, outputSamples_.get(), *numOutputSamples);
     }
     
-    return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
+    return outputSamples_;
 }
 
 void RADETransmitStep::restartVocoder()
@@ -174,26 +187,17 @@ void RADETransmitStep::restartVocoder()
     const int NUM_SAMPLES_SILENCE = 60 * getOutputSampleRate() / 1000;
     int numEOOSamples = rade_n_tx_eoo_out(dv_);
 
-    RADE_COMP* eooOut = new RADE_COMP[numEOOSamples];
-    assert(eooOut != nullptr);
+    rade_tx_eoo(dv_, eooOut_);
 
-    short* eooOutShort = new short[numEOOSamples + NUM_SAMPLES_SILENCE];
-    assert(eooOutShort != nullptr);
-
-    rade_tx_eoo(dv_, eooOut);
-
-    memset(eooOutShort, 0, sizeof(short) * (numEOOSamples + NUM_SAMPLES_SILENCE));
+    memset(eooOutShort_, 0, sizeof(short) * (numEOOSamples + NUM_SAMPLES_SILENCE));
     for (int index = 0; index < numEOOSamples; index++)
     {
-        eooOutShort[index] = eooOut[index].real * RADE_SCALING_FACTOR;
+        eooOutShort_[index] = eooOut_[index].real * RADE_SCALING_FACTOR;
     }
 
     log_info("Queueing %d EOO samples to output FIFO", numEOOSamples + NUM_SAMPLES_SILENCE);
-    if (codec2_fifo_write(outputSampleFifo_, eooOutShort, numEOOSamples + NUM_SAMPLES_SILENCE) != 0)
+    if (codec2_fifo_write(outputSampleFifo_, eooOutShort_, numEOOSamples + NUM_SAMPLES_SILENCE) != 0)
     {
         log_warn("Could not queue EOO samples (remaining space in FIFO = %d)", codec2_fifo_free(outputSampleFifo_));
     }
-
-    delete[] eooOutShort;
-    delete[] eooOut;
 }

--- a/src/pipeline/RADETransmitStep.h
+++ b/src/pipeline/RADETransmitStep.h
@@ -51,6 +51,12 @@ private:
     std::vector<float> featureList_;
     
     FILE* featuresFile_;
+
+    std::shared_ptr<short> outputSamples_;
+    RADE_COMP* radeOut_;
+    short* radeOutShort_;
+    RADE_COMP* eooOut_;
+    short* eooOutShort_;
 };
 
 #endif // AUDIO_PIPELINE__RADE_TRANSMIT_STEP_H

--- a/src/pipeline/ResampleStep.cpp
+++ b/src/pipeline/ResampleStep.cpp
@@ -36,24 +36,20 @@ static int resample_step(SRC_STATE *src,
             int        output_sample_rate,
             int        input_sample_rate,
             int        length_output_short, // maximum output array length in samples
-            int        length_input_short
+            int        length_input_short,
+            float     *tmpInput,
+            float     *tmpOutput
             )
 {
     SRC_DATA src_data;
-    float*    input = new float[length_input_short];
-    assert(input != nullptr);
-
-    float*    output = new float[length_output_short];
-    assert(output != nullptr);
-
     int      ret;
 
     assert(src != NULL);
 
-    src_short_to_float_array(input_short, input, length_input_short);
+    src_short_to_float_array(input_short, tmpInput, length_input_short);
 
-    src_data.data_in = input;
-    src_data.data_out = output;
+    src_data.data_in = tmpInput;
+    src_data.data_out = tmpOutput;
     src_data.input_frames = length_input_short;
     src_data.output_frames = length_output_short;
     src_data.end_of_input = 0;
@@ -67,10 +63,7 @@ static int resample_step(SRC_STATE *src,
     assert(ret == 0);
 
     assert(src_data.output_frames_gen <= length_output_short);
-    src_float_to_short_array(output, output_short, src_data.output_frames_gen);
-
-    delete[] input;
-    delete[] output;
+    src_float_to_short_array(tmpOutput, output_short, src_data.output_frames_gen);
 
     return src_data.output_frames_gen;
 }
@@ -82,11 +75,27 @@ ResampleStep::ResampleStep(int inputSampleRate, int outputSampleRate)
     int src_error;
     resampleState_ = src_new(SRC_SINC_MEDIUM_QUALITY, 1, &src_error);
     assert(resampleState_ != nullptr);
+
+    // Pre-allocate buffers so we don't have to do so during real-time operation.
+    auto maxSamples = std::max(getInputSampleRate(), getOutputSampleRate());
+    outputSamples_ = std::shared_ptr<short>(
+        new short[maxSamples], 
+        std::default_delete<short[]>());
+    assert(outputSamples_ != nullptr);
+    
+    tempInput_ = new float[std::max(inputSampleRate, outputSampleRate)];
+    assert(tempInput_ != nullptr);
+
+    tempOutput_ = new float[std::max(inputSampleRate, outputSampleRate)];
+    assert(tempOutput_ != nullptr);
 }
 
 ResampleStep::~ResampleStep()
 {
     src_delete(resampleState_);
+
+    delete[] tempInput_;
+    delete[] tempOutput_;
 }
 
 int ResampleStep::getInputSampleRate() const
@@ -101,24 +110,20 @@ int ResampleStep::getOutputSampleRate() const
 
 std::shared_ptr<short> ResampleStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    short* outputSamples = nullptr;
     if (numInputSamples > 0)
     {
         double scaleFactor = ((double)outputSampleRate_)/((double)inputSampleRate_);
         int outputArraySize = std::max(numInputSamples, (int)(scaleFactor*numInputSamples));
         assert(outputArraySize > 0);
 
-        outputSamples = new short[outputArraySize];
-        assert(outputSamples != nullptr);
- 
         *numOutputSamples = resample_step(
-            resampleState_, outputSamples, inputSamples.get(), outputSampleRate_, 
-            inputSampleRate_, outputArraySize, numInputSamples);
+            resampleState_, outputSamples_.get(), inputSamples.get(), outputSampleRate_, 
+            inputSampleRate_, outputArraySize, numInputSamples, tempInput_, tempOutput_);
     }
     else
     {
         *numOutputSamples = 0;
     }
  
-    return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
+    return outputSamples_;
 }

--- a/src/pipeline/ResampleStep.h
+++ b/src/pipeline/ResampleStep.h
@@ -41,6 +41,10 @@ private:
     int inputSampleRate_;
     int outputSampleRate_;
     SRC_STATE* resampleState_;
+
+    float* tempInput_;
+    float* tempOutput_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__RESAMPLE_STEP_H

--- a/src/pipeline/SpeexStep.h
+++ b/src/pipeline/SpeexStep.h
@@ -50,6 +50,8 @@ private:
     SpeexPreprocessState* speexStateObj_;
     int numSamplesPerSpeexRun_;
     struct FIFO* inputSampleFifo_;
+
+    std::shared_ptr<short> outputSamples_;
 };
 
 

--- a/src/pipeline/TapStep.cpp
+++ b/src/pipeline/TapStep.cpp
@@ -53,10 +53,13 @@ std::shared_ptr<short> TapStep::execute(std::shared_ptr<short> inputSamples, int
     
     if (operateBackground_)
     {
+        // 5 millisecond timeout to queue to background thread.
+        // Since this is likely for the UI, it's fine if the step
+        // doesn't execute.
         enqueue_([&, inputSamples, numInputSamples]() {
             int temp = 0;
             tapStep_->execute(inputSamples, numInputSamples, &temp);
-        });
+        }, 5);
     }
     else
     {

--- a/src/pipeline/TapStep.cpp
+++ b/src/pipeline/TapStep.cpp
@@ -24,9 +24,10 @@
 
 #include <assert.h>
 
-TapStep::TapStep(int sampleRate, IPipelineStep* tapStep)
+TapStep::TapStep(int sampleRate, IPipelineStep* tapStep, bool operateBackground)
     : tapStep_(tapStep)
     , sampleRate_(sampleRate)
+    , operateBackground_(operateBackground)
 {
     // empty
 }
@@ -48,9 +49,20 @@ int TapStep::getOutputSampleRate() const
 
 std::shared_ptr<short> TapStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    int temp = 0;
     assert(tapStep_->getInputSampleRate() == sampleRate_);
-    tapStep_->execute(inputSamples, numInputSamples, &temp);
+    
+    if (operateBackground_)
+    {
+        enqueue_([&, inputSamples, numInputSamples]() {
+            int temp = 0;
+            tapStep_->execute(inputSamples, numInputSamples, &temp);
+        });
+    }
+    else
+    {
+        int temp = 0;
+        tapStep_->execute(inputSamples, numInputSamples, &temp);
+    }
     
     *numOutputSamples = numInputSamples;
     return inputSamples;

--- a/src/pipeline/TapStep.h
+++ b/src/pipeline/TapStep.h
@@ -26,11 +26,12 @@
 #include <memory>
 
 #include "IPipelineStep.h"
+#include "util/ThreadedObject.h"
 
-class TapStep : public IPipelineStep
+class TapStep : public IPipelineStep, public ThreadedObject
 {
 public:
-    TapStep(int inputSampleRate, IPipelineStep* tapStep);
+    TapStep(int inputSampleRate, IPipelineStep* tapStep, bool operateBackground);
     virtual ~TapStep();
     
     virtual int getInputSampleRate() const;
@@ -40,6 +41,7 @@ public:
 private:
     std::shared_ptr<IPipelineStep> tapStep_;
     int sampleRate_;
+    bool operateBackground_;
 };
 
 #endif // AUDIO_PIPELINE__TAP_STEP_H

--- a/src/pipeline/ToneInterfererStep.h
+++ b/src/pipeline/ToneInterfererStep.h
@@ -45,6 +45,7 @@ private:
     std::function<float()> toneFrequencyFn_;
     std::function<float()> toneAmplitudeFn_;
     std::function<float*()> tonePhaseFn_;
+    std::shared_ptr<short> outputSamples_;
 };
 
 #endif // AUDIO_PIPELINE__TONE_INTERFERER_STEP_H

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -468,11 +468,11 @@ void* TxRxThread::Entry()
 {
     initializePipeline_();
     
-#if __APPLE__ || WIN32
+#if defined(__APPLE__) || defined(WIN32)
     // Request real-time scheduling from the operating system. Needed on macOS and Windows
     // to prevent dropouts.
     RequestRealTimeScheduling();
-#endif // __APPLE__ || WIN32
+#endif // defined(__APPLE__) || defined(WIN32)
     
     while (m_run)
     {
@@ -507,10 +507,10 @@ void* TxRxThread::Entry()
     // Force pipeline to delete itself when we're done with the thread.
     pipeline_ = nullptr;
     
-#if __APPLE__ || WIN32
+#if defined(__APPLE__) || defined(WIN32)
     // Return to normal scheduling
     RequestNormalScheduling();
-#endif // __APPLE__ || WIN32
+#endif // defined(__APPLE__) || defined(WIN32)
     
     return NULL;
 }

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -499,7 +499,9 @@ void* TxRxThread::Entry()
         if (m_tx) txProcessing_();
         else rxProcessing_();
 
-        std::this_thread::sleep_until(currentTime + 10ms);
+        // 11ms is chosen here to hopefully ensure that we never execute at the same time as any other
+        // audio threads.
+        std::this_thread::sleep_until(currentTime + 11ms); 
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -501,19 +501,8 @@ void* TxRxThread::Entry()
         
         inputDevice_->stopRealTimeWork();
 
-        auto endTime = std::chrono::steady_clock::now();
-        
-        if ((endTime - beginTime) >= 10ms)
-        {
-            // Sleep for 10ms if we went over the time quantum, just so the OS
-            // doesn't penalize this thread.
-            std::this_thread::sleep_for(10ms); 
-        }
-        else
-        {
-            // Sleep for the remainder of the time quantum
-            std::this_thread::sleep_until(beginTime + 10ms); 
-        }
+        // Sleep for the remainder of the time quantum
+        std::this_thread::sleep_until(beginTime + 10ms); 
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -494,7 +494,7 @@ void* TxRxThread::Entry()
 
         if (!m_run) break;
         
-        log_info("thread woken up: m_tx=%d", (int)m_tx));
+        log_info("thread woken up: m_tx=%d", (int)m_tx);
         inputDevice_->startRealTimeWork();
         
         if (m_tx) txProcessing_();

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -48,6 +48,7 @@ using namespace std::chrono_literals;
 #include "LinkStep.h"
 
 #include "util/logging/ulog.h"
+#include "os/os_interface.h"
 
 #include <wx/stopwatch.h>
 
@@ -467,6 +468,12 @@ void* TxRxThread::Entry()
 {
     initializePipeline_();
     
+#if __APPLE__ || WIN32
+    // Request real-time scheduling from the operating system. Needed on macOS and Windows
+    // to prevent dropouts.
+    RequestRealTimeScheduling();
+#endif // __APPLE__ || WIN32
+    
     while (m_run)
     {
 #if defined(__linux__)
@@ -497,6 +504,11 @@ void* TxRxThread::Entry()
     
     // Force pipeline to delete itself when we're done with the thread.
     pipeline_ = nullptr;
+    
+#if __APPLE__ || WIN32
+    // Return to normal scheduling
+    RequestNormalScheduling();
+#endif // __APPLE__ || WIN32
     
     return NULL;
 }

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -149,7 +149,7 @@ void TxRxThread::initializePipeline_()
         auto recordMicPipeline = new AudioPipeline(inputSampleRate_, inputSampleRate_);
         recordMicPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(recordMicStep));
         
-        auto recordMicTap = new TapStep(inputSampleRate_, recordMicPipeline);
+        auto recordMicTap = new TapStep(inputSampleRate_, recordMicPipeline, false);
         auto bypassRecordMic = new AudioPipeline(inputSampleRate_, inputSampleRate_);
         
         auto eitherOrRecordMic = new EitherOrStep(
@@ -216,7 +216,7 @@ void TxRxThread::initializePipeline_()
             auto micAudioPipeline = new AudioPipeline(inputSampleRate_, equalizedMicAudioLink_->getSampleRate());
             micAudioPipeline->appendPipelineStep(equalizedMicAudioLink_->getInputPipelineStep());
         
-            auto micAudioTap = std::make_shared<TapStep>(inputSampleRate_, micAudioPipeline);
+            auto micAudioTap = std::make_shared<TapStep>(inputSampleRate_, micAudioPipeline, false);
             pipeline_->appendPipelineStep(micAudioTap);
         }
                 
@@ -225,7 +225,7 @@ void TxRxThread::initializePipeline_()
         auto resampleForPlotPipeline = new AudioPipeline(inputSampleRate_, resampleForPlotStep->getOutputSampleRate());
         resampleForPlotPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotStep));
 
-        auto resampleForPlotTap = new TapStep(inputSampleRate_, resampleForPlotPipeline);
+        auto resampleForPlotTap = new TapStep(inputSampleRate_, resampleForPlotPipeline, true);
         pipeline_->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotTap));
         
         // FreeDV TX step (analog leg)
@@ -253,7 +253,7 @@ void TxRxThread::initializePipeline_()
         auto recordModulatedPipeline = new AudioPipeline(outputSampleRate_, recordModulatedStep->getOutputSampleRate());
         recordModulatedPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(recordModulatedStep));
         
-        auto recordModulatedTap = new TapStep(outputSampleRate_, recordModulatedPipeline);
+        auto recordModulatedTap = new TapStep(outputSampleRate_, recordModulatedPipeline, false);
         auto recordModulatedTapPipeline = new AudioPipeline(outputSampleRate_, outputSampleRate_);
         recordModulatedTapPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(recordModulatedTap));
         
@@ -294,7 +294,7 @@ void TxRxThread::initializePipeline_()
         auto recordRadioPipeline = new AudioPipeline(inputSampleRate_, inputSampleRate_);
         recordRadioPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(recordRadioStep));
         
-        auto recordRadioTap = new TapStep(inputSampleRate_, recordRadioPipeline);
+        auto recordRadioTap = new TapStep(inputSampleRate_, recordRadioPipeline, false);
         auto bypassRecordRadio = new AudioPipeline(inputSampleRate_, inputSampleRate_);
         
         auto eitherOrRecordRadio = new EitherOrStep(
@@ -340,7 +340,7 @@ void TxRxThread::initializePipeline_()
         auto resampleForPlotPipeline = new AudioPipeline(inputSampleRate_, resampleForPlotStep->getOutputSampleRate());
         resampleForPlotPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotStep));
 
-        auto resampleForPlotTap = new TapStep(inputSampleRate_, resampleForPlotPipeline);
+        auto resampleForPlotTap = new TapStep(inputSampleRate_, resampleForPlotPipeline, true);
         pipeline_->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotTap));
         
         // Tone interferer step (optional)
@@ -367,7 +367,7 @@ void TxRxThread::initializePipeline_()
             inputSampleRate_, computeRfSpectrumStep->getOutputSampleRate());
         computeRfSpectrumPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(computeRfSpectrumStep));
         
-        auto computeRfSpectrumTap = new TapStep(inputSampleRate_, computeRfSpectrumPipeline);
+        auto computeRfSpectrumTap = new TapStep(inputSampleRate_, computeRfSpectrumPipeline, true);
         pipeline_->appendPipelineStep(std::shared_ptr<IPipelineStep>(computeRfSpectrumTap));
         
         // RX demodulation step
@@ -457,7 +457,7 @@ void TxRxThread::initializePipeline_()
         auto resampleForPlotOutPipeline = new AudioPipeline(outputSampleRate_, resampleForPlotOutStep->getOutputSampleRate());
         resampleForPlotOutPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotOutStep));
 
-        auto resampleForPlotOutTap = new TapStep(outputSampleRate_, resampleForPlotOutPipeline);
+        auto resampleForPlotOutTap = new TapStep(outputSampleRate_, resampleForPlotOutPipeline, true);
         pipeline_->appendPipelineStep(std::shared_ptr<IPipelineStep>(resampleForPlotOutTap));
         
         // Clear anything in the FIFO before resuming decode.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -494,7 +494,7 @@ void* TxRxThread::Entry()
 
         if (!m_run) break;
         
-        log_info("thread woken up: m_tx=%d", (int)m_tx);
+        //log_info("thread woken up: m_tx=%d", (int)m_tx);
         inputDevice_->startRealTimeWork();
         
         if (m_tx) txProcessing_();

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -490,7 +490,7 @@ void* TxRxThread::Entry()
         }
 #endif
 
-        auto currentTime = std::chrono::steady_clock::now();
+        auto beginTime = std::chrono::steady_clock::now();
 
         if (!m_run) break;
         
@@ -501,7 +501,19 @@ void* TxRxThread::Entry()
         
         inputDevice_->stopRealTimeWork();
 
-        std::this_thread::sleep_until(currentTime + 10ms); 
+        auto endTime = std::chrono::steady_clock::now();
+        
+        if ((endTime - beginTime) >= 10ms)
+        {
+            // Sleep for 10ms if we went over the time quantum, just so the OS
+            // doesn't penalize this thread.
+            std::this_thread::sleep_for(10ms); 
+        }
+        else
+        {
+            // Sleep for the remainder of the time quantum
+            std::this_thread::sleep_until(beginTime + 10ms); 
+        }
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -127,7 +127,7 @@ void TxRxThread::initializePipeline_()
     // Function definitions shared across both pipelines.
     auto callbackLockFn = []() {
         // Prevent priority inversions by bounding the time we can wait for a lock.
-        g_mutexProtectingCallbackData.LockTimeout(1);
+        g_mutexProtectingCallbackData.LockTimeout(5);
     };
     
     auto callbackUnlockFn = []() {
@@ -327,7 +327,7 @@ void TxRxThread::initializePipeline_()
         auto eitherOrPlayRadioStep = new EitherOrStep(
             []() { 
                 // Prevent priority inversions by bounding the time we can wait for a lock.
-                g_mutexProtectingCallbackData.LockTimeout(1);
+                g_mutexProtectingCallbackData.LockTimeout(5);
                 auto result = g_playFileFromRadio && (g_sfPlayFileFromRadio != NULL);
                 g_mutexProtectingCallbackData.Unlock();
                 return result;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -499,9 +499,7 @@ void* TxRxThread::Entry()
         if (m_tx) txProcessing_();
         else rxProcessing_();
 
-        // 7ms is chosen here to hopefully ensure that we never execute at the same time as any other
-        // audio threads.
-        std::this_thread::sleep_until(currentTime + 7ms); 
+        std::this_thread::sleep_until(currentTime + 10ms); 
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -126,7 +126,8 @@ void TxRxThread::initializePipeline_()
 {
     // Function definitions shared across both pipelines.
     auto callbackLockFn = []() {
-        g_mutexProtectingCallbackData.Lock();
+        // Prevent priority inversions by bounding the time we can wait for a lock.
+        g_mutexProtectingCallbackData.LockTimeout(1);
     };
     
     auto callbackUnlockFn = []() {
@@ -325,7 +326,8 @@ void TxRxThread::initializePipeline_()
         
         auto eitherOrPlayRadioStep = new EitherOrStep(
             []() { 
-                g_mutexProtectingCallbackData.Lock();
+                // Prevent priority inversions by bounding the time we can wait for a lock.
+                g_mutexProtectingCallbackData.LockTimeout(1);
                 auto result = g_playFileFromRadio && (g_sfPlayFileFromRadio != NULL);
                 g_mutexProtectingCallbackData.Unlock();
                 return result;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -494,6 +494,7 @@ void* TxRxThread::Entry()
 
         if (!m_run) break;
         
+        log_info("thread woken up: m_tx=%d", (int)m_tx));
         inputDevice_->startRealTimeWork();
         
         if (m_tx) txProcessing_();

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -379,7 +379,8 @@ void TxRxThread::initializePipeline_()
             []() { return g_channel_noise; },
             []() { return wxGetApp().appConfiguration.noiseSNR; },
             []() { return g_RxFreqOffsetHz; },
-            []() { return &g_sig_pwr_av; }
+            []() { return &g_sig_pwr_av; },
+            helper_
         );
         rfDemodulationPipeline->appendPipelineStep(std::shared_ptr<IPipelineStep>(rfDemodulationStep));
         
@@ -469,7 +470,7 @@ void* TxRxThread::Entry()
     initializePipeline_();
     
     // Request real-time scheduling from the operating system.    
-    inputDevice_->setHelperRealTime();
+    helper_->setHelperRealTime();
     
     while (m_run)
     {
@@ -495,19 +496,19 @@ void* TxRxThread::Entry()
         if (!m_run) break;
         
         //log_info("thread woken up: m_tx=%d", (int)m_tx);
-        inputDevice_->startRealTimeWork();
+        helper_->startRealTimeWork();
         
         if (m_tx) txProcessing_();
         else rxProcessing_();
         
-        inputDevice_->stopRealTimeWork();
+        helper_->stopRealTimeWork();
     }
     
     // Force pipeline to delete itself when we're done with the thread.
     pipeline_ = nullptr;
     
     // Return to normal scheduling
-    inputDevice_->clearHelperRealTime();
+    helper_->clearHelperRealTime();
     
     return NULL;
 }

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -499,9 +499,9 @@ void* TxRxThread::Entry()
         if (m_tx) txProcessing_();
         else rxProcessing_();
 
-        // 11ms is chosen here to hopefully ensure that we never execute at the same time as any other
+        // 7ms is chosen here to hopefully ensure that we never execute at the same time as any other
         // audio threads.
-        std::this_thread::sleep_until(currentTime + 11ms); 
+        std::this_thread::sleep_until(currentTime + 7ms); 
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -491,8 +491,6 @@ void* TxRxThread::Entry()
         }
 #endif
 
-        auto beginTime = std::chrono::steady_clock::now();
-
         if (!m_run) break;
         
         //log_info("thread woken up: m_tx=%d", (int)m_tx);

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -501,9 +501,6 @@ void* TxRxThread::Entry()
         else rxProcessing_();
         
         inputDevice_->stopRealTimeWork();
-
-        // Sleep for the remainder of the time quantum
-        std::this_thread::sleep_until(beginTime + 10ms); 
     }
     
     // Force pipeline to delete itself when we're done with the thread.

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -53,6 +53,10 @@ public:
     { 
         assert(inputSampleRate_ > 0);
         assert(outputSampleRate_ > 0);
+
+        inputSamples_ = std::shared_ptr<short>(
+            new short[std::max(inputSampleRate_, outputSampleRate_)], 
+            std::default_delete<short[]>());
     }
 
     // thread execution starts here
@@ -77,6 +81,7 @@ private:
     LinkStep* equalizedMicAudioLink_;
     bool hasEooBeenSent_;
     std::shared_ptr<IRealtimeHelper> helper_;
+    std::shared_ptr<short> inputSamples_;
     
     void initializePipeline_();
     void txProcessing_();

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -29,6 +29,7 @@
 #include <condition_variable>
 
 #include "AudioPipeline.h"
+#include "audio/IAudioDevice.h"
 
 // Forward declarations
 class LinkStep;
@@ -39,7 +40,7 @@ class LinkStep;
 class TxRxThread : public wxThread
 {
 public:
-    TxRxThread(bool tx, int inputSampleRate, int outputSampleRate, LinkStep* micAudioLink) 
+    TxRxThread(bool tx, int inputSampleRate, int outputSampleRate, LinkStep* micAudioLink, std::shared_ptr<IAudioDevice> inputDevice) 
         : wxThread(wxTHREAD_JOINABLE)
         , m_tx(tx)
         , m_run(1)
@@ -48,6 +49,7 @@ public:
         , outputSampleRate_(outputSampleRate)
         , equalizedMicAudioLink_(micAudioLink)
         , hasEooBeenSent_(false)
+        , inputDevice_(inputDevice)
     { 
         assert(inputSampleRate_ > 0);
         assert(outputSampleRate_ > 0);
@@ -74,6 +76,7 @@ private:
     int outputSampleRate_;
     LinkStep* equalizedMicAudioLink_;
     bool hasEooBeenSent_;
+    std::shared_ptr<IAudioDevice> inputDevice_;
     
     void initializePipeline_();
     void txProcessing_();

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -29,7 +29,7 @@
 #include <condition_variable>
 
 #include "AudioPipeline.h"
-#include "audio/IAudioDevice.h"
+#include "util/IRealtimeHelper.h"
 
 // Forward declarations
 class LinkStep;
@@ -40,7 +40,7 @@ class LinkStep;
 class TxRxThread : public wxThread
 {
 public:
-    TxRxThread(bool tx, int inputSampleRate, int outputSampleRate, LinkStep* micAudioLink, std::shared_ptr<IAudioDevice> inputDevice) 
+    TxRxThread(bool tx, int inputSampleRate, int outputSampleRate, LinkStep* micAudioLink, std::shared_ptr<IRealtimeHelper> helper) 
         : wxThread(wxTHREAD_JOINABLE)
         , m_tx(tx)
         , m_run(1)
@@ -49,7 +49,7 @@ public:
         , outputSampleRate_(outputSampleRate)
         , equalizedMicAudioLink_(micAudioLink)
         , hasEooBeenSent_(false)
-        , inputDevice_(inputDevice)
+        , helper_(helper)
     { 
         assert(inputSampleRate_ > 0);
         assert(outputSampleRate_ > 0);
@@ -76,7 +76,7 @@ private:
     int outputSampleRate_;
     LinkStep* equalizedMicAudioLink_;
     bool hasEooBeenSent_;
-    std::shared_ptr<IAudioDevice> inputDevice_;
+    std::shared_ptr<IRealtimeHelper> helper_;
     
     void initializePipeline_();
     void txProcessing_();

--- a/src/pipeline/test/TapTest.cpp
+++ b/src/pipeline/test/TapTest.cpp
@@ -19,7 +19,7 @@ public:
 bool tapDataEqual()
 {
     PassThroughStep* step = new PassThroughStep;
-    TapStep tapStep(8000, step);
+    TapStep tapStep(8000, step, false);
     
     int outputSamples = 0;
     short* pData = new short[1];

--- a/src/util/IRealtimeHelper.h
+++ b/src/util/IRealtimeHelper.h
@@ -1,0 +1,46 @@
+//=========================================================================
+// Name:            IRealtimeHelper.h
+// Purpose:         Defines the interface to a helper for real-time operation.
+//
+// Authors:         Mooneer Salem
+// License:
+//
+//  All rights reserved.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//=========================================================================
+
+
+#ifndef I_REALTIME_HELPER_H
+#define I_REALTIME_HELPER_H
+
+class IRealtimeHelper
+{
+public:
+    // Configures current thread for real-time priority. This should be
+    // called from the thread that will be operating on received audio.
+    virtual void setHelperRealTime() = 0;
+    
+    // Lets audio system know that we're beginning to do work with the
+    // received audio.
+    virtual void startRealTimeWork() = 0;
+    
+    // Lets audio system know that we're done with the work on the received
+    // audio.
+    virtual void stopRealTimeWork() = 0;
+    
+    // Reverts real-time priority for current thread.
+    virtual void clearHelperRealTime() = 0;
+};
+
+#endif

--- a/src/util/ThreadedObject.cpp
+++ b/src/util/ThreadedObject.cpp
@@ -20,7 +20,10 @@
 //
 //=========================================================================
 
+#include <chrono>
 #include "ThreadedObject.h"
+
+using namespace std::chrono_literals;
 
 ThreadedObject::ThreadedObject()
     : isDestroying_(false)
@@ -37,10 +40,41 @@ ThreadedObject::~ThreadedObject()
     objectThread_.join();
 }
 
-void ThreadedObject::enqueue_(std::function<void()> fn)
+void ThreadedObject::enqueue_(std::function<void()> fn, int timeoutMilliseconds)
 {
-    std::unique_lock<std::recursive_mutex> lk(eventQueueMutex_);
+    std::unique_lock<std::recursive_mutex> lk(eventQueueMutex_, std::defer_lock_t());
+
+    if (timeoutMilliseconds == 0)
+    {
+        lk.lock();
+    }
+    else
+    {
+        auto beginTime = std::chrono::high_resolution_clock::now();
+        auto endTime = std::chrono::high_resolution_clock::now();
+        bool locked = false;
+
+        do
+        {
+            if (lk.try_lock())
+            {
+                locked = true;
+                break;
+            }
+            std::this_thread::sleep_for(1ms);
+            endTime = std::chrono::high_resolution_clock::now();
+        } while ((endTime - beginTime) < std::chrono::milliseconds(timeoutMilliseconds));
+        
+        if (!locked)
+        {
+            // could not lock, so we're not bothering to enqueue.
+            return;
+        }
+    }
+
     eventQueue_.push_back(fn);
+    lk.unlock();
+
     eventQueueCV_.notify_one();
 }
 

--- a/src/util/ThreadedObject.h
+++ b/src/util/ThreadedObject.h
@@ -37,7 +37,9 @@ public:
 protected:
     ThreadedObject();
     
-    void enqueue_(std::function<void()> fn);
+    // Enqueues some code to run on a different thread.
+    // @param timeoutMilliseconds Timeout to wait for lock. Note: if we can't get a lock within the timeout, the function doesn't run!
+    void enqueue_(std::function<void()> fn, int timeoutMilliseconds = 0);
     
 private:
     bool isDestroying_;


### PR DESCRIPTION
This PR requests real-time priority for audio pipeline threads to ensure that they execute consistently enough to reduce/prevent dropouts (especially in the GH environment). If so, this will also investigate the feasibility of reducing the audio latency from 40-50ms on macOS/Windows to closer to 10ms (as is standard in testing with pipewire).