### PR TITLE
Windows: Fix intermittent disappearance of audio devices

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -862,6 +862,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * PulseAudio/PortAudio: Only support default sample rate. (PR #964)
     * Force left-to-right rendering of UI elements. (PR #966)
     * macOS: improve behavior with Bluetooth devices. (PR #971)
+    * Windows: Fix intermittent disappearance of audio devices. (PR #974)
 2. Documentation:
     * Add missing dependency for macOS builds to README. (PR #925; thanks @relistan!)
     * Add note about using XWayland on Linux. (PR #926)

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -451,7 +451,7 @@ void WASAPIAudioDevice::stop()
             renderCaptureThread_.join();
         }
         
-        if (renderClient_ != nullptr || captureClient_ != nullptr)
+        if (renderClient_ || captureClient_)
         {
             HRESULT hr = client_->Stop();
             if (FAILED(hr))
@@ -500,7 +500,7 @@ void WASAPIAudioDevice::stop()
 
 bool WASAPIAudioDevice::isRunning()
 {
-    return (renderClient_ != nullptr) || (captureClient_ != nullptr);
+    return (renderClient_) || (captureClient_);
 }
 
 int WASAPIAudioDevice::getLatencyInMicroseconds()
@@ -556,7 +556,7 @@ void WASAPIAudioDevice::clearHelperRealTime()
 void WASAPIAudioDevice::renderAudio_(ComPtr<IAudioRenderClient> renderClient)
 {
     // If client is no longer available, abort
-    if (renderClient == nullptr)
+    if (!renderClient)
     {
         return;
     }
@@ -615,7 +615,7 @@ void WASAPIAudioDevice::renderAudio_(ComPtr<IAudioRenderClient> renderClient)
 void WASAPIAudioDevice::captureAudio_(ComPtr<IAudioCaptureClient> captureClient)
 {
     // If client is no longer available, abort
-    if (captureClient == nullptr)
+    if (!captureClient)
     {
         return;
     }

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -36,8 +36,9 @@
 
 thread_local HANDLE WASAPIAudioDevice::HelperTask_ = nullptr;
     
-WASAPIAudioDevice::WASAPIAudioDevice(ComPtr<IAudioClient> client, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels)
+WASAPIAudioDevice::WASAPIAudioDevice(ComPtr<IAudioClient> client, ComPtr<IMMDevice> device, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels)
     : client_(client)
+    , device_(device)
     , renderClient_(nullptr)
     , captureClient_(nullptr)
     , direction_(direction)
@@ -63,9 +64,10 @@ WASAPIAudioDevice::~WASAPIAudioDevice()
     auto prom = std::make_shared<std::promise<void> >(); 
     auto fut = prom->get_future();
     enqueue_([&]() {
-        client_ = nullptr;
         renderClient_ = nullptr;
         captureClient_ = nullptr;
+        client_ = nullptr;
+        device_ = nullptr;
         prom->set_value();
     });
     fut.wait(); 

--- a/src/audio/WASAPIAudioDevice.h
+++ b/src/audio/WASAPIAudioDevice.h
@@ -34,6 +34,7 @@
 #include "IAudioEngine.h"
 #include "IAudioDevice.h"
 #include "../util/Win32COMObject.h"
+#include "../util/Win32ComPointer.h"
 
 class WASAPIAudioDevice : public Win32COMObject, public IAudioDevice
 {
@@ -68,12 +69,12 @@ public:
 protected:
     friend class WASAPIAudioEngine;
 
-    WASAPIAudioDevice(IAudioClient* client, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels);
+    WASAPIAudioDevice(ComPtr<IAudioClient> client, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels);
 
 private:
-    IAudioClient* client_;
-    IAudioRenderClient* renderClient_;
-    IAudioCaptureClient* captureClient_;
+    ComPtr<IAudioClient> client_;
+    ComPtr<IAudioRenderClient> renderClient_;
+    ComPtr<IAudioCaptureClient> captureClient_;
     IAudioEngine::AudioDirection direction_;
     int sampleRate_;
     int numChannels_;
@@ -91,8 +92,8 @@ private:
     bool isFloatingPoint_;
     short* tmpBuf_;
 
-    void renderAudio_();
-    void captureAudio_();
+    void renderAudio_(ComPtr<IAudioRenderClient> renderClient);
+    void captureAudio_(ComPtr<IAudioCaptureClient> captureClient);
     void copyFromWindowsBuffer_(void* buf, int numFrames);
     void copyToWindowsBuffer_(void* buf, int numFrames);
 

--- a/src/audio/WASAPIAudioDevice.h
+++ b/src/audio/WASAPIAudioDevice.h
@@ -69,10 +69,11 @@ public:
 protected:
     friend class WASAPIAudioEngine;
 
-    WASAPIAudioDevice(ComPtr<IAudioClient> client, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels);
+    WASAPIAudioDevice(ComPtr<IAudioClient> client, ComPtr<IMMDevice> device, IAudioEngine::AudioDirection direction, int sampleRate, int numChannels);
 
 private:
     ComPtr<IAudioClient> client_;
+    ComPtr<IMMDevice> device_;
     ComPtr<IAudioRenderClient> renderClient_;
     ComPtr<IAudioCaptureClient> captureClient_;
     IAudioEngine::AudioDirection direction_;

--- a/src/audio/WASAPIAudioDevice.h
+++ b/src/audio/WASAPIAudioDevice.h
@@ -34,7 +34,7 @@
 #include "IAudioEngine.h"
 #include "IAudioDevice.h"
 #include "../util/Win32COMObject.h"
-#include "../util/Win32ComPointer.h"
+#include "../util/Win32COMPointer.h"
 
 class WASAPIAudioDevice : public Win32COMObject, public IAudioDevice
 {

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -124,9 +124,9 @@ void WASAPIAudioEngine::stop()
     auto prom = std::make_shared<std::promise<void> >();
     auto fut = prom->get_future();
     enqueue_([&]() {
+        devEnumerator_ = nullptr;
         inputDeviceList_ = nullptr;
         outputDeviceList_ = nullptr;
-        devEnumerator_ = nullptr;
         prom->set_value();
     });
     fut.wait();
@@ -295,7 +295,7 @@ std::shared_ptr<IAudioDevice> WASAPIAudioEngine::getAudioDevice(wxString deviceN
                 int finalNumChannels = std::max(numChannels, dev.minChannels);
                 finalNumChannels = std::min(finalNumChannels, dev.maxChannels);
 
-                auto devPtr = new WASAPIAudioDevice(client, direction, finalSampleRate, finalNumChannels);
+                auto devPtr = new WASAPIAudioDevice(client, device, direction, finalSampleRate, finalNumChannels);
                 result = std::shared_ptr<IAudioDevice>(devPtr);
             }
         }

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -129,8 +129,8 @@ void WASAPIAudioEngine::stop()
         outputDeviceList_ = nullptr;
         
         // Invalidate cached devices.
-        cachedInputDeviceList.clear();
-        cachedOutputDeviceList.clear();
+        cachedInputDeviceList_.clear();
+        cachedOutputDeviceList_.clear();
         
         prom->set_value();
     });

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -496,14 +496,15 @@ AudioDeviceSpecification WASAPIAudioEngine::getDeviceSpecification_(ComPtr<IMMDe
 
 std::string WASAPIAudioEngine::getUTF8String_(LPWSTR str)
 {
-    std::vector<char> buffer; 
     std::string val = "";  
     int size = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
     if (size > 0) 
     {
-        buffer.resize(size);
-        WideCharToMultiByte(CP_UTF8, 0, str, -1, static_cast<LPSTR>(&buffer[0]), buffer.size(), NULL, NULL);
-        val = std::string(&buffer[0]);
+        char* tmp = new char[size];
+        assert(tmp != nullptr);
+        WideCharToMultiByte(CP_UTF8, 0, str, -1, tmp, size, NULL, NULL);
+        val = tmp;
+        delete[] tmp;
     }
     return val;
 }

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -326,7 +326,7 @@ std::vector<int> WASAPIAudioEngine::getSupportedSampleRates(wxString deviceName,
     return fut.get();
 }
 
-AudioDeviceSpecification WASAPIAudioEngine::getDeviceSpecification_(IMMDevice* device)
+AudioDeviceSpecification WASAPIAudioEngine::getDeviceSpecification_(ComPtr<IMMDevice> device)
 {
     // Get device name
     ComPtr<IPropertyStore> propStore = nullptr;

--- a/src/audio/WASAPIAudioEngine.h
+++ b/src/audio/WASAPIAudioEngine.h
@@ -30,6 +30,7 @@
 #include <initguid.h>
 #include <mmdeviceapi.h>
 #include "../util/Win32COMObject.h"
+#include "../util/Win32COMPointer.h"
 #include "IAudioEngine.h"
 
 class WASAPIAudioEngine : public Win32COMObject, public IAudioEngine
@@ -48,11 +49,11 @@ public:
 protected:
 
 private:
-    IMMDeviceEnumerator* devEnumerator_;
-    IMMDeviceCollection* inputDeviceList_;
-    IMMDeviceCollection* outputDeviceList_;
+    ComPtr<IMMDeviceEnumerator> devEnumerator_;
+    ComPtr<IMMDeviceCollection> inputDeviceList_;
+    ComPtr<IMMDeviceCollection> outputDeviceList_;
 
-    AudioDeviceSpecification getDeviceSpecification_(IMMDevice* device);
+    AudioDeviceSpecification getDeviceSpecification_(ComPtr<IMMDevice> device);
     std::string getUTF8String_(LPWSTR str);
 };
 

--- a/src/audio/WASAPIAudioEngine.h
+++ b/src/audio/WASAPIAudioEngine.h
@@ -52,6 +52,9 @@ private:
     ComPtr<IMMDeviceEnumerator> devEnumerator_;
     ComPtr<IMMDeviceCollection> inputDeviceList_;
     ComPtr<IMMDeviceCollection> outputDeviceList_;
+    
+    std::vector<AudioDeviceSpecification> cachedInputDeviceList_;
+    std::vector<AudioDeviceSpecification> cachedOutputDeviceList_;
 
     AudioDeviceSpecification getDeviceSpecification_(ComPtr<IMMDevice> device);
     std::string getUTF8String_(LPWSTR str);

--- a/src/util/Win32COMPointer.h
+++ b/src/util/Win32COMPointer.h
@@ -1,0 +1,205 @@
+//=========================================================================
+// Name:            Win32COMPointer.h
+// Purpose:         Smart pointer implementation for COM objects.
+//                  Original implementation at https://learn.microsoft.com/en-us/archive/msdn-magazine/2015/february/windows-with-c-com-smart-pointers-revisited.
+//
+// Authors:         Kenny Kerr with modifications by Mooneer Salem
+// License:
+//
+//  All rights reserved.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//=========================================================================
+
+#ifndef WIN32_COM_POINTER_H
+#define WIN32_COM_POINTER_H
+
+template <typename Interface>
+class ComPtr
+{
+public:
+    // Hide AddRef and Release to prevent overriding ComPtr counting
+    class RemoveAddRefRelease : public Interface
+    {
+        ULONG __stdcall AddRef();
+        ULONG __stdcall Release();
+    };
+    
+    ComPtr() noexcept = default;
+    ComPtr(ComPtr const & other) noexcept :
+      m_ptr(other.m_ptr)
+    {
+      InternalAddRef();
+    }
+    
+    ComPtr(ComPtr&& other) noexcept
+        : m_ptr(other.m_ptr)
+    {
+        other.m_ptr = nullptr;
+    }
+    
+    template <typename T>
+    ComPtr(ComPtr<T> const & other) noexcept :
+      m_ptr(other.m_ptr)
+    {
+      InternalAddRef();
+    }
+    
+    template <typename T>
+    ComPtr(ComPtr<T> && other) noexcept :
+      m_ptr(other.m_ptr)
+    {
+      other.m_ptr = nullptr;
+    }
+    
+    ~ComPtr() noexcept
+    {
+      InternalRelease();
+    }
+  
+    RemoveAddRefRelease<Interface> * operator->() const noexcept
+    {
+        return static_cast<RemoveAddRefRelease<Interface> *>(m_ptr);
+    }
+    
+    ComPtr & operator=(ComPtr const & other) noexcept
+    {
+      InternalCopy(other.m_ptr);
+      return *this;
+    }
+    
+    template <typename T>
+    ComPtr & operator=(ComPtr<T> const & other) noexcept
+    {
+      InternalCopy(other.m_ptr);
+      return *this;
+    }
+    
+    template <typename T>
+    ComPtr & operator=(ComPtr<T> && other) noexcept
+    {
+      InternalMove(other);
+      return *this;
+    }
+    
+    void Swap(ComPtr & other) noexcept
+    {
+      Interface * temp = m_ptr;
+      m_ptr = other.m_ptr;
+      other.m_ptr = temp;
+    }
+    
+    template <typename Interface>
+    void swap(ComPtr<Interface> & left, 
+      ComPtr<Interface> & right) noexcept
+    {
+      left.Swap(right);
+    }
+    
+    explicit operator bool() const noexcept
+    {
+      return nullptr != m_ptr;
+    }
+    
+    void Reset() noexcept
+    {
+      InternalRelease();
+    }
+    
+    Interface * Get() const noexcept
+    {
+      return m_ptr;
+    }
+    
+    Interface * Detach() noexcept
+    {
+      Interface * temp = m_ptr;
+      m_ptr = nullptr;
+      return temp;
+    }
+    
+    void Copy(Interface * other) noexcept
+    {
+      InternalCopy(other);
+    }
+    
+    void Attach(Interface * other) noexcept
+    {
+      InternalRelease();
+      m_ptr = other;
+    }
+    
+    Interface ** GetAddressOf() noexcept
+    {
+      ASSERT(m_ptr == nullptr);
+      return &m_ptr;
+    }
+    
+    void CopyTo(Interface ** other) const noexcept
+    {
+      InternalAddRef();
+      *other = m_ptr;
+    }
+    
+    template <typename T>
+    ComPtr<T> As() const noexcept
+    {
+      ComPtr<T> temp;
+      m_ptr->QueryInterface(temp.GetAddressOf());
+      return temp;
+    }
+  
+private:
+  Interface * m_ptr = nullptr;
+  
+  void InternalAddRef() const noexcept
+  {
+    if (m_ptr)
+    {
+      m_ptr->AddRef();
+    }
+  }
+  
+  void InternalRelease() noexcept
+  {
+    Interface * temp = m_ptr;
+    if (temp)
+    {
+      m_ptr = nullptr;
+      temp->Release();
+    }
+  }
+  
+  void InternalCopy(Interface * other) noexcept
+  {
+    if (m_ptr != other)
+    {
+      InternalRelease();
+      m_ptr = other;
+      InternalAddRef();
+    }
+  }
+  
+  template <typename T>
+  void InternalMove(ComPtr<T> & other) noexcept
+  {
+    if (m_ptr != other.m_ptr)
+    {
+      InternalRelease();
+      m_ptr = other.m_ptr;
+      other.m_ptr = nullptr;
+    }
+  }
+};
+
+#endif // WIN32_COM_POINTER_H

--- a/src/util/Win32COMPointer.h
+++ b/src/util/Win32COMPointer.h
@@ -24,6 +24,8 @@
 #ifndef WIN32_COM_POINTER_H
 #define WIN32_COM_POINTER_H
 
+#include <cassert>
+
 template <typename Interface>
 class ComPtr
 {
@@ -31,11 +33,16 @@ public:
     // Hide AddRef and Release to prevent overriding ComPtr counting
     class RemoveAddRefRelease : public Interface
     {
+    private:
         ULONG __stdcall AddRef();
         ULONG __stdcall Release();
     };
     
     ComPtr() noexcept = default;
+    ComPtr(std::nullptr_t) noexcept
+        : m_ptr(nullptr)
+    { }
+
     ComPtr(ComPtr const & other) noexcept :
       m_ptr(other.m_ptr)
     {
@@ -67,9 +74,9 @@ public:
       InternalRelease();
     }
   
-    RemoveAddRefRelease<Interface> * operator->() const noexcept
+    RemoveAddRefRelease* operator->() const noexcept
     {
-        return static_cast<RemoveAddRefRelease<Interface> *>(m_ptr);
+        return static_cast<RemoveAddRefRelease*>(m_ptr);
     }
     
     ComPtr & operator=(ComPtr const & other) noexcept
@@ -99,9 +106,9 @@ public:
       other.m_ptr = temp;
     }
     
-    template <typename Interface>
+    template <typename Interface2>
     void swap(ComPtr<Interface> & left, 
-      ComPtr<Interface> & right) noexcept
+      ComPtr<Interface2> & right) noexcept
     {
       left.Swap(right);
     }
@@ -141,7 +148,7 @@ public:
     
     Interface ** GetAddressOf() noexcept
     {
-      ASSERT(m_ptr == nullptr);
+      assert(m_ptr == nullptr);
       return &m_ptr;
     }
     


### PR DESCRIPTION
This PR fixes an issue discovered during 2.0.1 testing where Windows audio devices intermittently disappear and cause incorrect error messages to appear. Several code changes were made:

1. The audio device list is now cached when first requested. This list is requested repeatedly during the audio device creation process, and it is theorized that some sort of Windows bug is causing the original issue.
2. COM pointer accesses are now wrapper in smart pointers to make sure reference counts are correct. This was done due to the possibility of accidentally freeing something that shouldn't be, but this doesn't appear to be the case. Still a good idea, though.
3. Slightly tweaked how Windows device names were converted to UTF-8, thinking that this was causing another buffer overflow. Also not the case, but still a good idea.