### PR TITLE
Fix issue with Git hash not appearing in Windows installer name.

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -20,6 +20,8 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-24.04
+    outputs: 
+      INSTALLER_FILENAME: ${{ steps.installer-filename.outputs.INSTALLER_FILENAME }}
 
     steps:
     - uses: actions/checkout@v4
@@ -79,17 +81,19 @@ jobs:
         export PATH=${{github.workspace}}/llvm-mingw-20250430-ucrt-ubuntu-22.04-x86_64/bin:$PATH
         make -j$(nproc) package
 
-    - name: Rename installer
+    - name: Calculate installer filename
       shell: bash
+      id: installer-filename
       working-directory: ${{github.workspace}}/build_windows
       run: |
-        mv FreeDV*.exe FreeDV.exe
-    
+          export FREEDV_INSTALLER_FILE=`ls FreeDV*.exe`
+          echo "INSTALLER_FILENAME=${FREEDV_INSTALLER_FILE}" >> "$GITHUB_OUTPUT"
+
     - name: Stash for next step
       uses: actions/upload-artifact@v4
       with:
-        name: FreeDVSetupProgram
-        path: ${{github.workspace}}/build_windows/FreeDV.exe
+        name: ${{ steps.installer-filename.outputs.INSTALLER_FILENAME }}
+        path: ${{github.workspace}}/build_windows/${{ steps.installer-filename.outputs.INSTALLER_FILENAME }}
 
   test:
     runs-on: windows-2022
@@ -103,7 +107,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        name: FreeDVSetupProgram
+        name: ${{needs.build.outputs.INSTALLER_FILENAME}}
         path: ${{github.workspace}}
   
     - uses: ilammy/msvc-dev-cmd@v1
@@ -111,7 +115,7 @@ jobs:
     - name: Install FreeDV on hard drive
       shell: pwsh
       run: |
-          .\FreeDV.exe /S /D=${{github.workspace}}\FreeDV-Install-Location | Out-Null
+          .\${{needs.build.outputs.INSTALLER_FILENAME}} /S /D=${{github.workspace}}\FreeDV-Install-Location | Out-Null
   
     - name: Copy test scripts to install folder
       shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,11 +591,11 @@ else(FreeDV_VERSION_TWEAK)
 endif(FreeDV_VERSION_TWEAK)
     
 if(FREEDV_VERSION_TAG)
-    if(FREEDV_HASH)
-        set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${FREEDV_VERSION_TAG}-${DATE_RESULT}-${FREEDV_HASH}")
-    else(FREEDV_HASH)
+    if(GIT_HASH)
+        set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${FREEDV_VERSION_TAG}-${DATE_RESULT}-${GIT_HASH}")
+    else(GIT_HASH)
         set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${FREEDV_VERSION_TAG}-${DATE_RESULT}")
-    endif(FREEDV_HASH)
+    endif(GIT_HASH)
     message(STATUS "package name = ${CPACK_PACKAGE_VERSION_PATCH}")
 endif()
 
@@ -664,7 +664,7 @@ VIAddVersionKey \\\"Company\\\" \\\"FreeDV\\\"
 VIAddVersionKey \\\"LegalCopyright\\\" \\\"Copyright (c) ${COPYRIGHT_YEAR} FreeDV\\\"
 VIAddVersionKey \\\"FileDescription\\\" \\\"FreeDV - ${PROJECT_DESCRIPTION}\\\"
 VIAddVersionKey \\\"FileVersion\\\" \\\"${CPACK_WIN_VERSION}\\\"
-VIAddVersionKey \\\"GitHash\\\" \\\"${FREEDV_HASH}\\\"
+VIAddVersionKey \\\"GitHash\\\" \\\"${GIT_HASH}\\\"
     ")
 
     # Ensures that we don't need to constantly update the rc file on every new release.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -828,7 +828,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Add note about using XWayland on Linux. (PR #926)
 3. Build system:
     * Update Hamlib to 4.6.3 (macOS/Windows). (PR #930)
-    * Reload current Git hash every time it changes. (PR #935)
+    * Reload current Git hash every time it changes. (PR #935, #951)
     * Add infrastructure for generating AppImage builds. (PR #937)
 
 ## V2.0.0 June 2025

--- a/cmake/CheckGit.cmake
+++ b/cmake/CheckGit.cmake
@@ -61,6 +61,7 @@ function(CheckGitVersion)
         configure_file(${pre_configure_file} ${post_configure_file} @ONLY)
     endif ()
 
+    set(GIT_HASH ${GIT_HASH} PARENT_SCOPE)
 endfunction()
 
 function(CheckGitSetup)
@@ -81,6 +82,8 @@ function(CheckGitSetup)
     add_dependencies(git_version AlwaysCheckGit)
 
     CheckGitVersion()
+    message(STATUS "Git hash: ${GIT_HASH}")
+    set(GIT_HASH ${GIT_HASH} PARENT_SCOPE)
 endfunction()
 
 # This is used to run this function from an external cmake process.


### PR DESCRIPTION
This PR fixes a bug introduced in the fix for #934 where the Windows installer filename and Registry keys don't indicate the Git hash used for the build.