### PR TITLE
Fix issue preventing filter from properly changing in the FreeDV Reporter window.

### DIFF
--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -1141,14 +1141,10 @@ void FreeDVReporterDialog::setBandFilter(FilterFrequency freq)
 
 void FreeDVReporterDialog::FreeDVReporterDataModel::setBandFilter(FilterFrequency freq)
 {
-    if (filteredFrequency_ != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency ||
-        currentBandFilter_ != freq)
-    {
-        filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
-        currentBandFilter_ = freq;
+    filteredFrequency_ = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
+    currentBandFilter_ = freq;
 
-        refreshAllRows();
-    }
+    refreshAllRows();
 }
 
 wxString FreeDVReporterDialog::FreeDVReporterDataModel::makeValidTime_(std::string timeStr, wxDateTime& timeObj)


### PR DESCRIPTION
Fixes #895 by forcing a refresh regardless of the previous state of the band/frequency filter.