### PR TITLE
Force left-to-right rendering of UI elements.

### DIFF
--- a/src/gui/controls/plot.cpp
+++ b/src/gui/controls/plot.cpp
@@ -46,6 +46,10 @@ END_EVENT_TABLE()
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 PlotPanel::PlotPanel(wxWindow* parent, const char* plotName) : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, plotName)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     m_zoomFactor        = 1.0;
     m_firstPass         = true;
     m_line_color        = 0;

--- a/src/gui/controls/plot_scalar.cpp
+++ b/src/gui/controls/plot_scalar.cpp
@@ -49,6 +49,10 @@ PlotScalar::PlotScalar(wxWindow* parent,
                        const char* plotName)
     : PlotPanel(parent, plotName)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     int i;
 
     m_rCtrl = GetClientRect();

--- a/src/gui/controls/plot_scatter.cpp
+++ b/src/gui/controls/plot_scatter.cpp
@@ -38,6 +38,10 @@ BEGIN_EVENT_TABLE(PlotScatter, PlotPanel)
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 PlotScatter::PlotScatter(wxWindow* parent) : PlotPanel(parent)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     clearCurrentSamples();
 
     // defaults so we start off with something sensible

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -53,6 +53,10 @@ END_EVENT_TABLE()
 PlotSpectrum::PlotSpectrum(wxWindow* parent, float *magdB, int n_magdB, 
                            float min_mag_db, float max_mag_db, bool clickTune): PlotPanel(parent)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     m_greyscale     = 0;
     m_Bufsz         = GetMaxClientSize();
     m_newdata       = false;

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -59,7 +59,10 @@ END_EVENT_TABLE()
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 PlotWaterfall::PlotWaterfall(wxWindow* parent, bool graticule, int colour): PlotPanel(parent)
 {
-
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     for(int i = 0; i < 255; i++)
     {
         m_heatmap_lut[i] = heatmap((float)i, 0.0, 255.0);

--- a/src/gui/dialogs/dlg_audiooptions.cpp
+++ b/src/gui/dialogs/dlg_audiooptions.cpp
@@ -88,6 +88,10 @@ void AudioOptsDialog::buildTestControls(PlotScalar **plotScalar, wxButton **btnT
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 AudioOptsDialog::AudioOptsDialog(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", title, wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -55,6 +55,10 @@ EasySetupDialog::EasySetupDialog(wxWindow* parent, wxWindowID id, const wxString
     , serialPortTestObject_(nullptr)
     , hasAppliedChanges_(false)
 {    
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", title, wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/dlg_filter.cpp
+++ b/src/gui/dialogs/dlg_filter.cpp
@@ -59,6 +59,10 @@ extern wxMutex g_mutexProtectingCallbackData;
 FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool *newSpkOutFilter,
                      wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", title, wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -44,6 +44,10 @@ extern wxConfigBase *pConfig;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", title, wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/dlg_ptt.cpp
+++ b/src/gui/dialogs/dlg_ptt.cpp
@@ -48,6 +48,10 @@ extern wxConfigBase *pConfig;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=--=-=-=-=
 ComPortsDlg::ComPortsDlg(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", title, wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -60,6 +60,10 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     : wxFrame(parent, id, title, pos, size, style)
     , tipWindow_(nullptr)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     if (wxGetApp().customConfigFileName != "")
     {
         SetTitle(wxString::Format("%s (%s)", _("FreeDV Reporter"), wxGetApp().customConfigFileName));

--- a/src/gui/dialogs/monitor_volume_adj.cpp
+++ b/src/gui/dialogs/monitor_volume_adj.cpp
@@ -30,6 +30,10 @@ MonitorVolumeAdjPopup::MonitorVolumeAdjPopup( wxWindow* parent, ConfigurationDat
     : wxPopupTransientWindow(parent)
     , configVal_(configVal)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
     wxStaticBoxSizer* mainSizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Monitor volume (dB)"));
     
     volumeSlider_ = new wxSlider(mainSizer->GetStaticBox(), wxID_ANY, configVal, -40, 0, wxDefaultPosition, wxSize(250, -1), wxSL_AUTOTICKS | wxSL_LABELS);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -165,7 +165,12 @@ public:
     int m_tabCtrlHeight;
 };
  
-TabFreeAuiNotebook::TabFreeAuiNotebook() : wxAuiNotebook() { }
+TabFreeAuiNotebook::TabFreeAuiNotebook() : wxAuiNotebook() 
+{ 
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+}
 TabFreeAuiNotebook::TabFreeAuiNotebook(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size, long style)
         : wxAuiNotebook(parent, id, pos, size, style) { }
     
@@ -311,6 +316,10 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 //=========================================================================
 TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxFrame(parent, id, title, pos, size, style)
 {
+    // XXX - FreeDV only supports English but makes a best effort to at least use regional formatting
+    // for e.g. numbers. Thus, we only need to override layout direction.
+    SetLayoutDirection(wxLayout_LeftToRight);
+    
 #if wxUSE_ACCESSIBILITY
     // Initialize accessibility logic
     SetAccessible(new NameOverrideAccessible([&]() {


### PR DESCRIPTION
This PR resolves #965 by forcing window rendering to occur left-to-right rather than right-to-left (on Windows and Linux, at least). By doing this, we avoid having to make wider changes around locale handling (i.e. forcing rendering of numbers/dates to en_US-style).