### PR TITLE
Second attempt at fixing Windows Start/Stop crashes

### DIFF
--- a/cmake/GetDependencies.cmake.in
+++ b/cmake/GetDependencies.cmake.in
@@ -118,6 +118,9 @@ set( _windlls
 
     # Filter Python DLLs as they're already included via install()
     python312.dll
+
+    # Additional DLLs needed by Address Sanitizer
+    api-ms-win-core-synch-l1-2-0.dll
 )
 list(REMOVE_ITEM _deps ${_windlls})
 

--- a/cross-compile/freedv-mingw-llvm-aarch64.cmake
+++ b/cross-compile/freedv-mingw-llvm-aarch64.cmake
@@ -11,9 +11,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
-set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--pdb=")
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/cross-compile/freedv-mingw-llvm-x86_64.cmake
+++ b/cross-compile/freedv-mingw-llvm-x86_64.cmake
@@ -12,9 +12,9 @@ set(CMAKE_AR ${triple}-ar)
 set(CMAKE_RANLIB ${triple}-ranlib)
 set(CMAKE_RC_COMPILER ${triple}-windres)
 
-set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument -gcodeview")
-set(CMAKE_CXX_FLAGS "-Wno-unused-command-line-argument -gcodeview")
-set(CMAKE_EXE_LINKER_FLAGS -Wl,--pdb=)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument -gcodeview")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--pdb=")
 
 # For make package use.
 set(CMAKE_OBJDUMP ${triple}-objdump)

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -290,7 +290,7 @@ void WASAPIAudioDevice::start()
 
         // Start render/capture thread.
         isRenderCaptureRunning_ = true;
-        renderCaptureThread_ = std::thread([&]() {
+        renderCaptureThread_ = std::thread([this]() {
             log_info("Starting render/capture thread");
 
             HRESULT res = CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -382,6 +382,12 @@ void WASAPIAudioDevice::stop()
             }
         }
 
+        if (renderCaptureEvent_ != nullptr)
+        {
+            CloseHandle(renderCaptureEvent_);
+            renderCaptureEvent_ = nullptr;
+        }
+        
         if (renderClient_ != nullptr)
         {
             renderClient_->Release();

--- a/src/audio/WASAPIAudioDevice.h
+++ b/src/audio/WASAPIAudioDevice.h
@@ -79,7 +79,6 @@ private:
     int numChannels_;
     UINT32 bufferFrameCount_;
     bool initialized_;
-    HANDLE lowLatencyTask_;
     int latencyFrames_;
     std::thread renderCaptureThread_;
     HANDLE renderCaptureEvent_;
@@ -89,7 +88,7 @@ private:
     void renderAudio_();
     void captureAudio_();
     
-    static thread_local HANDLE helperTask_;
+    static thread_local HANDLE HelperTask_;
 };
 
 #endif // WASAPI_AUDIO_DEVICE_H

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -218,6 +218,7 @@ AudioDeviceSpecification WASAPIAudioEngine::getDefaultAudioDevice(AudioDirection
             if (defaultSpec.name == spec.name)
             {
                 prom->set_value(spec);
+                defaultDevice->Release();
                 return;
             }
         }
@@ -398,7 +399,7 @@ AudioDeviceSpecification WASAPIAudioEngine::getDeviceSpecification_(IMMDevice* d
         return AudioDeviceSpecification::GetInvalidDevice();
     }
 
-    WAVEFORMATEX* streamFormat;
+    WAVEFORMATEX* streamFormat = nullptr;
     hr = audioClient->GetMixFormat(&streamFormat);
     if (FAILED(hr))
     {

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -303,6 +303,9 @@ std::shared_ptr<IAudioDevice> WASAPIAudioEngine::getAudioDevice(wxString deviceN
 
                 auto devPtr = new WASAPIAudioDevice(client, direction, sampleRate, numChannels);
                 result = std::shared_ptr<IAudioDevice>(devPtr);
+                
+                client->Release();
+                device->Release();
             }
         }
         prom->set_value(result);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2855,6 +2855,9 @@ void MainFrame::stopRxStream()
 
         if (m_txThread)
         {
+            m_txThread->terminateThread();
+            m_txThread->Wait();
+            
             if (txInSoundDevice)
             {
                 txInSoundDevice->stop();
@@ -2867,15 +2870,15 @@ void MainFrame::stopRxStream()
                 txOutSoundDevice.reset();
             }
             
-            m_txThread->terminateThread();
-            m_txThread->Wait();
-            
             delete m_txThread;
             m_txThread = nullptr;
         }
 
         if (m_rxThread)
         {
+            m_rxThread->terminateThread();
+            m_rxThread->Wait();
+            
             if (rxInSoundDevice)
             {
                 rxInSoundDevice->stop();
@@ -2887,9 +2890,6 @@ void MainFrame::stopRxStream()
                 rxOutSoundDevice->stop();
                 rxOutSoundDevice.reset();
             }
-            
-            m_rxThread->terminateThread();
-            m_rxThread->Wait();
             
             delete m_txThread;
             m_rxThread = nullptr;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -515,7 +515,8 @@ void* TxRxThread::Entry()
 
 void TxRxThread::OnExit() 
 { 
-    // No actions required for exit.
+    // Free allocated buffer.
+    inputSamples_ = nullptr; 
 }
 
 void TxRxThread::terminateThread()

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -58,6 +58,12 @@ public:
             new short[std::max(inputSampleRate_, outputSampleRate_)], 
             std::default_delete<short[]>());
     }
+    
+    virtual ~TxRxThread()
+    {
+        // Free allocated buffer
+        inputSamples_ = nullptr;
+    }
 
     // thread execution starts here
     void *Entry();


### PR DESCRIPTION
Fixes COM object ref counting as well as changes shutdown ordering for remaining `TxRxThread` crashes reported by AddressSanitizer.