### PR TITLE
Fix compiler error on Fedora 42 when using Hamlib packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,27 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     message(STATUS "Hamlib library found.")
     include_directories(${HAMLIB_INCLUDE_DIR})
     list(APPEND FREEDV_LINK_LIBS ${HAMLIB_LIBRARY})
+
+    # Special-case to determine whether the user is using Hamlib >=4.6.
+    # In 4.6, RIGCAPS_NO_CONST is no longer defined and causes compiler 
+    # errors during build without special logic to handle this. This may
+    # also be true in 4.7 as the test script below prints 4.7~git on Fedora
+    # 42 as of 2025-06-15.
+    if (NOT CMAKE_CROSSCOMPILING)
+        try_run(HAMLIB_RUN_RESULT HAMLIB_COMPILE_RESULT
+            SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c
+            CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${HAMLIB_INCLUDE_DIR}
+            LINK_LIBRARIES ${HAMLIB_LIBRARY}
+            RUN_OUTPUT_VARIABLE HAMLIB_VERSION)
+        if (NOT HAMLIB_COMPILE_RESULT OR NOT HAMLIB_RUN_RESULT OR NOT HAMLIB_VERSION)
+            message(FATAL_ERROR "Could not determine Hamlib version.")
+        else()
+            if (NOT HAMLIB_VERSION STRLESS "Hamlib 4.6")
+                message(STATUS "Enabling Hamlib 4.6 compile workaround.")
+                add_definitions(-DHAMLIB_CONST_WORKAROUND)
+            endif (HAMLIB_VERSION STRLESS "Hamlib 4.6")
+        endif (NOT HAMLIB_COMPILE_RESULT OR NOT HAMLIB_RUN_RESULT OR NOT HAMLIB_VERSION)
+    endif (NOT CMAKE_CROSSCOMPILING)
 else(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     message(STATUS "Using own Hamlib build")
     include(cmake/BuildHamlib.cmake)

--- a/cmake/hamlib-test.c
+++ b/cmake/hamlib-test.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <hamlib/rig.h>
+
+int main()
+{
+    printf("%s", hamlib_version);
+    return 1;
+}

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -37,11 +37,11 @@ HamlibRigController::RigList HamlibRigController::RigList_;
 HamlibRigController::RigNameList HamlibRigController::RigNameList_;
 std::mutex HamlibRigController::RigListMutex_;
 
-#if RIGCAPS_NOT_CONST
+#if RIGCAPS_NOT_CONST && !HAMLIB_CONST_WORKAROUND
 int HamlibRigController::BuildRigList_(struct rig_caps *rig, rig_ptr_t rigList) {
 #else
 int HamlibRigController::BuildRigList_(const struct rig_caps *rig, rig_ptr_t rigList) {    
-#endif // RIGCAPS_NOT_CONST
+#endif // RIGCAPS_NOT_CONST && !HAMLIB_CONST_WORKAROUND
     ((HamlibRigController::RigList *)rigList)->push_back(rig); 
     return 1;
 }

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -107,11 +107,11 @@ private:
 
     static bool RigCompare_(const struct rig_caps *rig1, const struct rig_caps *rig2);
 
-#if RIGCAPS_NOT_CONST    
+#if RIGCAPS_NOT_CONST && !HAMLIB_CONST_WORKAROUND
     static int BuildRigList_(struct rig_caps *rig, rig_ptr_t);
 #else
     static int BuildRigList_(const struct rig_caps *rig, rig_ptr_t);
-#endif // RIGCAPS_NOT_CONST
+#endif // RIGCAPS_NOT_CONST && !HAMLIB_CONST_WORKAROUND
 };
 
 #endif // HAMLIB_RIG_CONTROLLER_H


### PR DESCRIPTION
On Fedora 42 (as of 2025-06-15), `RIGCAPS_NO_CONST` is improperly defined in its hamlib package, causing compiler errors on that version of the distro. This PR detects whether the current hamlib version is >= 4.6 and simply assumes that rigcaps is `const` if true.