### PR TITLE
Disable controls not supported by RADE.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -768,6 +768,25 @@ setDefaultMode:
         mode = defaultMode;
         goto setDefaultMode;
     }
+    
+    // Disable controls not supported by RADE.
+    bool isEnabled = mode != FREEDV_MODE_RADE;
+    m_sliderSQ->Enable(isEnabled);
+    m_ckboxSQ->Enable(isEnabled);
+    m_textSQ->Enable(isEnabled);
+    m_btnCenterRx->Enable(isEnabled);
+    
+    if (!isEnabled)
+    {
+        m_textBits->SetLabel("Bits: unk");
+        m_textErrors->SetLabel("Errs: unk");
+        m_textBER->SetLabel("BER: unk");
+        m_textFreqOffset->SetLabel("FrqOff: unk");
+        m_textSyncMetric->SetLabel("Sync: unk");
+        m_textCodec2Var->SetLabel("Var: unk");
+        m_textClockOffset->SetLabel("ClkOff: unk");
+    }
+    
     pConfig->SetPath(wxT("/"));
     
     m_togBtnAnalog->Disable();
@@ -1827,27 +1846,46 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             realigned_ = true;
         }
 
-        snprintf(bits, STR_LENGTH, "Bits: %d", freedvInterface.getTotalBits()); wxString bits_string(bits); m_textBits->SetLabel(bits_string);
-        snprintf(errors, STR_LENGTH, "Errs: %d", freedvInterface.getTotalBitErrors()); wxString errors_string(errors); m_textErrors->SetLabel(errors_string);
-        float b = (float)freedvInterface.getTotalBitErrors()/(1E-6+freedvInterface.getTotalBits());
-        snprintf(ber, STR_LENGTH, "BER: %4.3f", b); wxString ber_string(ber); m_textBER->SetLabel(ber_string);
-        snprintf(resyncs, STR_LENGTH, "Resyncs: %d", g_resyncs); wxString resyncs_string(resyncs); m_textResyncs->SetLabel(resyncs_string);
+        if (g_mode == FREEDV_MODE_RADE)
+        {
+            m_textBits->SetLabel("Bits: unk");
+            m_textErrors->SetLabel("Errs: unk");
+            m_textBER->SetLabel("BER: unk");
+            m_textFreqOffset->SetLabel("FrqOff: unk");
+            m_textSyncMetric->SetLabel("Sync: unk");
+            m_textCodec2Var->SetLabel("Var: unk");
+        }
+        else
+        {
+            snprintf(bits, STR_LENGTH, "Bits: %d", freedvInterface.getTotalBits()); wxString bits_string(bits); m_textBits->SetLabel(bits_string);
+            snprintf(errors, STR_LENGTH, "Errs: %d", freedvInterface.getTotalBitErrors()); wxString errors_string(errors); m_textErrors->SetLabel(errors_string);
+            float b = (float)freedvInterface.getTotalBitErrors()/(1E-6+freedvInterface.getTotalBits());
+            snprintf(ber, STR_LENGTH, "BER: %4.3f", b); wxString ber_string(ber); m_textBER->SetLabel(ber_string);
+            snprintf(resyncs, STR_LENGTH, "Resyncs: %d", g_resyncs); wxString resyncs_string(resyncs); m_textResyncs->SetLabel(resyncs_string);
 
-        snprintf(freqoffset, STR_LENGTH, "FrqOff: %3.1f", freedvInterface.getCurrentRxModemStats()->foff);
-        wxString freqoffset_string(freqoffset); m_textFreqOffset->SetLabel(freqoffset_string);
-        snprintf(syncmetric, STR_LENGTH, "Sync: %3.2f", freedvInterface.getCurrentRxModemStats()->sync_metric);
-        wxString syncmetric_string(syncmetric); m_textSyncMetric->SetLabel(syncmetric_string);
+            snprintf(freqoffset, STR_LENGTH, "FrqOff: %3.1f", freedvInterface.getCurrentRxModemStats()->foff);
+            wxString freqoffset_string(freqoffset); m_textFreqOffset->SetLabel(freqoffset_string);
+            snprintf(syncmetric, STR_LENGTH, "Sync: %3.2f", freedvInterface.getCurrentRxModemStats()->sync_metric);
+            wxString syncmetric_string(syncmetric); m_textSyncMetric->SetLabel(syncmetric_string);
 
-        // Codec 2 700D/E "auto EQ" equaliser variance
-        auto var = freedvInterface.getVariance();
-        char var_str[STR_LENGTH]; snprintf(var_str, STR_LENGTH, "Var: %4.1f", var);
-        wxString var_string(var_str); m_textCodec2Var->SetLabel(var_string);
+            // Codec 2 700D/E "auto EQ" equaliser variance
+            auto var = freedvInterface.getVariance();
+            char var_str[STR_LENGTH]; snprintf(var_str, STR_LENGTH, "Var: %4.1f", var);
+            wxString var_string(var_str); m_textCodec2Var->SetLabel(var_string);
+        }
 
         if (g_State) {
 
-            snprintf(clockoffset, STR_LENGTH, "ClkOff: %+-d", (int)round(freedvInterface.getCurrentRxModemStats()->clock_offset*1E6) % 10000);
-            wxString clockoffset_string(clockoffset); m_textClockOffset->SetLabel(clockoffset_string);
-
+            if (g_mode == FREEDV_MODE_RADE)
+            {
+                m_textClockOffset->SetLabel("ClkOff: unk");
+            }
+            else
+            {
+                snprintf(clockoffset, STR_LENGTH, "ClkOff: %+-d", (int)round(freedvInterface.getCurrentRxModemStats()->clock_offset*1E6) % 10000);
+                wxString clockoffset_string(clockoffset); m_textClockOffset->SetLabel(clockoffset_string);
+            }
+            
             // update error pattern plots if supported
             short* error_pattern = nullptr;
             int sz_error_pattern = freedvInterface.getErrorPattern(&error_pattern);
@@ -1997,6 +2035,13 @@ void MainFrame::OnChangeTxMode( wxCommandEvent& event )
     {
         obj->transmit(freedvInterface.getCurrentTxModeStr(), g_tx);
     }
+    
+    // Disable controls not supported by RADE
+    bool isEnabled = g_mode != FREEDV_MODE_RADE;
+    m_sliderSQ->Enable(isEnabled);
+    m_ckboxSQ->Enable(isEnabled);
+    m_textSQ->Enable(isEnabled);
+    m_btnCenterRx->Enable(isEnabled);
 }
 
 void MainFrame::performFreeDVOn_()

