### PR TITLE
Fix GTK+ assertion after FreeDV Reporter has been open for a long time.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -802,6 +802,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix WASAPI errors on some machines by supporting audio mix formats other than 16-bit integer. (PR #919)
     * Reduce CPU usage of FreeDV Reporter window by only re-sorting if we actually get new data from the server. (PR #915)
     * FreeDV Reporter: Fix issue with first column not being aligned properly with other columns. (PR #922)
+    * Fix GTK+ assertion after FreeDV Reporter has been open for a long time. (PR #929)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)


### PR DESCRIPTION
After the FreeDV Reporter window has been open for at least a few hours, the following GTK+ assertion appears in the terminal window:

```
(freedv:1307905): Gtk-CRITICAL **: 21:52:53.357: ../gtk/gtktreeview.c:6712 (validate_visible_area): assertion `has_next' failed.
There is a disparity between the internal view of the GtkTreeView,
and the GtkTreeModel. This generally means that the model has changed
without letting the view know. Any display from now on is likely to
be incorrect.

(freedv:1307905): Gtk-CRITICAL **: 21:52:53.600: _gtk_rbtree_reorder: assertion 'tree->root->count == length' failed
```

This does not seem to be producing any other problems, but out of an abundance of caution this PR was created to resolve this warning. One theory is that the `CallAfter()` calls that the FreeDV Reporter window are doing are somehow occurring out of order vs. internal events thrown by the `wxDataViewCtrl` control, so this PR basically ensures that all queued events are processed every time server messages trigger `CallAfter()`.

(Originally reported [here](https://github.com/drowe67/freedv-gui/issues/920#issuecomment-2960576297).)