### PR TITLE
Fix: CMake try_run compatibility for cmake versions < 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,18 +438,15 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     # also be true in 4.7 as the test script below prints 4.7~git on Fedora
     # 42 as of 2025-06-15.
     if (NOT CMAKE_CROSSCOMPILING)
-        if (CMAKE_VERSION VERSION_LESS 3.23)
+        if (CMAKE_VERSION VERSION_LESS 3.25)
             set(_HAMLIB_TRY_RUN_BINDIR "${CMAKE_CURRENT_BINARY_DIR}/HamlibTryRun")
-            set(_HAMLIB_TRY_RUN_SOURCE_ARGS "${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c")
             message(STATUS "Using old try_run syntax for CMake ${CMAKE_VERSION}")
         else()
-            set(_HAMLIB_TRY_RUN_BINDIR "")
-            set(_HAMLIB_TRY_RUN_SOURCE_ARGS "SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c")
+            set(_HAMLIB_TRY_RUN_BINDIR "SOURCES")
             message(STATUS "Using new try_run syntax for CMake ${CMAKE_VERSION}")
-        endif(CMAKE_VERSION VERSION_LESS 3.23)
+        endif(CMAKE_VERSION VERSION_LESS 3.25)
         try_run(HAMLIB_RUN_RESULT HAMLIB_COMPILE_RESULT
-            ${_HAMLIB_TRY_RUN_BINDIR}
-            ${_HAMLIB_TRY_RUN_SOURCE_ARGS}
+            ${_HAMLIB_TRY_RUN_BINDIR} ${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c
             CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${HAMLIB_INCLUDE_DIR}
             LINK_LIBRARIES ${HAMLIB_LIBRARY}
             RUN_OUTPUT_VARIABLE HAMLIB_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,8 +438,18 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
     # also be true in 4.7 as the test script below prints 4.7~git on Fedora
     # 42 as of 2025-06-15.
     if (NOT CMAKE_CROSSCOMPILING)
+        if (CMAKE_VERSION VERSION_LESS 3.23)
+            set(_HAMLIB_TRY_RUN_BINDIR "${CMAKE_CURRENT_BINARY_DIR}/HamlibTryRun")
+            set(_HAMLIB_TRY_RUN_SOURCE_ARGS "${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c")
+            message(STATUS "Using old try_run syntax for CMake ${CMAKE_VERSION}")
+        else()
+            set(_HAMLIB_TRY_RUN_BINDIR "")
+            set(_HAMLIB_TRY_RUN_SOURCE_ARGS "SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c")
+            message(STATUS "Using new try_run syntax for CMake ${CMAKE_VERSION}")
+        endif(CMAKE_VERSION VERSION_LESS 3.23)
         try_run(HAMLIB_RUN_RESULT HAMLIB_COMPILE_RESULT
-            SOURCES ${CMAKE_SOURCE_DIR}/cmake/hamlib-test.c
+            ${_HAMLIB_TRY_RUN_BINDIR}
+            ${_HAMLIB_TRY_RUN_SOURCE_ARGS}
             CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${HAMLIB_INCLUDE_DIR}
             LINK_LIBRARIES ${HAMLIB_LIBRARY}
             RUN_OUTPUT_VARIABLE HAMLIB_VERSION)
@@ -449,6 +459,8 @@ if(HAMLIB_LIBRARY AND HAMLIB_INCLUDE_DIR)
             if (NOT HAMLIB_VERSION STRLESS "Hamlib 4.6")
                 message(STATUS "Enabling Hamlib 4.6 compile workaround.")
                 add_definitions(-DHAMLIB_CONST_WORKAROUND)
+            else()
+                message(STATUS "Found ${HAMLIB_VERSION} - NOT enabling Hamlib 4.6 compile workaround.")
             endif (NOT HAMLIB_VERSION STRLESS "Hamlib 4.6")
         endif (NOT HAMLIB_COMPILE_RESULT OR NOT HAMLIB_RUN_RESULT OR NOT HAMLIB_VERSION)
     endif (NOT CMAKE_CROSSCOMPILING)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -805,7 +805,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Work around Linux bug preventing some flag emojis from being fully deleted on backspace. (PR #931)
     * Fix GTK+ assertion after FreeDV Reporter has been open for a long time. (PR #929)
     * Easy Setup: Use card names instead of device names for generating device list. (PR #932)
-    * Fix compiler error on Fedora 42 when using Hamlib packages. (PR #936)
+    * Fix compiler error on Fedora 42 when using Hamlib packages. (PR #936, #940; thanks @jaspejavier!)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)


### PR DESCRIPTION
Fix try_run syntax if cmake version < 3.25, according to [this comment](https://github.com/drowe67/freedv-gui/commit/47841eb54de37e3c20df75eb9b86071c5dd8c3fe#commitcomment-160256664)
Tested to build and run on:
Ubuntu 22.04.5 LTS - cmake 3.22.1 (old try_run syntax)
Ubuntu 24.04.2 LTS - cmake 3.28.3 (new try_run syntax)

Syntax references:
[try_run on cmake 3.24 and earlier](https://cmake.org/cmake/help/v3.24/command/try_run.html#command:try_run)
[try_run on cmake 3.25 onwards](https://cmake.org/cmake/help/v3.25/command/try_run.html#command:try_run)

[Current cmake versions in Ubuntu](https://launchpad.net/ubuntu/+source/cmake)