### PR TITLE
Add missing dependency for macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ $ sudo port install automake git libtool sox +universal cmake
 and on Homebrew:
 
 ```
-$ brew install automake libtool git sox cmake
+$ brew install automake libtool git sox cmake wget
 ```
 
 Once the dependencies are installed, you can then run the `build_osx.sh` script inside the source tree to build

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ one to build FreeDV for ARM as well as for Intel Windows systems.
 Using MacPorts, most of the appropriate dependencies can be installed by:
 
 ```
-$ sudo port install automake git libtool sox +universal cmake
+$ sudo port install automake git libtool sox +universal cmake wget
 ```
 
 and on Homebrew:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -800,6 +800,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Unit tests: Increase sleep time before killing recording to resolve macOS test failures. (PR #917)
     * Fix typo causing RX radio device to remain open. (PR #918)
     * Fix WASAPI errors on some machines by supporting audio mix formats other than 16-bit integer. (PR #919)
+2. Documentation:
+    * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
 
 ## V2.0.0 June 2025
 


### PR DESCRIPTION
Super tiny README fix. The build tooling depends on `wget` to build on macOS and it's not part of the base distro from Apple.