### PR TITLE
PulseAudio/pipewire: Add mutex around start/stop engine calls.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -825,7 +825,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Defer deallocation of disconnected users. (PR #948)
     * FreeDV Reporter: Be explicit about the use of signed char for reporting. (PR #953)
     * Fix issue preventing rtkit from being compiled-in on Ubuntu 22.04. (PR #954)
-    * PulseAudio: Make sure we can only do one stop() at a time. (PR #955)
+    * PulseAudio: Make sure we can only do one stop() at a time. (PR #955, #961)
     * macOS: Fix audio-related crash with certain devices. (PR #958)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)

--- a/src/audio/PulseAudioEngine.cpp
+++ b/src/audio/PulseAudioEngine.cpp
@@ -42,6 +42,8 @@ PulseAudioEngine::~PulseAudioEngine()
 
 void PulseAudioEngine::start()
 {
+    std::unique_lock<std::mutex> lk(startStopMtx_);
+
     // Allocate PA main loop and context.
     mainloop_ = pa_threaded_mainloop_new();
     
@@ -123,6 +125,8 @@ void PulseAudioEngine::start()
 
 void PulseAudioEngine::stop()
 {
+    std::unique_lock<std::mutex> lk(startStopMtx_);
+
     if (initialized_)
     {
         pa_threaded_mainloop_lock(mainloop_);

--- a/src/audio/PulseAudioEngine.h
+++ b/src/audio/PulseAudioEngine.h
@@ -23,6 +23,8 @@
 #ifndef PULSE_AUDIO_ENGINE_H
 #define PULSE_AUDIO_ENGINE_H
 
+#include <mutex>
+
 #include <pulse/pulseaudio.h>
 #include "IAudioEngine.h"
 
@@ -44,6 +46,7 @@ private:
     pa_threaded_mainloop *mainloop_;
     pa_mainloop_api *mainloopApi_;
     pa_context* context_;
+    std::mutex startStopMtx_;
 };
 
 #endif // PULSE_AUDIO_ENGINE_H


### PR DESCRIPTION
Followup to #955 to also add locking around `PulseAudioEngine` stop and start calls as the following error in GitHub Actions  logs appears to occur while tearing down the "main loop" (done by the engine, not the device classes):

```
Assertion 'pthread_mutex_destroy(&m->mutex) == 0' failed at ../src/pulsecore/mutex-posix.c:85, function pa_mutex_free(). Aborting.
```