### PR TITLE
Base RX highlighting on user time, not server time.

### DIFF
--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -2175,7 +2175,7 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onReceiveUpdateFn_(std::stri
             else
             {
                 iter->second->snr = snrString;
-                iter->second->lastRxDate = iter->second->lastUpdateDate;
+                iter->second->lastRxDate = wxDateTime::Now();
             }
        
             if (iter->second->isVisible)


### PR DESCRIPTION
This PR updates the RX event handler in the FreeDV Reporter window to use the user's current time instead of the server-reported time. This is to better handle cases where the user's time is significantly off, since in the previous implementation RX highlight time could be significantly less than expected (or simply not appear at all) unless the user's time exactly matches the server's. 