### PR TITLE
Various code improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,8 +195,8 @@ wxString utTxFile;
 wxString utRxFile;
 wxString utTxFeatureFile;
 wxString utRxFeatureFile;
-int utTxTimeSeconds;
-int utTxAttempts;
+long utTxTimeSeconds;
+long utTxAttempts;
 
 // WxWidgets - initialize the application
 
@@ -476,7 +476,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
             log_info("Piping %s through TX pipeline", (const char*)utTxFile.ToUTF8());
         }
 
-        if (parser.Found("txtime", (long*)&utTxTimeSeconds))
+        if (parser.Found("txtime", &utTxTimeSeconds))
         {
             log_info("Will transmit for %d seconds", utTxTimeSeconds);
         }
@@ -485,7 +485,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
             utTxTimeSeconds = 60;
         }
 
-        if (parser.Found("txattempts", (long*)&utTxAttempts))
+        if (parser.Found("txattempts", &utTxAttempts))
         {
             log_info("Will transmit %d time(s)", utTxAttempts);
         }

--- a/src/pipeline/ParallelStep.cpp
+++ b/src/pipeline/ParallelStep.cpp
@@ -261,7 +261,7 @@ std::shared_ptr<short> ParallelStep::execute(std::shared_ptr<short> inputSamples
     return outputTask->tempOutput;
 }
 
-void ParallelStep::executeRunnerThread_(ThreadInfo* threadState)
+void ParallelStep::executeRunnerThread_(ThreadInfo* threadState) noexcept
 #if defined(__clang__)
 #if defined(__has_feature) && __has_feature(realtime_sanitizer)
 [[clang::nonblocking]]

--- a/src/pipeline/ParallelStep.cpp
+++ b/src/pipeline/ParallelStep.cpp
@@ -220,7 +220,6 @@ std::shared_ptr<short> ParallelStep::execute(std::shared_ptr<short> inputSamples
     for (size_t index = 0; index < threads_.size(); index++)
     {
         ThreadInfo* threadInfo = threads_[index];
-        memset(threadInfo->tempOutput.get(), 0, sizeof(short) * outputSampleRate_);
         
         if (index == (size_t)stepToExecute || stepToExecute == -1)
         {
@@ -257,6 +256,10 @@ std::shared_ptr<short> ParallelStep::execute(std::shared_ptr<short> inputSamples
     
     ThreadInfo* outputTask = threads_[stepToOutput];
     *numOutputSamples = codec2_fifo_used(outputTask->outputFifo);
+    if (*numOutputSamples == 0)
+    {
+        memset(outputTask->tempOutput.get(), 0, sizeof(short) * outputSampleRate_);
+    }
     codec2_fifo_read(outputTask->outputFifo, outputTask->tempOutput.get(), *numOutputSamples);    
     return outputTask->tempOutput;
 }

--- a/src/pipeline/ParallelStep.h
+++ b/src/pipeline/ParallelStep.h
@@ -95,7 +95,13 @@ private:
     std::shared_ptr<void> state_;
     std::vector<std::shared_ptr<IPipelineStep>> parallelSteps_;
 
-    void executeRunnerThread_(ThreadInfo* threadState);
+    void executeRunnerThread_(ThreadInfo* threadState) noexcept
+#if defined(__clang__)
+#if defined(__has_feature) && __has_feature(realtime_sanitizer)
+[[clang::nonblocking]]
+#endif // defined(__has_feature) && __has_feature(realtime_sanitizer)
+#endif // defined(__clang__)
+    ;
 };
 
 #endif // AUDIO_PIPELINE__PARALLEL_STEP_H

--- a/src/pipeline/PlaybackStep.cpp
+++ b/src/pipeline/PlaybackStep.cpp
@@ -65,11 +65,6 @@ PlaybackStep::~PlaybackStep()
         nonRtThread_.join();
     }
     
-    if (playbackResampler_ != nullptr)
-    {
-        delete playbackResampler_;
-    }
-
     codec2_fifo_destroy(outputFifo_);
 }
 
@@ -159,6 +154,11 @@ void PlaybackStep::nonRtThreadEntry_()
         g_mutexProtectingCallbackData.Unlock();
         
         std::this_thread::sleep_for(100ms);
+    }
+
+    if (playbackResampler_ != nullptr)
+    {
+        delete playbackResampler_;
     }
 }
 

