### PR TITLE
Fix typo causing RX radio device to remain open.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -798,6 +798,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Force explicit background color (avoids unwanted mouseover highlights on Linux). (PR #911)
     * Fix compiler errors when using wxWidgets 3.0. (PR #914)
     * Unit tests: Increase sleep time before killing recording to resolve macOS test failures. (PR #917)
+    * Fix typo causing RX radio device to remain open. (PR #918)
 
 ## V2.0.0 June 2025
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2500,7 +2500,7 @@ void MainFrame::stopRxStream()
                 rxOutSoundDevice.reset();
             }
             
-            delete m_txThread;
+            delete m_rxThread;
             m_rxThread = nullptr;
         }
 


### PR DESCRIPTION
When a user pushes Stop, logic in the code is supposed to close all audio devices and threads. Due to a typo, the RX thread never gets deleted after being stopped, causing it to hold onto a reference to the RX input device (thus causing the RX input device never to be freed). This PR fixes this typo, allowing the RX audio device to be deleted.

(This was found during testing with Virtual Audio Cable on Windows; the setup program for VAC was still showing that the virtual audio cable was in use even after pushing the Stop button. However, this could presumably be happening on other platforms as well as the typo is in code that's platform-independent.)