### PR TITLE
Remove pre-PTT interrogation of frequency/mode.

### DIFF
--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1003,13 +1003,6 @@ void MainFrame::togglePTT(void) {
         m_togBtnOnOff->Enable(false);
     }
 
-    if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT) {
-        if (wxGetApp().rigFrequencyController != nullptr && wxGetApp().rigFrequencyController->isConnected()) {
-            // Update mode display on the bottom of the main UI.
-            wxGetApp().rigFrequencyController->requestCurrentFrequencyMode();
-        }
-    }
-
     auto newTx = m_btnTogPTT->GetValue();
     if (wxGetApp().rigPttController != nullptr && wxGetApp().rigPttController->isConnected()) 
     {


### PR DESCRIPTION
This contains a narrower scope of changes from #893 that are safe for 2.0.0 (namely no longer interrogating the radio for mode/frequency prior to toggling PTT).