### PR TITLE
Easy Setup: Use card names instead of device names for generating device list

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -804,6 +804,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Fix issue with first column not being aligned properly with other columns. (PR #922)
     * FreeDV Reporter: Work around Linux bug preventing some flag emojis from being fully deleted on backspace. (PR #931)
     * Fix GTK+ assertion after FreeDV Reporter has been open for a long time. (PR #929)
+    * Easy Setup: Use card names instead of device names for generating device list. (PR #932)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/audio/AudioDeviceSpecification.h
+++ b/src/audio/AudioDeviceSpecification.h
@@ -29,9 +29,10 @@
 struct AudioDeviceSpecification
 {
     int deviceId;
-    wxString name;
-    wxString apiName;
-    int defaultSampleRate;
+    wxString name;     // Display/config name of device
+    wxString cardName; // Name of the audio device
+    wxString portName; // Name of the port from the above audio device (e.g. "Speakers" on Windows). Optional.
+    wxString apiName;  // Name of the active audio API
     int maxChannels;
     int minChannels;
     

--- a/src/audio/AudioDeviceSpecification.h
+++ b/src/audio/AudioDeviceSpecification.h
@@ -31,6 +31,7 @@ struct AudioDeviceSpecification
     int deviceId;
     wxString name;     // Display/config name of device
     wxString cardName; // Name of the audio device
+    int cardIndex;     // TBD - internal data for PulseAudio to look up cardName
     wxString portName; // Name of the port from the above audio device (e.g. "Speakers" on Windows). Optional.
     wxString apiName;  // Name of the active audio API
     int defaultSampleRate;

--- a/src/audio/AudioDeviceSpecification.h
+++ b/src/audio/AudioDeviceSpecification.h
@@ -33,6 +33,7 @@ struct AudioDeviceSpecification
     wxString cardName; // Name of the audio device
     wxString portName; // Name of the port from the above audio device (e.g. "Speakers" on Windows). Optional.
     wxString apiName;  // Name of the active audio API
+    int defaultSampleRate;
     int maxChannels;
     int minChannels;
     

--- a/src/audio/MacAudioEngine.cpp
+++ b/src/audio/MacAudioEngine.cpp
@@ -363,6 +363,7 @@ AudioDeviceSpecification MacAudioEngine::getAudioSpecification_(int coreAudioId,
     AudioDeviceSpecification device;
     device.deviceId = coreAudioId;
     device.name = wxString::FromUTF8(deviceName);
+    device.cardName = device.name;
     device.apiName = "Core Audio";
     device.maxChannels = numChannels;
     device.minChannels = 1;

--- a/src/audio/PortAudioEngine.cpp
+++ b/src/audio/PortAudioEngine.cpp
@@ -135,6 +135,7 @@ std::vector<AudioDeviceSpecification> PortAudioEngine::getAudioDeviceList(AudioD
             AudioDeviceSpecification device;
             device.deviceId = index;
             device.name = wxString::FromUTF8(deviceInfo->name);
+            device.cardName = device.name;
             device.apiName = hostApiName;
 
             // For "whitelisted" devices, also assume channel counts

--- a/src/audio/PulseAudioEngine.cpp
+++ b/src/audio/PulseAudioEngine.cpp
@@ -24,6 +24,7 @@
 #include "PulseAudioEngine.h"
 
 #include <map>
+#include "../util/logging/ulog.h"
 
 PulseAudioEngine::PulseAudioEngine()
     : initialized_(false)
@@ -168,6 +169,7 @@ std::vector<AudioDeviceSpecification> PulseAudioEngine::getAudioDeviceList(Audio
             AudioDeviceSpecification device;
             device.deviceId = i->index;
             device.name = wxString::FromUTF8(i->name);
+            device.cardIndex = i->card;
             device.apiName = "PulseAudio";
             device.maxChannels = i->sample_spec.channels;
             device.minChannels = 1; // TBD: can minimum be >1 on PulseAudio or pipewire?
@@ -191,6 +193,7 @@ std::vector<AudioDeviceSpecification> PulseAudioEngine::getAudioDeviceList(Audio
             AudioDeviceSpecification device;
             device.deviceId = i->index;
             device.name = wxString::FromUTF8(i->name);
+            device.cardIndex = i->card;
             device.apiName = "PulseAudio";
             device.maxChannels = i->sample_spec.channels;
             device.minChannels = 1; // TBD: can minimum be >1 on PulseAudio or pipewire?
@@ -231,15 +234,14 @@ std::vector<AudioDeviceSpecification> PulseAudioEngine::getAudioDeviceList(Audio
     }
 
     pa_operation_unref(op);
-    
     pa_threaded_mainloop_unlock(mainloop_);
-    
+
     // Iterate over result and populate cardName
     for (auto& obj : tempObj.result)
     {
-        if (tempObj.cardResult.find(obj.deviceId) != tempObj.cardResult.end())
+        if (tempObj.cardResult.find(obj.cardIndex) != tempObj.cardResult.end())
         {
-            obj.cardName = wxString::FromUTF8(tempObj.cardResult[obj.deviceId].c_str());
+            obj.cardName = wxString::FromUTF8(tempObj.cardResult[obj.cardIndex].c_str());
         }
     }
     

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -1151,14 +1151,14 @@ void EasySetupDialog::updateAudioDevices_()
     
     for (auto& dev : inputDevices)
     {
-        if (dev.name.Find(_("Microsoft Sound Mapper")) != -1 ||
-            dev.name.Find(_(" [Loopback]")) != -1)
+        if (dev.cardName.Find(_("Microsoft Sound Mapper")) != -1 ||
+            dev.cardName.Find(_(" [Loopback]")) != -1)
         {
             // Sound mapper and loopback devices should be skipped.
             continue;
         }
 
-        wxString cleanedDeviceName = dev.name;
+        wxString cleanedDeviceName = dev.cardName;
         
         SoundDeviceData* soundData = new SoundDeviceData();
         assert(soundData != nullptr);
@@ -1187,13 +1187,15 @@ void EasySetupDialog::updateAudioDevices_()
 
     for (auto& dev : outputDevices)
     {
-        if (dev.name.Find(_("Microsoft Sound Mapper")) != -1 ||
-            dev.name.Find(_(" [Loopback]")) != -1)
+        if (dev.cardName.Find(_("Microsoft Sound Mapper")) != -1 ||
+            dev.cardName.Find(_(" [Loopback]")) != -1)
         {
             // Sound mapper and loopback devices should be skipped.
             continue;
         }
 
+        wxString cleanedDeviceName = dev.cardName;
+#if 0
         // For Windows, some devices have a designator at the beginning
         // (e.g. "Microphone (USB Audio CODEC)" and "Speakers (USB Audio CODEC)".
         // We need to be able to strip the designator without affecting
@@ -1202,8 +1204,7 @@ void EasySetupDialog::updateAudioDevices_()
         // device in the current list with the same suffix. If we do find
         // such a device, then we use this suffix as the device name to show
         // in the list instead.
-        wxString cleanedDeviceName = dev.name;
-        if (finalRadioDeviceList.find(dev.name) == finalRadioDeviceList.end())
+        if (finalRadioDeviceList.find(dev.cardName) == finalRadioDeviceList.end())
         {
             SoundDeviceData* foundItem = nullptr;
             wxString oldDeviceName;
@@ -1255,6 +1256,7 @@ void EasySetupDialog::updateAudioDevices_()
                 finalRadioDeviceList[cleanedDeviceName] = foundItem;
             }
         }
+#endif // 0
 
         SoundDeviceData* soundData = finalRadioDeviceList[cleanedDeviceName];
         if (soundData == nullptr)

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -1195,68 +1195,6 @@ void EasySetupDialog::updateAudioDevices_()
         }
 
         wxString cleanedDeviceName = dev.cardName;
-#if 0
-        // For Windows, some devices have a designator at the beginning
-        // (e.g. "Microphone (USB Audio CODEC)" and "Speakers (USB Audio CODEC)".
-        // We need to be able to strip the designator without affecting
-        // the actual name of the device. To do this, we remove a character
-        // at a time from the beginning of the device name until we find a
-        // device in the current list with the same suffix. If we do find
-        // such a device, then we use this suffix as the device name to show
-        // in the list instead.
-        if (finalRadioDeviceList.find(dev.cardName) == finalRadioDeviceList.end())
-        {
-            SoundDeviceData* foundItem = nullptr;
-            wxString oldDeviceName;
-            do
-            {
-                for (auto& kvp : finalRadioDeviceList)
-                {
-                    if (kvp.first.Find("DAX") == 0)
-                    {
-                        // FlexRadio devices are treated differently
-                        // so we shouldn't consider them here.
-                        continue;
-                    }
-
-                    auto suffix = kvp.first.Mid(kvp.first.size() - cleanedDeviceName.size());
-                    if (suffix == cleanedDeviceName)
-                    {
-                        foundItem = kvp.second;
-                        oldDeviceName = kvp.first;
-                        break;
-                    }
-                }
-                if (foundItem == nullptr)
-                {
-                    cleanedDeviceName = cleanedDeviceName.Mid(1);
-                }
-            } while (cleanedDeviceName.Length() > 5 && foundItem == nullptr);
-
-            if (foundItem == nullptr)
-            {
-                cleanedDeviceName = dev.name;
-            }
-            else
-            {
-                // Rename device in device list to "cleaned up" name.
-                cleanedDeviceName.Trim(false);
-                cleanedDeviceName.Trim(true);
-                auto parenthesisLoc = cleanedDeviceName.Find(_("("));
-                if (parenthesisLoc >= 0)
-                {
-                    cleanedDeviceName = cleanedDeviceName.Mid(parenthesisLoc + 1);
-                    if (cleanedDeviceName.Right(1) == _(")"))
-                    {
-                        cleanedDeviceName.RemoveLast(1);
-                    }
-                }
-
-                finalRadioDeviceList.erase(oldDeviceName);
-                finalRadioDeviceList[cleanedDeviceName] = foundItem;
-            }
-        }
-#endif // 0
 
         SoundDeviceData* soundData = finalRadioDeviceList[cleanedDeviceName];
         if (soundData == nullptr)


### PR DESCRIPTION
Resolves #912 by enhancing the audio interface to provide card names separately from device names. This simplifies the Easy Setup window's logic for generating the audio device list and improves its accuracy.