--- a/src/main.h
+++ b/src/main.h
@@ -434,6 +434,8 @@ class MainFrame : public TopFrame
 
         void OnSystemColorChanged(wxSysColourChangedEvent& event) override;
         
+        void OnNotebookPageChanging(wxAuiNotebookEvent& event) override;
+        
         void OnChooseAlternateVoiceKeyerFile( wxCommandEvent& event );
         void OnRecordNewVoiceKeyerFile( wxCommandEvent& event );
         

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1293,6 +1293,28 @@ void MainFrame::OnSystemColorChanged(wxSysColourChangedEvent& event)
     TopFrame::OnSystemColorChanged(event);
 }
 
+void MainFrame::OnNotebookPageChanging(wxAuiNotebookEvent& event)
+{
+    if (m_rbRADE->GetValue())
+    {
+        auto newSelection = event.GetSelection();
+        auto page = m_auiNbookCtrl->GetPage(newSelection);
+        
+        // Prevent selection of tabs not yet supported by RADE.
+        if (page == m_panelScatter || 
+            page == m_panelTimeOffset || 
+            page == m_panelFreqOffset || 
+            page == m_panelTestFrameErrors ||
+            page == m_panelTestFrameErrorsHist)
+        {
+            log_info("Veto attempt at viewing tab %d not supported by RADE", newSelection);
+            event.Veto();
+        }
+    }
+    
+    TopFrame::OnNotebookPageChanging(event);
+}
+
 void MainFrame::OnCenterRx(wxCommandEvent& event)
 {
     clickTune(FDMDV_FCENTRE);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -846,6 +846,8 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_cboReportFrequency->Connect(wxEVT_COMBOBOX, wxCommandEventHandler(TopFrame::OnChangeReportFrequency), NULL, this);
     m_cboReportFrequency->Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(TopFrame::OnReportFrequencySetFocus), NULL, this);
     m_cboReportFrequency->Connect(wxEVT_KILL_FOCUS, wxFocusEventHandler(TopFrame::OnReportFrequencyKillFocus), NULL, this);
+    
+    m_auiNbookCtrl->Connect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanging), NULL, this);
 }
 
 TopFrame::~TopFrame()
@@ -853,6 +855,8 @@ TopFrame::~TopFrame()
     //-------------------
     // Disconnect Events
     //-------------------
+    m_auiNbookCtrl->Disconnect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanging), NULL, this);
+    
     this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(TopFrame::topFrame_OnClose));
     this->Disconnect(wxEVT_PAINT, wxPaintEventHandler(TopFrame::topFrame_OnPaint));
     this->Disconnect(wxEVT_SIZE, wxSizeEventHandler(TopFrame::topFrame_OnSize));

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -212,6 +212,8 @@ class TopFrame : public wxFrame
 
         virtual void OnSystemColorChanged(wxSysColourChangedEvent& event) { event.Skip(); }
         
+        virtual void OnNotebookPageChanging(wxAuiNotebookEvent& event) { event.Skip(); }
+        
         void setVoiceKeyerButtonLabel_(wxString filename);
         
     public:


### PR DESCRIPTION
This PR disables controls and tabs on the main window that aren't yet (?) supported by RADE in order to avoid user confusion. Various stats that are relevant for non-RADE are also changed to report "unk" instead when RADE is the current mode.