### PR TITLE
Add ctest to verify RADE losses between TX and RX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,6 +718,13 @@ endif(NOT ENABLE_ASAN AND NOT ENABLE_RTSAN)
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES DISABLED TRUE)
 set_tests_properties(fullduplex_RADEV1_repeated PROPERTIES LABELS stress_test)
 
+if(NOT ENABLE_RTSAN)
+# Note: loading/saving feature files is currently not RT-safe
+add_test(NAME rade_loss
+         COMMAND sh -c "${CMAKE_CURRENT_SOURCE_DIR}/test/test_rade_loss.sh")
+set_tests_properties(rade_loss PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
+endif(NOT ENABLE_RTSAN)
+
 DefineAudioTest(700D)
 DefineAudioTest(700E)
 DefineAudioTest(1600)

--- a/test/test_rade_loss.sh
+++ b/test/test_rade_loss.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Determine sox driver to use for recording/playback
+OPERATING_SYSTEM=`uname`
+SOX_DRIVER=alsa
+FREEDV_BINARY=src/freedv
+if [ "$OPERATING_SYSTEM" == "Darwin" ]; then
+    SOX_DRIVER=coreaudio
+    FREEDV_BINARY=src/FreeDV.app/Contents/MacOS/freedv
+fi
+
+createVirtualAudioCable () {
+    CABLE_NAME=$1
+    pactl load-module module-null-sink sink_name=$CABLE_NAME sink_properties=device.description=$CABLE_NAME 
+}
+
+FREEDV_RADIO_TO_COMPUTER_DEVICE="${FREEDV_RADIO_TO_COMPUTER_DEVICE:-FreeDV_Radio_To_Computer}"
+FREEDV_COMPUTER_TO_SPEAKER_DEVICE="${FREEDV_COMPUTER_TO_SPEAKER_DEVICE:-FreeDV_Computer_To_Speaker}"
+FREEDV_MICROPHONE_TO_COMPUTER_DEVICE="${FREEDV_MICROPHONE_TO_COMPUTER_DEVICE:-FreeDV_Microphone_To_Computer}"
+FREEDV_COMPUTER_TO_RADIO_DEVICE="${FREEDV_COMPUTER_TO_RADIO_DEVICE:-FreeDV_Computer_To_Radio}"
+
+# Automated script to help find audio dropouts.
+# NOTE: this must be run from "build_linux". Also assumes PulseAudio/pipewire.
+if [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    DRIVER_INDEX_FREEDV_RADIO_TO_COMPUTER=$(createVirtualAudioCable FreeDV_Radio_To_Computer)
+    DRIVER_INDEX_FREEDV_COMPUTER_TO_SPEAKER=$(createVirtualAudioCable FreeDV_Computer_To_Speaker)
+    DRIVER_INDEX_FREEDV_MICROPHONE_TO_COMPUTER=$(createVirtualAudioCable FreeDV_Microphone_To_Computer)
+    DRIVER_INDEX_FREEDV_COMPUTER_TO_RADIO=$(createVirtualAudioCable FreeDV_Computer_To_Radio)
+    DRIVER_INDEX_LOOPBACK=`pactl load-module module-loopback source="FreeDV_Computer_To_Radio.monitor" sink="FreeDV_Radio_To_Computer"`
+fi
+
+# Determine correct record device to retrieve TX data
+FREEDV_CONF_FILE=freedv-ctest-reporting.conf 
+
+PLAY_DEVICE="$FREEDV_RADIO_TO_COMPUTER_DEVICE"
+if [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    REC_DEVICE="$FREEDV_COMPUTER_TO_RADIO_DEVICE.monitor"
+else
+    REC_DEVICE="$FREEDV_COMPUTER_TO_RADIO_DEVICE"
+fi
+
+# Generate config file
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+if [ "$FREEDV_RADIO_TO_COMPUTER_DEVICE" == "FreeDV_Radio_To_Computer" ] && [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    sed "s/@FREEDV_RADIO_TO_COMPUTER_DEVICE@/$FREEDV_RADIO_TO_COMPUTER_DEVICE.monitor/g" $SCRIPTPATH/$FREEDV_CONF_FILE.tmpl > $(pwd)/$FREEDV_CONF_FILE
+else
+    sed "s/@FREEDV_RADIO_TO_COMPUTER_DEVICE@/$FREEDV_RADIO_TO_COMPUTER_DEVICE/g" $SCRIPTPATH/$FREEDV_CONF_FILE.tmpl > $(pwd)/$FREEDV_CONF_FILE
+fi
+
+sed "s/@FREEDV_COMPUTER_TO_RADIO_DEVICE@/$FREEDV_COMPUTER_TO_RADIO_DEVICE/g" $(pwd)/$FREEDV_CONF_FILE > $(pwd)/$FREEDV_CONF_FILE.tmp
+mv $(pwd)/$FREEDV_CONF_FILE.tmp $(pwd)/$FREEDV_CONF_FILE
+sed "s/@FREEDV_COMPUTER_TO_SPEAKER_DEVICE@/$FREEDV_COMPUTER_TO_SPEAKER_DEVICE/g" $(pwd)/$FREEDV_CONF_FILE > $(pwd)/$FREEDV_CONF_FILE.tmp
+mv $(pwd)/$FREEDV_CONF_FILE.tmp $(pwd)/$FREEDV_CONF_FILE
+
+if [ "$FREEDV_MICROPHONE_TO_COMPUTER_DEVICE" == "FreeDV_Microphone_To_Computer" ] && [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    sed "s/@FREEDV_MICROPHONE_TO_COMPUTER_DEVICE@/$FREEDV_MICROPHONE_TO_COMPUTER_DEVICE.monitor/g" $(pwd)/$FREEDV_CONF_FILE > $(pwd)/$FREEDV_CONF_FILE.tmp
+else
+    sed "s/@FREEDV_MICROPHONE_TO_COMPUTER_DEVICE@/$FREEDV_MICROPHONE_TO_COMPUTER_DEVICE/g" $(pwd)/$FREEDV_CONF_FILE > $(pwd)/$FREEDV_CONF_FILE.tmp
+fi
+mv $(pwd)/$FREEDV_CONF_FILE.tmp $(pwd)/$FREEDV_CONF_FILE
+
+# Start recording
+if [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    parecord --channels=1 --rate 8000 --file-format=wav --device "$REC_DEVICE" --latency 1 test.wav &
+else
+    sox -t $SOX_DRIVER "$REC_DEVICE" -c 1 -r 8000 -t wav test.wav >/dev/null 2>&1 &
+fi
+RECORD_PID=$!
+
+# Start "radio"
+TIMES_BEFORE_KILL=1
+python3 $SCRIPTPATH/hamlibserver.py $RECORD_PID $TIMES_BEFORE_KILL &
+RADIO_PID=$!
+
+# Start FreeDV in test mode to record TX
+TX_ARGS="-txfile $(pwd)/rade_src/wav/all.wav -txfeaturefile $(pwd)/txfeatures.f32 "
+$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut tx -utmode RADE $TX_ARGS >tmp.log 2>&1 &
+
+FDV_PID=$!
+
+#if [ "$OPERATING_SYSTEM" != "Linux" ]; then
+#    xctrace record --template "Audio System Trace" --window 2m --output "instruments_trace_${FDV_PID}.trace" --attach $FDV_PID
+#fi
+
+#sleep 30 
+#screencapture ../screenshot.png
+#wpctl status
+#pw-top -b -n 5
+wait $FDV_PID
+cat tmp.log
+
+# Stop recording, play back in RX mode
+kill $RECORD_PID
+
+if [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    paplay --channels=1 --rate 8000 --file-format=wav --device "$PLAY_DEVICE" --latency 1 test.wav &
+else
+    sox -t $SOX_DRIVER "$PLAY_DEVICE" -c 1 -r 8000 -t wav test.wav >/dev/null 2>&1 &
+fi
+PLAY_PID=$!
+$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADE -rxfeaturefile $(pwd)/rxfeatures.f32 >tmp.log 2>&1 &
+FDV_PID=$!
+
+#if [ "$OPERATING_SYSTEM" != "Linux" ]; then
+#    xctrace record --template "Audio System Trace" --window 2m --output "instruments_trace_${FDV_PID}.trace" --attach $FDV_PID
+#fi
+wait $FDV_PID
+FREEDV_EXIT_CODE=$?
+cat tmp.log
+kill $PLAY_PID
+
+# Run feature files through loss tool
+python3 $(pwd)/rade_src/loss.py txfeatures.f32 rxfeatures.f32 --loss_test 0.15 --acq_time_test 0.5
+
+# Clean up PulseAudio virtual devices
+if [ "$OPERATING_SYSTEM" == "Linux" ]; then
+    pactl unload-module $DRIVER_INDEX_LOOPBACK
+    pactl unload-module $DRIVER_INDEX_FREEDV_RADIO_TO_COMPUTER
+    pactl unload-module $DRIVER_INDEX_FREEDV_COMPUTER_TO_SPEAKER
+    pactl unload-module $DRIVER_INDEX_FREEDV_COMPUTER_TO_RADIO
+    pactl unload-module $DRIVER_INDEX_FREEDV_MICROPHONE_TO_COMPUTER
+fi
+
+# End radio process as it's no longer needed
+kill $RADIO_PID
+
+exit $FREEDV_EXIT_CODE


### PR DESCRIPTION
Based on feedback received outside of GitHub, this PR adds some additional testing to make sure that the RX and TX pipelines do not introduce unnecessary loss during the RADE encode and decode process.