### PR TITLE
Hamlib: improve behavior with Icom rigs, serial port PTT

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -140,7 +140,7 @@ your radio:
 + Hamlib: support for many different radios via the Hamlib library and a serial port (or via TCP/IP for some devices, e.g. SDRs or FLrig/rigctld).
 + Serial Port: direct access to the serial port pins
 
-You may also optionally configure a second serial port for PTT input.
+You may also optionally configure an additional serial port for PTT input.
 This can be useful for interfacing devices like foot switches to 
 FreeDV. If configured, FreeDV will switch into transmit mode (including
 sending the needed Hamlib or serial commands to initiate PTT) when it
@@ -917,6 +917,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add rig control option to prevent auto-adjustment of the radio's current mode. (PR #809)
     * Update default 80 and 160m calling frequencies. (PR #831)
     * Shorten PulseAudio/pipewire app name. (PR #843)
+    * Hamlib: support CAT PTT via the Data port instead of Mic (needed for some older radios). (PR #875)
 3. Build system:
     * Allow overriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.8. (PR #861)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -894,7 +894,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Fix bug preventing saving of the previously used path when playing back files. (PR #729)
     * Fix bug preventing proper time display in FreeDV Reporter on macOS. (PR #748)
-    * Set timeout for Hamlib comms to avoid GUI getting stuck. (PR #746)
+    * Hamlib: Improve behavior with Icom rigs, serial port PTT. (PR #875)
     * Fix various audio dropout issues, especially on Linux. (PR #761)
     * Fix issue preventing non-ASCII text from appearing properly in FreeDV Reporter messages. (PR #812)
     * Don't adjust Msg column width when user disconnects. (PR #828)

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -174,6 +174,7 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
     m_cbPttMethod->Append(wxT("None"));
+    m_cbPttMethod->Append(wxT("CAT via Data port"));
     m_cbPttMethod->SetSelection(0);
 
     /* Serial port box */

--- a/src/gui/dialogs/dlg_ptt.cpp
+++ b/src/gui/dialogs/dlg_ptt.cpp
@@ -142,6 +142,7 @@ ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title,
     m_cbPttMethod->Append(wxT("RTS"));
     m_cbPttMethod->Append(wxT("DTR"));
     m_cbPttMethod->Append(wxT("None"));
+    m_cbPttMethod->Append(wxT("CAT via Data port"));
     
     mainSizer->Add(staticBoxSizer18, 0, wxEXPAND, 5);
 

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -372,6 +372,7 @@ reattempt_connection:
     {
         // On some radios, timeouts don't really work. Reattempt connection without
         // setting them.
+        log_debug("Reattempting connection to radio without timeouts");
         setTimeouts = false;
         rig_cleanup(rig_);
         goto reattempt_connection;
@@ -381,7 +382,7 @@ reattempt_connection:
         std::string errMsg = std::string("Could not connect to radio: ") + rigerror(result);
         onRigError(this, errMsg);
     }
-    log_debug("hamlib: rig_open() failed ...");
+    log_debug("hamlib: rig_open() failed: %s", rigerror(result));
 
     rig_cleanup(rig_);
     rig_ = nullptr;

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -342,6 +342,7 @@ void HamlibRigController::connectImpl_()
             rig_set_conf(rig_, rig_token_lookup(rig_, "ptt_type"), "None");
             break;
         case PTT_VIA_CAT:
+        case PTT_VIA_CAT_DATA:
             rig_set_conf(rig_, rig_token_lookup(rig_, "ptt_type"), "RIG");
             break;
         default:
@@ -429,7 +430,11 @@ void HamlibRigController::pttImpl_(bool state)
     }
 
     ptt_t on = state ? RIG_PTT_ON : RIG_PTT_OFF;
-
+    if (pttType_ == PTT_VIA_CAT_DATA && on != RIG_PTT_OFF)
+    {
+        on = RIG_PTT_ON_DATA;
+    }
+    
     auto oldTime = std::chrono::steady_clock::now();
     int result = RIG_OK;
     if (pttType_ != PTT_VIA_NONE)
@@ -498,7 +503,7 @@ void HamlibRigController::setFrequencyImpl_(uint64_t frequencyHz)
     if (pttSet_)
     {
         // If transmitting, temporarily stop transmitting so we can change the mode.
-        int result = rig_set_ptt(rig_, RIG_VFO_CURR, RIG_PTT_ON);
+        int result = rig_set_ptt(rig_, RIG_VFO_CURR, pttType_ == PTT_VIA_CAT_DATA ? RIG_PTT_ON_DATA : RIG_PTT_ON);
         if (result != RIG_OK) 
         {
             // If we can't stop transmitting, we shouldn't try to change the mode
@@ -571,7 +576,7 @@ void HamlibRigController::setModeImpl_(IRigFrequencyController::Mode mode)
     if (pttSet_)
     {
         // If transmitting, temporarily stop transmitting so we can change the mode.
-        int result = rig_set_ptt(rig_, RIG_VFO_CURR, RIG_PTT_ON);
+        int result = rig_set_ptt(rig_, RIG_VFO_CURR, pttType_ == PTT_VIA_CAT_DATA ? RIG_PTT_ON_DATA : RIG_PTT_ON);
         if (result != RIG_OK) 
         {
             // If we can't stop transmitting, we shouldn't try to change the mode

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -342,6 +342,8 @@ void HamlibRigController::connectImpl_()
             rig_set_conf(rig_, rig_token_lookup(rig_, "ptt_type"), "None");
             break;
         case PTT_VIA_CAT:
+            rig_set_conf(rig_, rig_token_lookup(rig_, "ptt_type"), "RIG");
+            break;
         default:
             break;
     }

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -264,8 +264,6 @@ int HamlibRigController::GetNumberSupportedRadios()
 
 void HamlibRigController::connectImpl_()
 {
-    bool setTimeouts = true;
-
     if (rig_ != nullptr)
     {
         std::string errMsg = "Already connected to radio.";

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -311,7 +311,9 @@ void HamlibRigController::connectImpl_()
 
     rig_set_conf(rig_, rig_token_lookup(rig_, "rig_pathname"), serialPort_.c_str());
 
-    if (pttSerialPort_.size() > 0)
+    if (pttSerialPort_.size() > 0 && 
+        pttSerialPort_ != serialPort_ &&
+        (pttType_ == PTT_VIA_RTS || pttType_ == PTT_VIA_DTR))
     {
         rig_set_conf(rig_, rig_token_lookup(rig_, "ptt_pathname"), pttSerialPort_.c_str());
     }

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -285,7 +285,6 @@ void HamlibRigController::connectImpl_()
     origFreq_ = 0;
     origMode_ = RIG_MODE_NONE;
 
-reattempt_connection:
     rig_ = rig_init(RigList_[rigIndex]->rig_model);
     if (!rig_) 
     {
@@ -341,13 +340,6 @@ reattempt_connection:
         default:
             break;
     }
-    
-    if (setTimeouts)
-    {
-        rig_set_conf(rig_, rig_token_lookup(rig_, "timeout"), "1000");
-        rig_set_conf(rig_, rig_token_lookup(rig_, "retry"), "1");
-        rig_set_conf(rig_, rig_token_lookup(rig_, "timeout_retry"), "1");
-    }
 
     auto result = rig_open(rig_);
     if (result == RIG_OK) 
@@ -367,15 +359,6 @@ reattempt_connection:
         // revert on close.
         requestCurrentFrequencyModeImpl_();
         return;
-    }
-    else if (setTimeouts)
-    {
-        // On some radios, timeouts don't really work. Reattempt connection without
-        // setting them.
-        log_debug("Reattempting connection to radio without timeouts");
-        setTimeouts = false;
-        rig_cleanup(rig_);
-        goto reattempt_connection;
     }
     else
     {

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -45,6 +45,7 @@ public:
         PTT_VIA_RTS,
         PTT_VIA_DTR,
         PTT_VIA_NONE,
+        PTT_VIA_CAT_DATA,
     };
     
     HamlibRigController(std::string rigName, std::string serialPort, const int serialRate, const int civHex = 0, const PttType pttType = PTT_VIA_CAT, std::string pttSerialPort = std::string(), bool restoreFreqModeOnDisconnect = false, bool freqOnly = false);


### PR DESCRIPTION
~On some radios (e.g. Flex 6000/8000 series), attempting to set the timeout in Hamlib causes `rig_open()` to fail. This PR causes FreeDV to reattempt connection without setting timeouts, ensuring that rig control can still be used.~

This PR performs the following:

1. Reverts timeout changes from #745.
2. Adapts various config requests from WSJT-X to (a) improve Icom behavior and (b) improve behavior when using serial port PTT.
3. Adds support in Hamlib for CAT PTT via the Data port (instead of Mic)--needed for some older radios.