### PR TITLE
Show /dev/tty.* devices on macOS.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -918,6 +918,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update default 80 and 160m calling frequencies. (PR #831)
     * Shorten PulseAudio/pipewire app name. (PR #843)
     * Hamlib: support CAT PTT via the Data port instead of Mic (needed for some older radios). (PR #875)
+    * macOS: Show /dev/tty.* devices in CAT/PTT options. (PR #883)
 3. Build system:
     * Allow overriding the version tag when building. (PR #727)
     * Update wxWidgets to 3.2.8. (PR #861)

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -1038,11 +1038,12 @@ void EasySetupDialog::updateHamlibDevices_()
 
 #if defined(__FreeBSD__) || defined(__WXOSX__)
     glob_t    gl;
-#ifdef __FreeBSD__
-    if(glob("/dev/tty*", GLOB_MARK, NULL, &gl)==0) {
+#if defined(__FreeBSD__)
+    if(glob("/dev/tty*", GLOB_MARK, NULL, &gl)==0 ||
 #else
-    if(glob("/dev/cu.*", GLOB_MARK, NULL, &gl)==0) {
-#endif
+    if(glob("/dev/tty.*", GLOB_MARK, NULL, &gl)==0 ||
+#endif // defined(__FreeBSD__)
+       glob("/dev/cu.*", GLOB_MARK, NULL, &gl)==0) {
         for(unsigned int i=0; i<gl.gl_pathc; i++) {
             if(gl.gl_pathv[i][strlen(gl.gl_pathv[i])-1]=='/')
                 continue;

--- a/src/gui/dialogs/dlg_ptt.cpp
+++ b/src/gui/dialogs/dlg_ptt.cpp
@@ -395,11 +395,12 @@ void ComPortsDlg::populatePortList()
 
 #if defined(__FreeBSD__) || defined(__WXOSX__)
     glob_t    gl;
-#ifdef __FreeBSD__
-    if(glob("/dev/tty*", GLOB_MARK, NULL, &gl)==0) {
+#if defined(__FreeBSD__)
+    if(glob("/dev/tty*", GLOB_MARK, NULL, &gl)==0 ||
 #else
-    if(glob("/dev/cu.*", GLOB_MARK, NULL, &gl)==0) {
-#endif
+    if(glob("/dev/tty.*", GLOB_MARK, NULL, &gl)==0 ||
+#endif // defined(__FreeBSD__)
+       glob("/dev/cu.*", GLOB_MARK, NULL, &gl)==0) {
         for(unsigned int i=0; i<gl.gl_pathc; i++) {
             if(gl.gl_pathv[i][strlen(gl.gl_pathv[i])-1]=='/')
                 continue;


### PR DESCRIPTION
Originally /dev/tty.* was filtered out on macOS since this version was typically not openable by FreeDV (whereas the /dev/cu.* version was). However, it was discovered that some radios do not provide a /dev/cu.* equivalent, so this PR allows /dev/tty.* devices to appear for CAT/PTT setup.