### PR TITLE
Warning cleanup of 2.0 code branch

### DIFF
--- a/src/3rdparty/websocketpp/endpoint.hpp
+++ b/src/3rdparty/websocketpp/endpoint.hpp
@@ -109,7 +109,7 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+    ~endpoint() {}
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable

--- a/src/3rdparty/websocketpp/logger/basic.hpp
+++ b/src/3rdparty/websocketpp/logger/basic.hpp
@@ -58,33 +58,33 @@ namespace log {
 template <typename concurrency, typename names>
 class basic {
 public:
-    basic<concurrency,names>(channel_type_hint::value h =
+    basic(channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(std::ostream * out)
+    basic(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
-    basic<concurrency,names>(level c, channel_type_hint::value h =
+    basic(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(level c, std::ostream * out)
+    basic(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
     /// Destructor
-    ~basic<concurrency,names>() {}
+    ~basic() {}
 
     /// Copy constructor
-    basic<concurrency,names>(basic<concurrency,names> const & other)
+    basic(basic<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
@@ -92,12 +92,12 @@ public:
     
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy assignment operator because of const member variables
-    basic<concurrency,names> & operator=(basic<concurrency,names> const &) = delete;
+    basic & operator=(basic<concurrency,names> const &) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    basic<concurrency,names>(basic<concurrency,names> && other)
+    basic(basic<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)

--- a/src/audio/MacAudioDevice.h
+++ b/src/audio/MacAudioDevice.h
@@ -48,14 +48,14 @@ protected:
     MacAudioDevice(int coreAudioId, IAudioEngine::AudioDirection direction, int numChannels, int sampleRate);
     
 private:
-    const double FRAME_TIME_SEC_ = 0.01;
-    
     int coreAudioId_;
     IAudioEngine::AudioDirection direction_;
     int numChannels_;
     int sampleRate_;
     void* engine_; // actually AVAudioEngine but this file is shared with C++ code
     void* player_; // actually AVAudioPlayerNode
+
+    short* inputFrames_;
 };
 
 #endif // MAC_AUDIO_DEVICE_H

--- a/src/audio/MacAudioDevice.mm
+++ b/src/audio/MacAudioDevice.mm
@@ -397,7 +397,9 @@ int MacAudioDevice::getLatencyInMicroseconds()
         UInt32 streamLatency = 0;
         if (result == noErr)
         {
-            AudioStreamID streams[size / sizeof(AudioStreamID)];
+            AudioStreamID* streams = new AudioStreamID[size / sizeof(AudioStreamID)];
+            assert(streams != nullptr);
+
             result = AudioObjectGetPropertyData(
                       coreAudioId_, 
                       &propertyAddress, 
@@ -417,6 +419,8 @@ int MacAudioDevice::getLatencyInMicroseconds()
                           &size, 
                           &streamLatency);
             }
+
+            delete[] streams;
         }
         
         auto ioLatency = streamLatency + deviceLatencyFrames + deviceSafetyOffset;

--- a/src/audio/MacAudioEngine.cpp
+++ b/src/audio/MacAudioEngine.cpp
@@ -69,14 +69,16 @@ std::vector<AudioDeviceSpecification> MacAudioEngine::getAudioDeviceList(AudioDi
     
     // Get audio device IDs.
     auto deviceCount = propertySize / sizeof(AudioDeviceID);
-    AudioDeviceID ids[deviceCount];
+    AudioDeviceID* ids = new AudioDeviceID[deviceCount];
+    assert(ids != nullptr);
+
     status = AudioObjectGetPropertyData(
         kAudioObjectSystemObject,
         &propertyAddress,
         0,
         nullptr,
         &propertySize,
-        &ids
+        ids
     );
     if (status != noErr)
     {
@@ -84,6 +86,8 @@ std::vector<AudioDeviceSpecification> MacAudioEngine::getAudioDeviceList(AudioDi
         {
             onAudioErrorFunction(*this, "Could not get audio device IDs", onAudioErrorState);
         }
+
+        delete[] ids;
         return result;
     }
     
@@ -99,6 +103,7 @@ std::vector<AudioDeviceSpecification> MacAudioEngine::getAudioDeviceList(AudioDi
         }
     }
     
+    delete[] ids;
     return result;
 }
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -691,9 +691,13 @@ void FreeDVInterface::setReliableText(const char* callsign)
     {
         log_info("generating RADE text string");
         int nsyms = rade_n_eoo_bits(rade_);
-        float eooSyms[nsyms];
+        float* eooSyms = new float[nsyms];
+        assert(eooSyms);
+
         rade_text_generate_tx_string(radeTextPtr_, callsign, strlen(callsign), eooSyms, nsyms);
         rade_tx_set_eoo_bits(rade_, eooSyms);
+
+        delete[] eooSyms;
     }
 
     for (auto& rt : reliableText_)

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -381,7 +381,7 @@ void PlotWaterfall::plotPixelData()
 
     // Draw last line of blocks using latest amplitude data ------------------
     int baseRowWidthPixels = ((float)MODEM_STATS_NSPEC / (float)m_modem_stats_max_f_hz) * MAX_F_HZ;
-    unsigned char* dyImageData = new char[3 * baseRowWidthPixels];
+    unsigned char* dyImageData = new unsigned char[3 * baseRowWidthPixels];
     assert(dyImageData != nullptr);
 
     for(px = 0; px < baseRowWidthPixels; px++)

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -424,7 +424,7 @@ void PlotWaterfall::plotPixelData()
 
     if (dy > 0)
     {
-        wxImage* tmpImage = new wxImage(baseRowWidthPixels, 1, (unsigned char*)&dyImageData, true);
+        wxImage* tmpImage = new wxImage(baseRowWidthPixels, 1, (unsigned char*)dyImageData, true);
         wxBitmap* tmpBmp = new wxBitmap(*tmpImage);
         {
             wxMemoryDC fullBmpSourceDC(*m_fullBmp);

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -381,7 +381,9 @@ void PlotWaterfall::plotPixelData()
 
     // Draw last line of blocks using latest amplitude data ------------------
     int baseRowWidthPixels = ((float)MODEM_STATS_NSPEC / (float)m_modem_stats_max_f_hz) * MAX_F_HZ;
-    unsigned char dyImageData[3 * baseRowWidthPixels];
+    unsigned char* dyImageData = new char[3 * baseRowWidthPixels];
+    assert(dyImageData != nullptr);
+
     for(px = 0; px < baseRowWidthPixels; px++)
     {
         index = px;
@@ -435,6 +437,8 @@ void PlotWaterfall::plotPixelData()
         delete tmpBmp; 
         delete tmpImage;
     }
+
+    delete[] dyImageData;
 }
 
 //-------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1637,11 +1637,14 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
                                will be updated.
                             */
 
-                            COMP rx_symbols_copy[g_Nc/2];
+                            COMP* rx_symbols_copy = new COMP[g_Nc/2];
+                            assert(rx_symbols_copy != nullptr);
 
                             for(c=0; c<g_Nc/2; c++)
                                 rx_symbols_copy[c] = fcmult(0.5, cadd(freedvInterface.getCurrentRxModemStats()->rx_symbols[r][c], freedvInterface.getCurrentRxModemStats()->rx_symbols[r][c+g_Nc/2]));
                             m_panelScatter->add_new_samples_scatter(rx_symbols_copy);
+
+                            delete[] rx_symbols_copy;
                         }
                         else {
                             /*
@@ -3231,17 +3234,15 @@ void MainFrame::startRxStream()
         rxInSoundDevice->setOnAudioData([&](IAudioDevice& dev, void* data, size_t size, void* state) {
             paCallBackData* cbData = static_cast<paCallBackData*>(state);
             short* audioData = static_cast<short*>(data);
-            short  indata[size];
 
             for (size_t i = 0; i < size; i++, audioData += dev.getNumChannels())
             {
-                indata[i] = audioData[0];
-            }
-            
-            if (codec2_fifo_write(cbData->infifo1, indata, size)) 
-            {
-                log_warn("RX FIFO full");
-                g_infifo1_full++;
+                if (codec2_fifo_write(cbData->infifo1, &audioData[0], 1)) 
+                {
+                    log_warn("RX FIFO full");
+                    g_infifo1_full++;
+                    break;
+                }
             }
 
             m_rxThread->notify();
@@ -3265,7 +3266,8 @@ void MainFrame::startRxStream()
             rxOutSoundDevice->setOnAudioData([](IAudioDevice& dev, void* data, size_t size, void* state) {
                 paCallBackData* cbData = static_cast<paCallBackData*>(state);
                 short* audioData = static_cast<short*>(data);
-                short  outdata[size];
+                short* outdata = new short[size];
+                assert(outdata != nullptr);
  
                 int result = codec2_fifo_read(cbData->outfifo2, outdata, size);
                 if (result == 0) 
@@ -3282,6 +3284,8 @@ void MainFrame::startRxStream()
                 {
                     g_outfifo2_empty++;
                 }
+
+                delete[] outdata;
             }, g_rxUserdata);
             
             rxOutSoundDevice->setOnAudioOverflow([](IAudioDevice& dev, void* state)
@@ -3297,18 +3301,15 @@ void MainFrame::startRxStream()
             txInSoundDevice->setOnAudioData([&](IAudioDevice& dev, void* data, size_t size, void* state) {
                 paCallBackData* cbData = static_cast<paCallBackData*>(state);
                 short* audioData = static_cast<short*>(data);
-                short  indata[size];
                 
                 if (!endingTx) 
                 {
                     for(size_t i = 0; i < size; i++, audioData += dev.getNumChannels())
                     {
-                        indata[i] = audioData[0];
-                    }
-                    
-                    if (codec2_fifo_write(cbData->infifo2, indata, size)) 
-                    {
-                        g_infifo2_full++;
+                        if (codec2_fifo_write(cbData->infifo2, &audioData[0], 1)) 
+                        {
+                            g_infifo2_full++;
+                        }
                     }
                 }
 
@@ -3328,7 +3329,8 @@ void MainFrame::startRxStream()
             txOutSoundDevice->setOnAudioData([](IAudioDevice& dev, void* data, size_t size, void* state) {
                 paCallBackData* cbData = static_cast<paCallBackData*>(state);
                 short* audioData = static_cast<short*>(data);
-                short  outdata[size];
+                short* outdata = new short[size];
+                assert(outdata != nullptr);
                 
                 int available = std::min(codec2_fifo_used(cbData->outfifo1), (int)size);
 
@@ -3366,6 +3368,8 @@ void MainFrame::startRxStream()
                 {
                     g_outfifo1_empty++;
                 }
+
+                delete[] outdata;
             }, g_rxUserdata);
         
             txOutSoundDevice->setOnAudioOverflow([](IAudioDevice& dev, void* state)
@@ -3386,7 +3390,9 @@ void MainFrame::startRxStream()
             rxOutSoundDevice->setOnAudioData([](IAudioDevice& dev, void* data, size_t size, void* state) {
                 paCallBackData* cbData = static_cast<paCallBackData*>(state);
                 short* audioData = static_cast<short*>(data);
-                short  outdata[size];
+
+                short* outdata = new short[size];
+                assert(outdata != nullptr);
 
                 int result = codec2_fifo_read(cbData->outfifo1, outdata, size);
                 if (result == 0) 
@@ -3403,6 +3409,8 @@ void MainFrame::startRxStream()
                 {
                     g_outfifo1_empty++;
                 }
+
+                delete[] outdata;
             }, g_rxUserdata);
             
             rxOutSoundDevice->setOnAudioOverflow([](IAudioDevice& dev, void* state)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3332,7 +3332,7 @@ void MainFrame::startRxStream()
                 short* outdata = new short[size];
                 assert(outdata != nullptr);
                 
-                int available = std::min(codec2_fifo_used(cbData->outfifo1), (int)size);
+                unsigned int available = std::min(codec2_fifo_used(cbData->outfifo1), (int)size);
 
                 int result = codec2_fifo_read(cbData->outfifo1, outdata, available);
                 if (result == 0) 

--- a/src/pipeline/ComputeRfSpectrumStep.cpp
+++ b/src/pipeline/ComputeRfSpectrumStep.cpp
@@ -49,7 +49,9 @@ int ComputeRfSpectrumStep::getOutputSampleRate() const
 
 std::shared_ptr<short> ComputeRfSpectrumStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    COMP  rx_fdm[numInputSamples];
+    COMP*  rx_fdm = new COMP[numInputSamples];
+    assert(rx_fdm != nullptr);
+
     float rx_spec[MODEM_STATS_NSPEC];
     
     auto inputSamplesPtr = inputSamples.get();
@@ -69,5 +71,7 @@ std::shared_ptr<short> ComputeRfSpectrumStep::execute(std::shared_ptr<short> inp
     
     // Tap only, no output.
     *numOutputSamples = 0;
+    delete[] rx_fdm;
+
     return std::shared_ptr<short>((short*)nullptr, std::default_delete<short[]>());
 }

--- a/src/pipeline/FreeDVReceiveStep.cpp
+++ b/src/pipeline/FreeDVReceiveStep.cpp
@@ -1,5 +1,5 @@
 //=========================================================================
-// Name:            FreeDVReceiveStep.h
+// Name:            FreeDVReceiveStep.cpp
 // Purpose:         Describes a demodulation step in the audio pipeline.
 //
 // Authors:         Mooneer Salem
@@ -67,11 +67,18 @@ std::shared_ptr<short> FreeDVReceiveStep::execute(std::shared_ptr<short> inputSa
     *numOutputSamples = 0;
     short* outputSamples = nullptr;
     
-    short input_buf[freedv_get_n_max_modem_samples(dv_)];
-    short output_buf[freedv_get_n_speech_samples(dv_)];
-    COMP  rx_fdm[freedv_get_n_max_modem_samples(dv_)];
-    COMP  rx_fdm_offset[freedv_get_n_max_modem_samples(dv_)];
-    
+    short* input_buf = new short[freedv_get_n_max_modem_samples(dv_)];
+    assert(input_buf != nullptr);
+
+    short* output_buf = new short[freedv_get_n_speech_samples(dv_)];
+    assert(output_buf != nullptr);
+
+    COMP* rx_fdm = new COMP[freedv_get_n_max_modem_samples(dv_)];
+    assert(rx_fdm != nullptr);
+
+    COMP* rx_fdm_offset = new COMP[freedv_get_n_max_modem_samples(dv_)];
+    assert(rx_fdm_offset != nullptr);
+
     short* inputPtr = inputSamples.get();
     while (numInputSamples > 0 && inputPtr != nullptr)
     {
@@ -116,5 +123,10 @@ std::shared_ptr<short> FreeDVReceiveStep::execute(std::shared_ptr<short> inputSa
         }
     }
     
+    delete[] input_buf;
+    delete[] output_buf;
+    delete[] rx_fdm;
+    delete[] rx_fdm_offset;
+ 
     return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
 }

--- a/src/pipeline/LinkStep.cpp
+++ b/src/pipeline/LinkStep.cpp
@@ -44,10 +44,13 @@ LinkStep::~LinkStep()
 void LinkStep::clearFifo()
 {
     int numUsed = codec2_fifo_used(fifo_);
-    short tmp[numUsed];
+    short* tmp = new short[numUsed];
+    assert(tmp != nullptr);
     
     // Read data and then promptly throw it out.
     codec2_fifo_read(fifo_, tmp, numUsed);
+
+    delete[] tmp;
 }
 
 std::shared_ptr<short> LinkStep::InputStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)

--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -83,10 +83,15 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
     *numOutputSamples = 0;
     short* outputSamples = nullptr;
     
-    RADE_COMP input_buf_cplx[rade_nin_max(dv_)];
-    short input_buf[rade_nin_max(dv_)];
-    float features_out[rade_n_features_in_out(dv_)];
-    
+    RADE_COMP* input_buf_cplx = new RADE_COMP[rade_nin_max(dv_)];
+    assert(input_buf_cplx != nullptr);
+
+    short* input_buf = new short[rade_nin_max(dv_)];
+    assert(input_buf != nullptr);
+
+    float* features_out = new float[rade_n_features_in_out(dv_)];
+    assert(features_out != nullptr);
+
     short* inputPtr = inputSamples.get();
     while (numInputSamples > 0 && inputPtr != nullptr)
     {
@@ -108,7 +113,9 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
 
             // RADE processing (input signal->features).
             int hasEooOut = 0;
-            float eooOut[rade_n_eoo_bits(dv_)];
+            float* eooOut = new float[rade_n_eoo_bits(dv_)];
+            assert(eooOut != nullptr);
+
             nout = rade_rx(dv_, features_out, &hasEooOut, eooOut, input_buf_cplx);
             if (hasEooOut && textPtr_ != nullptr)
             {
@@ -155,7 +162,8 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
                     codec2_fifo_write(outputSampleFifo_, pcm, LPCNET_FRAME_SIZE);
                 }
             }
-            
+
+            delete[] eooOut;            
             nin = rade_nin(dv_);
         }
     }
@@ -167,5 +175,9 @@ std::shared_ptr<short> RADEReceiveStep::execute(std::shared_ptr<short> inputSamp
         codec2_fifo_read(outputSampleFifo_, outputSamples, *numOutputSamples);
     }
 
+    delete[] input_buf_cplx;
+    delete[] input_buf;
+    delete[] features_out;
+    
     return std::shared_ptr<short>(outputSamples, std::default_delete<short[]>());
 }

--- a/src/pipeline/RADETransmitStep.cpp
+++ b/src/pipeline/RADETransmitStep.cpp
@@ -108,7 +108,7 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
         
         if (codec2_fifo_used(inputSampleFifo_) >= LPCNET_FRAME_SIZE)
         {
-            int numRequiredFeaturesForRADE = rade_n_features_in_out(dv_);
+            unsigned int numRequiredFeaturesForRADE = rade_n_features_in_out(dv_);
             int numOutputSamples = rade_n_tx_out(dv_);
             short pcm[LPCNET_FRAME_SIZE];
             float features[NB_TOTAL_FEATURES];
@@ -139,7 +139,7 @@ std::shared_ptr<short> RADETransmitStep::execute(std::shared_ptr<short> inputSam
             while (featureList_.size() >= numRequiredFeaturesForRADE)
             {
                 rade_tx(dv_, radeOut, &featureList_[0]);
-                for (int index = 0; index < numRequiredFeaturesForRADE; index++)
+                for (unsigned int index = 0; index < numRequiredFeaturesForRADE; index++)
                 {
                     featureList_.erase(featureList_.begin());
                 }

--- a/src/pipeline/ResampleStep.cpp
+++ b/src/pipeline/ResampleStep.cpp
@@ -40,8 +40,12 @@ static int resample_step(SRC_STATE *src,
             )
 {
     SRC_DATA src_data;
-    float    input[length_input_short];
-    float    output[length_output_short];
+    float*    input = new float[length_input_short];
+    assert(input != nullptr);
+
+    float*    output = new float[length_output_short];
+    assert(output != nullptr);
+
     int      ret;
 
     assert(src != NULL);
@@ -64,6 +68,9 @@ static int resample_step(SRC_STATE *src,
 
     assert(src_data.output_frames_gen <= length_output_short);
     src_float_to_short_array(output, output_short, src_data.output_frames_gen);
+
+    delete[] input;
+    delete[] output;
 
     return src_data.output_frames_gen;
 }

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -621,7 +621,9 @@ void TxRxThread::txProcessing_()
         int nsam_in_48 = freedvInterface.getTxNumSpeechSamples() * ((float)inputSampleRate_ / (float)freedvInterface.getTxSpeechSampleRate());
         assert(nsam_in_48 > 0);
 
-        short           insound_card[nsam_in_48];
+        short*           insound_card = new short[nsam_in_48];
+        assert(insound_card != nullptr);
+
         int             nout;
 
         
@@ -693,7 +695,8 @@ void TxRxThread::txProcessing_()
                 codec2_fifo_write(cbData->outfifo1, outputSamples.get(), nout);
             }
         }
-        
+       
+        delete[] insound_card; 
         txModeChangeMutex.Unlock();
     }
     else
@@ -738,7 +741,9 @@ void TxRxThread::rxProcessing_()
     int nsam = (int)(inputSampleRate_ * FRAME_DURATION);
     assert(nsam > 0);
 
-    short           insound_card[nsam];
+    short*           insound_card = new short[nsam];
+    assert(insound_card != nullptr);
+
     int             nout;
 
 
@@ -774,4 +779,6 @@ void TxRxThread::rxProcessing_()
                 (g_tx && wxGetApp().appConfiguration.monitorTxAudio) ||
                 (!g_voice_keyer_tx && ((g_half_duplex && !g_tx) || !g_half_duplex));
     }
+
+    delete[] insound_card;
 }

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -37,11 +37,7 @@ HamlibRigController::RigList HamlibRigController::RigList_;
 HamlibRigController::RigNameList HamlibRigController::RigNameList_;
 std::mutex HamlibRigController::RigListMutex_;
 
-#if RIGCAPS_NOT_CONST
-int HamlibRigController::BuildRigList_(struct rig_caps *rig, rig_ptr_t rigList) {
-#else
 int HamlibRigController::BuildRigList_(const struct rig_caps *rig, rig_ptr_t rigList) {    
-#endif // RIGCAPS_NOT_CONST
     ((HamlibRigController::RigList *)rigList)->push_back(rig); 
     return 1;
 }

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -106,11 +106,7 @@ private:
 
     static bool RigCompare_(const struct rig_caps *rig1, const struct rig_caps *rig2);
 
-#if RIGCAPS_NOT_CONST    
-    static int BuildRigList_(struct rig_caps *rig, rig_ptr_t);
-#else
     static int BuildRigList_(const struct rig_caps *rig, rig_ptr_t);
-#endif // RIGCAPS_NOT_CONST
 };
 
 #endif // HAMLIB_RIG_CONTROLLER_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -259,8 +259,12 @@ int resample(SRC_STATE *src,
             )
 {
     SRC_DATA src_data;
-    float    input[length_input_short];
-    float    output[length_output_short];
+    float*   input = new float[length_input_short];
+    assert(input != nullptr);
+
+    float*   output = new float[length_output_short];
+    assert(output != nullptr);
+
     int      ret;
 
     assert(src != NULL);
@@ -284,6 +288,9 @@ int resample(SRC_STATE *src,
     assert(src_data.output_frames_gen <= length_output_short);
     src_float_to_short_array(output, output_short, src_data.output_frames_gen);
 
+    delete[] input;
+    delete[] output;
+
     return src_data.output_frames_gen;
 }
 
@@ -298,7 +305,8 @@ void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs)
     int decimation = fs/WAVEFORM_PLOT_FS;
     int nSamples, sample;
     int i, st, en, max, min;
-    short dec_samples[length];
+    short* dec_samples = new short[length];
+    assert(dec_samples != nullptr);
 
     nSamples = length/decimation;
 
@@ -316,6 +324,7 @@ void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs)
         dec_samples[sample+1] = min;
     }
     codec2_fifo_write(plotFifo, dec_samples, nSamples);
+    delete[] dec_samples;
 }
 
 // State machine to detect sync

--- a/src/util/ulog_logger.h
+++ b/src/util/ulog_logger.h
@@ -55,48 +55,48 @@ namespace log {
 template <typename concurrency, typename names>
 class ulog {
 public:
-    ulog<concurrency,names>(channel_type_hint::value h =
+    ulog(channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0) {}
 
-    ulog<concurrency,names>(std::ostream * out)
+    ulog(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0) {}
 
-    ulog<concurrency,names>(level c, channel_type_hint::value h =
+    ulog(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0) {}
 
-    ulog<concurrency,names>(level c, std::ostream * out)
+    ulog(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0) {}
 
     /// Destructor
-    ~ulog<concurrency,names>() {}
+    ~ulog() {}
 
     /// Copy constructor
-    ulog<concurrency,names>(ulog<concurrency,names> const & other)
+    ulog(ulog<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
     {}
     
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy assignment operator because of const member variables
-    ulog<concurrency,names> & operator=(ulog<concurrency,names> const &) = delete;
+    ulog & operator=(ulog<concurrency,names> const &) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    ulog<concurrency,names>(ulog<concurrency,names> && other)
+    ulog(ulog<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
     {}
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no move assignment operator because of const member variables
-    ulog<concurrency,names> & operator=(ulog<concurrency,names> &&) = delete;
+    ulog & operator=(ulog<concurrency,names> &&) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #endif // _WEBSOCKETPP_MOVE_SEMANTICS_


### PR DESCRIPTION
This PR cleans up compiler warnings currently in the v2.0-dev tree. Currently focused on warnings similar to the following:

```
/Users/mooneer/devel/freedv-gui/src/pipeline/RADETransmitStep.cpp:115:31: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  115 |             RADE_COMP radeOut[numOutputSamples];
      |                               ^~~~~~~~~~~~~~~~
/Users/mooneer/devel/freedv-gui/src/pipeline/RADETransmitStep.cpp:115:31: note: read of non-const variable 'numOutputSamples' is not allowed in a constant expression
/Users/mooneer/devel/freedv-gui/src/pipeline/RADETransmitStep.cpp:112:17: note: declared here
  112 |             int numOutputSamples = rade_n_tx_out(dv_);
      |                 ^
```

as these are causing problems on macOS in some cases. Other warning cleanup is WIP.