### PR TITLE
Fix compiler errors reported by other users

### DIFF
--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -539,7 +539,7 @@ void FreeDVReporterDialog::setReporter(std::shared_ptr<FreeDVReporter> reporter)
     {
         // Update status message
         auto statusMsg = m_statusMessage->GetValue();
-        reporter->updateMessage(statusMsg.utf8_string());
+        reporter->updateMessage((const char*)statusMsg.utf8_str());
     }
 }
 
@@ -649,7 +649,7 @@ void FreeDVReporterDialog::OnSendQSY(wxCommandEvent& event)
 
 void FreeDVReporterDialog::OnOpenWebsite(wxCommandEvent& event)
 {
-    std::string url = "https://" + wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->utf8_string() + "/";
+    std::string url = std::string("https://") + (const char*)wxGetApp().appConfiguration.reportingConfiguration.freedvReporterHostname->utf8_str() + "/";
     wxLaunchDefaultBrowser(url);
     DeselectItem();
 }

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -161,7 +161,7 @@ class FreeDVReporterDialog : public wxFrame
              {
                  if (reporter_)
                  {
-                     reporter_->updateMessage(statusMsg.utf8_string());
+                     reporter_->updateMessage((const char*)statusMsg.utf8_str());
                  }
              }
 

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -37,7 +37,11 @@ HamlibRigController::RigList HamlibRigController::RigList_;
 HamlibRigController::RigNameList HamlibRigController::RigNameList_;
 std::mutex HamlibRigController::RigListMutex_;
 
+#if RIGCAPS_NOT_CONST
+int HamlibRigController::BuildRigList_(struct rig_caps *rig, rig_ptr_t rigList) {
+#else
 int HamlibRigController::BuildRigList_(const struct rig_caps *rig, rig_ptr_t rigList) {    
+#endif // RIGCAPS_NOT_CONST
     ((HamlibRigController::RigList *)rigList)->push_back(rig); 
     return 1;
 }

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -107,7 +107,11 @@ private:
 
     static bool RigCompare_(const struct rig_caps *rig1, const struct rig_caps *rig2);
 
+#if RIGCAPS_NOT_CONST    
+    static int BuildRigList_(struct rig_caps *rig, rig_ptr_t);
+#else
     static int BuildRigList_(const struct rig_caps *rig, rig_ptr_t);
+#endif // RIGCAPS_NOT_CONST
 };
 
 #endif // HAMLIB_RIG_CONTROLLER_H


### PR DESCRIPTION
This PR fixes the following compiler errors reported by other users:

1. Some distros are still using Hamlib 4.5.x, so the `RIGCAPS_NOT_CONST` check was brought back.
2. Some distros are still on wxWidgets 3.0.x, so we need to use `utf8_str` instead of `utf8_string` in FreeDV Reporter code.

