### PR TITLE
Legacy FreeDV modes: ensure that sync is obtained in an atomic manner.

### DIFF
--- a/src/pipeline/FreeDVReceiveStep.cpp
+++ b/src/pipeline/FreeDVReceiveStep.cpp
@@ -36,6 +36,8 @@ FreeDVReceiveStep::FreeDVReceiveStep(struct freedv* dv)
     , channelNoiseSnr_(0)
     , freqOffsetHz_(0)
 {
+    assert(syncState_.is_lock_free());
+
     // Set FIFO to be 2x the number of samples per run so we don't lose anything.
     inputSampleFifo_ = codec2_fifo_create(freedv_get_modem_sample_rate(dv_));
     assert(inputSampleFifo_ != nullptr);
@@ -121,6 +123,7 @@ std::shared_ptr<short> FreeDVReceiveStep::execute(std::shared_ptr<short> inputSa
         }
     }
 
+    syncState_ = freedv_get_sync(dv_);
     return outputSamples_;
 }
 

--- a/src/pipeline/FreeDVReceiveStep.h
+++ b/src/pipeline/FreeDVReceiveStep.h
@@ -23,6 +23,7 @@
 #ifndef AUDIO_PIPELINE__FREEDV_RECEIVE_STEP_H
 #define AUDIO_PIPELINE__FREEDV_RECEIVE_STEP_H
 
+#include <atomic>
 #include <functional>
 #include "IPipelineStep.h"
 #include "../freedv_interface.h"
@@ -48,15 +49,16 @@ public:
     
     void setSigPwrAvg(float newVal) { sigPwrAvg_ = newVal; }
     float getSigPwrAvg() const { return sigPwrAvg_; }
-    int getSync() const { return freedv_get_sync(dv_); }
+    int getSync() const { return syncState_.load(); }
     void setChannelNoiseEnable(bool enabled, int snr) 
     { 
         channelNoiseEnabled_ = enabled; 
         channelNoiseSnr_ = snr;
     }
     void setFreqOffset(float freq) { freqOffsetHz_ = freq; }
-    
+
 private:
+    std::atomic<int> syncState_;
     struct freedv* dv_;
     struct FIFO* inputSampleFifo_;
     COMP rxFreqOffsetPhaseRectObjs_;


### PR DESCRIPTION
Current Codec2 clears the sync flag internally for 700D and E modes at the beginning of `freedv_rx()`. Because of this, there is a small window where sync is not in its final state when other parts of the system retrieve it. This is most evident in macOS tests failing in the GitHub environment but this is theoretically possible on (a) any platform and (b) in user-facing contexts (i.e. brief audio dropouts due to the multi-RX logic occurring while decode is still in progress). 

As most development is focused on RADE, this PR updates the freedv-gui logic to only retrieve the sync state from Codec2 *after* `FreeDVReceiveStep` finishes processing a block of audio, ensuring that other parts of the system always see consistent state for sync.