### PR TITLE
Display message box in Windows installer prior to installing Python.

### DIFF
--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -147,7 +147,7 @@ install(
 # otherwise no packages will be installed.
 set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
     "ExecWait '\\\"\$INSTDIR\\\\bin\\\\vc_redist.x64.exe\\\" /install /passive'
-    MessageBox MB_OK 'FreeDV will now open a Command Propmpt window to finish installing the Python components needed for RADE. Please allow this process to complete without interruption. It may appear as though nothing is happening but rest assured, things are happening :)' /SD IDOK
+    MessageBox MB_OK 'FreeDV will now open a Command Prompt window to finish installing the Python components needed for RADE. Please allow this process to complete without interruption. It may appear as though nothing is happening but rest assured, things are happening.' /SD IDOK
     ExecShellWait '' '\$INSTDIR\\\\bin\\\\rade-setup.bat' ''")
 
 # Make sure we fully clean up after Python on uninstall.

--- a/cmake/BuildRADE.cmake
+++ b/cmake/BuildRADE.cmake
@@ -147,6 +147,7 @@ install(
 # otherwise no packages will be installed.
 set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
     "ExecWait '\\\"\$INSTDIR\\\\bin\\\\vc_redist.x64.exe\\\" /install /passive'
+    MessageBox MB_OK 'FreeDV will now open a Command Propmpt window to finish installing the Python components needed for RADE. Please allow this process to complete without interruption. It may appear as though nothing is happening but rest assured, things are happening :)' /SD IDOK
     ExecShellWait '' '\$INSTDIR\\\\bin\\\\rade-setup.bat' ''")
 
 # Make sure we fully clean up after Python on uninstall.


### PR DESCRIPTION
This PR adds a message box to the Windows installer prior to installing the Python components needed for RADE. This should hopefully cut down on confusion during the install process.