### PR TITLE
FreeDV Reporter: Highlight update and re-sorting should also be queued up to be reported.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -803,7 +803,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Reduce CPU usage of FreeDV Reporter window by only re-sorting if we actually get new data from the server. (PR #915)
     * FreeDV Reporter: Fix issue with first column not being aligned properly with other columns. (PR #922)
     * FreeDV Reporter: Work around Linux bug preventing some flag emojis from being fully deleted on backspace. (PR #931)
-    * Fix GTK+ assertion after FreeDV Reporter has been open for a long time. (PR #929)
+    * Fix GTK+ assertion after FreeDV Reporter has been open for a long time. (PR #929, #945)
     * Easy Setup: Use card names instead of device names for generating device list. (PR #932)
     * Fix compiler error on Fedora 42 when using Hamlib packages. (PR #936, #940; thanks @jaspejavier!)
     * Legacy FreeDV modes: ensure that sync is obtained in an atomic manner. (PR #939)

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -158,6 +158,7 @@ class FreeDVReporterDialog : public wxFrame
              void refreshAllRows();
              void requestQSY(wxDataViewItem selectedItem, uint64_t frequency, wxString customText);
              void updateHighlights();
+             void triggerResort();
              void updateMessage(wxString statusMsg)
              {
                  if (reporter_)


### PR DESCRIPTION
Based on report in https://github.com/drowe67/freedv-gui/issues/920#issuecomment-2994158145, this PR pushes timer-based operations to our existing operation queue. This is done since there's a hidden GTK+/wxWidgets event that fires when the official data changed callbacks are fired by our application, so the app state must completely update prior to that event firing to avoid "model out of sync" warnings.