### PR TITLE
PulseAudio: Make sure we can only do one stop() at a time.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -300,7 +300,7 @@ jobs:
           sleep 5
           ln -s ${{github.workspace}}/build_linux/rade_src/model19_check3 model19_check3
           . ../rade-venv/bin/activate
-          ASAN_OPTIONS=suppressions=${{github.workspace}}/test/asan_suppressions.txt LSAN_OPTIONS=suppressions=${{github.workspace}}/test/lsan_suppressions.txt PYTHONPATH=${{github.workspace}}/build_linux/rade_src:$PYTHONPATH ctest -V -R fullduplex_
+          ASAN_OPTIONS=suppressions=${{github.workspace}}/test/asan_suppressions.txt LSAN_OPTIONS=suppressions=${{github.workspace}}/test/lsan_suppressions.txt PYTHONPATH=${{github.workspace}}/build_linux/rade_src:$PYTHONPATH ctest -V
 
     - name: Execute unit tests
       shell: bash

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -824,6 +824,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix intermittent crash on Windows when pushing Start. (PR #943)
     * FreeDV Reporter: Defer deallocation of disconnected users. (PR #948)
     * Fix issue preventing rtkit from being compiled-in on Ubuntu 22.04. (PR #954)
+    * PulseAudio: Make sure we can only do one stop() at a time. (PR #955)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/audio/PulseAudioDevice.cpp
+++ b/src/audio/PulseAudioDevice.cpp
@@ -59,10 +59,7 @@ PulseAudioDevice::PulseAudioDevice(pa_threaded_mainloop *mainloop, pa_context* c
 
 PulseAudioDevice::~PulseAudioDevice()
 {
-    if (stream_ != nullptr)
-    {
-        stop();
-    }
+    stop();
 }
 
 bool PulseAudioDevice::isRunning()
@@ -72,6 +69,8 @@ bool PulseAudioDevice::isRunning()
 
 void PulseAudioDevice::start()
 {
+    std::unique_lock<std::mutex> lk(objLock_);
+
     pa_sample_spec sample_specification;
     sample_specification.format = PA_SAMPLE_S16LE;
     sample_specification.rate = sampleRate_;
@@ -152,6 +151,7 @@ void PulseAudioDevice::start()
 
 void PulseAudioDevice::stop()
 {
+    std::unique_lock<std::mutex> lk(objLock_);
     if (stream_ != nullptr)
     {
         pa_threaded_mainloop_lock(mainloop_);

--- a/src/audio/PulseAudioDevice.h
+++ b/src/audio/PulseAudioDevice.h
@@ -73,6 +73,7 @@ protected:
     PulseAudioDevice(pa_threaded_mainloop *mainloop, pa_context* context, wxString devName, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels);
     
 private:
+    std::mutex objLock_;
     pa_context* context_;
     pa_threaded_mainloop* mainloop_;
     pa_stream* stream_;


### PR DESCRIPTION
Discovered during work on #949. There are instances where `PulseAudioDevice::stop()` gets called multiple times during shutdown. This causes segfaults inside libpulse, along with automated tests to fail. This PR adds locking around `start()` and `stop()` to prevent this issue.