### PR TITLE
PulseAudio/PortAudio: Only support default sample rate.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -827,6 +827,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix issue preventing rtkit from being compiled-in on Ubuntu 22.04. (PR #954)
     * PulseAudio: Make sure we can only do one stop() at a time. (PR #955, #961)
     * macOS: Fix audio-related crash with certain devices. (PR #958, #960)
+    * PulseAudio/PortAudio: Only support default sample rate. (PR #964)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/audio/PortAudioEngine.cpp
+++ b/src/audio/PortAudioEngine.cpp
@@ -167,6 +167,7 @@ std::vector<int> PortAudioEngine::getSupportedSampleRates(wxString deviceName, A
     {
         if (device.name.IsSameAs(deviceName))
         {
+#if 0
             PaStreamParameters streamParameters;
             
             streamParameters.device = device.deviceId;
@@ -204,6 +205,9 @@ std::vector<int> PortAudioEngine::getSupportedSampleRates(wxString deviceName, A
             {
                 result.push_back(device.defaultSampleRate);
             }
+#endif // 0
+            result.push_back(device.defaultSampleRate);
+            break;
         }
     }
     

--- a/src/audio/PulseAudioEngine.cpp
+++ b/src/audio/PulseAudioEngine.cpp
@@ -256,6 +256,7 @@ std::vector<int> PulseAudioEngine::getSupportedSampleRates(wxString deviceName, 
 {
     std::vector<int> result;
     
+#if 0
     int index = 0;
     while (IAudioEngine::StandardSampleRates[index] != -1)
     {
@@ -264,6 +265,17 @@ std::vector<int> PulseAudioEngine::getSupportedSampleRates(wxString deviceName, 
             result.push_back(IAudioEngine::StandardSampleRates[index]);
         }
         index++;
+    }
+#endif
+    
+    auto devList = getAudioDeviceList(direction);
+    for (auto& dev : devList)
+    {
+        if (dev.name == deviceName)
+        {
+            result.push_back(dev.defaultSampleRate);
+            break;
+        }
     }
     
     return result;


### PR DESCRIPTION
Based on feedback in #963, this PR only reports the default sample rate as supported on PulseAudio/pipewire. Out of an abundance of caution, the same is also done for PortAudio support (not used by default on Windows/macOS/Linux).