--- a/src/pipeline/RecordStep.cpp
+++ b/src/pipeline/RecordStep.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<short> RecordStep::execute(std::shared_ptr<short> inputSamples, 
     codec2_fifo_write(inputFifo_, inputSamples.get(), numInputSamples);
     
     *numOutputSamples = 0;    
-    return std::shared_ptr<short>((short*)nullptr, std::default_delete<short[]>());
+    return std::shared_ptr<short>((short*)nullptr);
 }
 
 void RecordStep::reset()

--- a/src/pipeline/ResampleStep.cpp
+++ b/src/pipeline/ResampleStep.cpp
@@ -77,9 +77,8 @@ ResampleStep::ResampleStep(int inputSampleRate, int outputSampleRate)
     assert(resampleState_ != nullptr);
 
     // Pre-allocate buffers so we don't have to do so during real-time operation.
-    auto maxSamples = std::max(getInputSampleRate(), getOutputSampleRate());
     outputSamples_ = std::shared_ptr<short>(
-        new short[maxSamples], 
+        new short[outputSampleRate], 
         std::default_delete<short[]>());
     assert(outputSamples_ != nullptr);
     

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -547,7 +547,7 @@ void TxRxThread::clearFifos_()
 // Main real time processing for tx and rx of FreeDV signals, run in its own threads
 //---------------------------------------------------------------------------------------------
 
-void TxRxThread::txProcessing_()
+void TxRxThread::txProcessing_() noexcept
 #if defined(__clang__)
 #if defined(__has_feature) && __has_feature(realtime_sanitizer)
 [[clang::nonblocking]]
@@ -666,7 +666,7 @@ void TxRxThread::txProcessing_()
     }
 }
 
-void TxRxThread::rxProcessing_()
+void TxRxThread::rxProcessing_() noexcept
 #if defined(__clang__)
 #if defined(__has_feature) && __has_feature(realtime_sanitizer)
 [[clang::nonblocking]]

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -87,8 +87,22 @@ private:
     std::shared_ptr<short> inputSamples_;
     
     void initializePipeline_();
-    void txProcessing_();
-    void rxProcessing_();
+    void txProcessing_() noexcept
+#if defined(__clang__)
+#if defined(__has_feature) && __has_feature(realtime_sanitizer)
+[[clang::nonblocking]]
+#endif // defined(__has_feature) && __has_feature(realtime_sanitizer)
+#endif // defined(__clang__)
+    ;
+
+    void rxProcessing_() noexcept
+#if defined(__clang__)
+#if defined(__has_feature) && __has_feature(realtime_sanitizer)
+[[clang::nonblocking]]
+#endif // defined(__has_feature) && __has_feature(realtime_sanitizer)
+#endif // defined(__clang__)
+    ;
+
     void clearFifos_();
 };
 

--- a/test/hamlibserver.py
+++ b/test/hamlibserver.py
@@ -322,11 +322,11 @@ class HamlibHandler:
       self.ErrParam()
     else:
       if (not x) and self.app.ptt:
-          # Sleep for 20ms to match typical SDR behavior + 30ms to account for varying system load/virtual audio latency.
+          # Sleep for 20ms to match typical SDR behavior + 60ms to account for varying system load/virtual audio latency.
           # References:
-          #   Virtual audio latency: https://vb-audio.com/Cable/VBCABLE_ReferenceManual.pdf (assuming 10ms/512 sample buffer size @ 48 kHz)
+          #   Virtual audio latency: https://vb-audio.com/Cable/VBCABLE_ReferenceManual.pdf (assuming 20ms/1024 sample buffer size @ 48 kHz)
           #   Example TX->RX switching time: Flex 6000/8000 (https://community.flexradio.com/discussion/8028104/question-regarding-tx-delay)
-          time.sleep(50 / 1000)
+          time.sleep(80 / 1000)
           os.kill(self.pid, signal.SIGTERM)
       if x:
         self.app.ptt = 1


### PR DESCRIPTION
Ports over low-risk code improvements from #933:

* main.cpp: Fix AddressSanitizer violation when running unit tests.
* ParallelStep.cpp/TxRxThread.cpp: Add required `noexcept` when using RTSan.
* PlaybackStep.cpp: Delete resampler inside thread that created it.
* ResampleStep.cpp: Reduce memory consumption by creating output buffer based on output sample rate (not max(input, output)).
* hamlibserver.py: Increase sleep time prior to `os.kill()` to match 20ms audio latency used in codebase.