### PR TITLE
Additional cleanup of RT-unsafe logic.

### DIFF
--- a/src/gui/dialogs/dlg_audiooptions.cpp
+++ b/src/gui/dialogs/dlg_audiooptions.cpp
@@ -898,8 +898,11 @@ void AudioOptsDialog::plotDeviceInputForAFewSecs(wxString devName, PlotScalar *p
                         }
                     
                         int n8k = resample(src, in8k_short, in48k_short, 8000, sampleRate, TEST_BUF_SIZE, TEST_BUF_SIZE);
-                        resample_for_plot(fifo, in8k_short, n8k, FS);
-    
+                        short* tmp = new short[n8k];
+                        assert(tmp != nullptr);
+                        resample_for_plot(fifo, in8k_short, tmp, n8k, FS);
+                        delete[] tmp;
+ 
                         short plotSamples[TEST_WAVEFORM_PLOT_BUF];
                         if (codec2_fifo_read(fifo, plotSamples, TEST_WAVEFORM_PLOT_BUF))
                         {
@@ -1033,8 +1036,11 @@ void AudioOptsDialog::plotDeviceOutputForAFewSecs(wxString devName, PlotScalar *
                         }
                     
                         int n8k = resample(src, out8k_short, out48k_short, 8000, sampleRate, TEST_BUF_SIZE, TEST_BUF_SIZE);
-                        resample_for_plot(fifo, out8k_short, n8k, FS);
-    
+                        short* tmp = new short[n8k];
+                        assert(tmp != nullptr);
+                        resample_for_plot(fifo, out8k_short, tmp, n8k, FS);
+                        delete[] tmp;
+ 
                         short plotSamples[TEST_WAVEFORM_PLOT_BUF];
                         if (codec2_fifo_read(fifo, plotSamples, TEST_WAVEFORM_PLOT_BUF))
                         {

--- a/src/main.h
+++ b/src/main.h
@@ -520,7 +520,7 @@ class MainFrame : public TopFrame
         void onRadioDisconnected_(IRigController* ptr);
 };
 
-void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);
+void resample_for_plot(struct FIFO *plotFifo, short buf[], short* dec_samples, int length, int fs);
 
 int resample(SRC_STATE *src,
              short      output_short[],

--- a/src/pipeline/AudioPipeline.cpp
+++ b/src/pipeline/AudioPipeline.cpp
@@ -86,6 +86,7 @@ void AudioPipeline::appendPipelineStep(std::shared_ptr<IPipelineStep> pipelineSt
     pipelineSteps_.push_back(pipelineStep);
     resamplers_.resize(pipelineSteps_.size(), nullptr); // will be updated by reloadResampler_() below.
     reloadResampler_(pipelineSteps_.size() - 1);
+    reloadResultResampler_();
 }
 
 void AudioPipeline::reloadResampler_(int index)

--- a/src/pipeline/ComputeRfSpectrumStep.cpp
+++ b/src/pipeline/ComputeRfSpectrumStep.cpp
@@ -72,5 +72,5 @@ std::shared_ptr<short> ComputeRfSpectrumStep::execute(std::shared_ptr<short> inp
     // Tap only, no output.
     *numOutputSamples = 0;
 
-    return std::shared_ptr<short>((short*)nullptr, std::default_delete<short[]>());
+    return std::shared_ptr<short>(nullptr);
 }

--- a/src/pipeline/ParallelStep.h
+++ b/src/pipeline/ParallelStep.h
@@ -60,7 +60,7 @@ public:
     virtual int getOutputSampleRate() const;
     virtual std::shared_ptr<short> execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples);
     
-    const std::vector<std::shared_ptr<IPipelineStep>> getParallelSteps() const { return parallelSteps_; }
+    const std::vector<std::shared_ptr<IPipelineStep>>& getParallelSteps() const { return parallelSteps_; }
     
     std::shared_ptr<void> getState() { return state_; }
     

--- a/src/pipeline/ResamplePlotStep.cpp
+++ b/src/pipeline/ResamplePlotStep.cpp
@@ -24,17 +24,18 @@
 #include "ResamplePlotStep.h"
 
 // TBD - maybe include code for function here?
-extern void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs);
+extern void resample_for_plot(struct FIFO *plotFifo, short buf[], short* dec_samples, int length, int fs);
 
 ResampleForPlotStep::ResampleForPlotStep(struct FIFO* fifo)
     : fifo_(fifo)
 {
-    // empty
+    decSamples_ = new short[FS];
+    assert(decSamples_ != nullptr);
 }
 
 ResampleForPlotStep::~ResampleForPlotStep()
 {
-    // empty
+    delete[] decSamples_;
 }
 
 int ResampleForPlotStep::getInputSampleRate() const
@@ -49,8 +50,8 @@ int ResampleForPlotStep::getOutputSampleRate() const
 
 std::shared_ptr<short> ResampleForPlotStep::execute(std::shared_ptr<short> inputSamples, int numInputSamples, int* numOutputSamples)
 {
-    resample_for_plot(fifo_, inputSamples.get(), numInputSamples, FS);
+    resample_for_plot(fifo_, inputSamples.get(), decSamples_, numInputSamples, FS);
     
     *numOutputSamples = 0;    
-    return std::shared_ptr<short>((short*)nullptr, std::default_delete<short[]>());
+    return std::shared_ptr<short>(nullptr);
 }

--- a/src/pipeline/ResamplePlotStep.h
+++ b/src/pipeline/ResamplePlotStep.h
@@ -41,6 +41,7 @@ public:
     
 private:
     struct FIFO* fifo_;
+    short* decSamples_;
 };
 
 #endif // AUDIO_PIPELINE__RESAMPLE_PLOT_STEP_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -300,13 +300,11 @@ int resample(SRC_STATE *src,
 // we don't hammer the graphics system too hard.  Saves decimated data
 // to a fifo for plotting on screen.
 
-void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs)
+void resample_for_plot(struct FIFO *plotFifo, short buf[], short* dec_samples, int length, int fs)
 {
     int decimation = fs/WAVEFORM_PLOT_FS;
     int nSamples, sample;
     int i, st, en, max, min;
-    short* dec_samples = new short[length];
-    assert(dec_samples != nullptr);
 
     nSamples = length/decimation;
     if (nSamples % 2) nSamples++; // dec_samples is populated in groups of two
@@ -325,7 +323,6 @@ void resample_for_plot(struct FIFO *plotFifo, short buf[], int length, int fs)
         dec_samples[sample+1] = min;
     }
     codec2_fifo_write(plotFifo, dec_samples, nSamples);
-    delete[] dec_samples;
 }
 
 // State machine to detect sync


### PR DESCRIPTION
Fedora 42 has Clang 20 available, which contains something cool called [RTSan](https://github.com/realtime-sanitizer/rtsan?tab=readme-ov-file). Running it on the FreeDV codebase allowed me to find several instances where real-time unsafe constructs were implicitly used. This PR contains all the fixes that we're able to implement in freedv-gui itself (Codec2 and librade can't currently be made fully real-time safe due to extensive use of `malloc()`).