### PR TITLE
Be explicit about the use of signed char for reporting.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -823,6 +823,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Legacy FreeDV modes: ensure that sync is obtained in an atomic manner. (PR #939)
     * Fix intermittent crash on Windows when pushing Start. (PR #943)
     * FreeDV Reporter: Defer deallocation of disconnected users. (PR #948)
+    * FreeDV Reporter: Be explicit about the use of signed char for reporting. (PR #953)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/reporting/FreeDVReporter.cpp
+++ b/src/reporting/FreeDVReporter.cpp
@@ -147,7 +147,7 @@ void FreeDVReporter::showOurselves()
     }
 }
     
-void FreeDVReporter::addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr)
+void FreeDVReporter::addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, signed char snr)
 {
     if (isValidForReporting() && isFullyConnected_)
     {

--- a/src/reporting/FreeDVReporter.h
+++ b/src/reporting/FreeDVReporter.h
@@ -81,7 +81,7 @@ public:
     
     virtual void inAnalogMode(bool inAnalog) override;
     
-    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr) override;
+    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, signed char snr) override;
     virtual void send() override;
     
     void setOnReporterConnectFn(ReporterConnectionFn fn);

--- a/src/reporting/IReporter.h
+++ b/src/reporting/IReporter.h
@@ -35,7 +35,7 @@ public:
     
     virtual void inAnalogMode(bool inAnalog) = 0;
     
-    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr) = 0;
+    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, signed char snr) = 0;
     virtual void send() = 0;
 };
 

--- a/src/reporting/pskreporter.cpp
+++ b/src/reporting/pskreporter.cpp
@@ -85,7 +85,7 @@ static const unsigned char txFormatHeader[] = {
     0x00, 0x96, 0x00, 0x04
 };
 
-SenderRecord::SenderRecord(std::string callsign, uint64_t frequency, char snr)
+SenderRecord::SenderRecord(std::string callsign, uint64_t frequency, signed char snr)
     : callsign(callsign)
     , frequency(frequency)
     , snr(snr)
@@ -163,7 +163,7 @@ PskReporter::~PskReporter()
 #endif // defined(WIN32)
 }
 
-void PskReporter::addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr)
+void PskReporter::addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, signed char snr)
 {
     std::unique_lock<std::mutex> lock(recordListMutex_);
     recordList_.push_back(SenderRecord(callsign, frequency, snr));

--- a/src/reporting/pskreporter.h
+++ b/src/reporting/pskreporter.h
@@ -30,12 +30,12 @@ struct SenderRecord
 {
     std::string callsign;
     uint64_t frequency;
-    char snr;
+    signed char snr;
     std::string mode;
     char infoSource;
     int flowTimeSeconds;
     
-    SenderRecord(std::string callsign, uint64_t frequency, char snr);
+    SenderRecord(std::string callsign, uint64_t frequency, signed char snr);
     
     int recordSize();    
     void encode(char* buf);
@@ -47,7 +47,7 @@ public:
     PskReporter(std::string callsign, std::string gridSquare, std::string software);
     virtual ~PskReporter() override;
     
-    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, char snr) override;
+    virtual void addReceiveRecord(std::string callsign, std::string mode, uint64_t frequency, signed char snr) override;
     virtual void send() override;
     
     // The below aren't implemented for PSK Reporter.


### PR DESCRIPTION
The reporting interface uses `char` for the SNR. Most other C data types default to `signed` but whether `char` defaults to signed depends on the compiler and platform, causing some systems (for example, Raspberry Pi) to report extremely high SNR figures to FreeDV Reporter instead of negative SNRs as expected. This PR forces used of `signed char` for the SNR field to ensure that reporting behavior is correct regardless of platform.