### PR TITLE
Update Hamlib to 4.6.3 (macOS/Windows).

### DIFF
--- a/build_osx.sh
+++ b/build_osx.sh
@@ -42,7 +42,7 @@ if [ $BUILD_DEPS == 1 ]; then
     if [ ! -d hamlib-code ]; then
         git clone https://github.com/Hamlib/Hamlib.git hamlib-code
     fi
-    cd hamlib-code && git checkout 4.6.2 && git pull
+    cd hamlib-code && git checkout 4.6.3 && git pull
     ./bootstrap
     if [ $UNIV_BUILD == 1 ]; then
         CFLAGS="-g -O2 -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" CXXFLAGS="-g -O2 -mmacosx-version-min=10.9 -arch x86_64 -arch arm64" ./configure --enable-shared --prefix $HAMLIBDIR

--- a/cmake/BuildHamlib.cmake
+++ b/cmake/BuildHamlib.cmake
@@ -16,7 +16,7 @@ endif(MINGW AND CMAKE_CROSSCOMPILING)
 
 include(ExternalProject)
 ExternalProject_Add(build_hamlib
-    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.6.2.zip
+    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.6.3.zip
     BUILD_IN_SOURCE 1
     INSTALL_DIR external/dist
     PATCH_COMMAND ${HAMLIB_PATCH_CMD}

--- a/src/audio/AudioDeviceSpecification.h
+++ b/src/audio/AudioDeviceSpecification.h
@@ -29,8 +29,10 @@
 struct AudioDeviceSpecification
 {
     int deviceId;
-    wxString name;
-    wxString apiName;
+    wxString name;     // Display/config name of device
+    wxString cardName; // Name of the audio device
+    wxString portName; // Name of the port from the above audio device (e.g. "Speakers" on Windows). Optional
+    wxString apiName;  // Name of the active audio API
     int defaultSampleRate;
     int maxChannels;
     int minChannels;


### PR DESCRIPTION
As the PR says. Not sure if this version is available in any Linux distros yet but we can at least include it in Windows and macOS builds.