### PR TITLE
macOS: Only report support for device default sample rates.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -826,7 +826,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Be explicit about the use of signed char for reporting. (PR #953)
     * Fix issue preventing rtkit from being compiled-in on Ubuntu 22.04. (PR #954)
     * PulseAudio: Make sure we can only do one stop() at a time. (PR #955)
-    * macOS: Fix audio-related crash with certain devices. (PR #958)
+    * macOS: Fix audio-related crash with certain devices. (PR #958, #960)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/audio/MacAudioEngine.cpp
+++ b/src/audio/MacAudioEngine.cpp
@@ -221,6 +221,7 @@ std::vector<int> MacAudioEngine::getSupportedSampleRates(wxString deviceName, Au
     {
         if (dev.name == deviceName)
         {
+#if 0
             AudioObjectPropertyAddress propertyAddress = {
                 .mSelector = kAudioDevicePropertyAvailableNominalSampleRates,
                 .mScope = kAudioObjectPropertyScopeGlobal,
@@ -289,6 +290,8 @@ std::vector<int> MacAudioEngine::getSupportedSampleRates(wxString deviceName, Au
             }
             
             free(rates);
+#endif // 0
+            result.push_back(dev.defaultSampleRate);
             break;
         }
     }


### PR DESCRIPTION
With the current AVAudioEngine-based audio implementation, usage of sample rates other than the defaults (even when supported by HW) causes a whole bunch of issues with devices not working properly. This PR causes `MacAudioDevice` and `MacAudioEngine` to behave more like Windows WASAPI (where only a single sample rate is reported to the higher level code). This is especially important for e.g. Bluetooth devices as technical issues require use of the default sample rates reported by the OS.