### PR TITLE
Add Hamlib as a build dependency if we're building it ourselves.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -836,7 +836,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update Hamlib to 4.6.3 (macOS/Windows). (PR #930)
     * Reload current Git hash every time it changes. (PR #935, #951)
     * Add infrastructure for generating AppImage builds. (PR #937)
-    * Make explicit various codec2 dependencies to avoid compile race condition. (PR #957)
+    * Make explicit various dependencies to avoid compile race condition. (PR #957, #959)
 
 ## V2.0.0 June 2025
 

--- a/cmake/BuildHamlib.cmake
+++ b/cmake/BuildHamlib.cmake
@@ -28,6 +28,7 @@ ExternalProject_Add(build_hamlib
 ExternalProject_Get_Property(build_hamlib BINARY_DIR)
 ExternalProject_Get_Property(build_hamlib SOURCE_DIR)
 add_library(hamlib SHARED IMPORTED)
+add_dependencies(hamlib build_hamlib)
 
 set_target_properties(hamlib PROPERTIES
     IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/external/dist/lib/libhamlib${CMAKE_SHARED_LIBRARY_SUFFIX}"

--- a/src/gui/dialogs/CMakeLists.txt
+++ b/src/gui/dialogs/CMakeLists.txt
@@ -11,6 +11,10 @@ target_include_directories(fdv_gui_dialogs PRIVATE ${CODEC2_INCLUDE_DIRS} ${CMAK
 
 add_dependencies(fdv_gui_dialogs rade opus codec2)
 
+if(HAMLIB_ADD_DEPENDENCY)
+add_dependencies(fdv_gui_dialogs hamlib)
+endif(HAMLIB_ADD_DEPENDENCY)
+
 if(BOOTSTRAP_WXWIDGETS)
     add_dependencies(fdv_gui_dialogs wx::core wx::base wx::aui wx::html wx::net wx::adv wx::propgrid wx::xrc)
     target_compile_definitions(fdv_gui_dialogs PRIVATE ${WXBUILD_BUILD_DEFS})


### PR DESCRIPTION
Discovered while trying to build the signed Windows binary. Followup to #956.