### PR TITLE
Harmonize resizing hacks across codebase.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -772,7 +772,7 @@ void MainFrame::loadConfiguration_()
     });
     CallAfter([=]()
     {
-        SetSize(w, h - 1);
+        SetSize(w + 1, h + 1);
     });
     CallAfter([=]()
     {
@@ -2062,7 +2062,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             });
             CallAfter([=]()
             {
-                SetSize(w, h - 1);
+                SetSize(w + 1, h + 1);
             });
             CallAfter([=]()
             {


### PR DESCRIPTION
This PR applies the same exact display hack across all parts of the codebase that use it. Previously, some versions subtracted 1 from the y axis while others added 1 to both x and y (for example).