### PR TITLE
WASAPI: Adjust shutdown to avoid crash on repeated start/stop.

### DIFF
--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -292,7 +292,6 @@ void WASAPIAudioDevice::start()
         // Start render/capture thread.
         isRenderCaptureRunning_ = true;
         renderCaptureThread_ = std::thread([&]() {
-            SetThreadDescription(GetCurrentThread(), L"WASAPI_RenderCapture");
             log_info("Starting render/capture thread");
 
             HRESULT res = CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);


### PR DESCRIPTION
When repeatedly starting and stopping, FreeDV intermittently crashes. This PR resolves this issue by changing how things shut down in the audio layer.