### PR TITLE
FreeDV Reporter: Use numeric sort for SNR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum OS X deployment version")
 
 set(PROJECT_NAME FreeDV)
-set(PROJECT_VERSION 2.0.1)
+set(PROJECT_VERSION 2.0.2)
 set(PROJECT_DESCRIPTION "HF Digital Voice for Radio Amateurs")
 set(PROJECT_HOMEPAGE_URL "https://freedv.org")
 
@@ -58,12 +58,12 @@ endif(NOT DEFINED LINUX)
 # Adds a tag to the end of the version string. Leave empty
 # for official release builds.
 if(NOT DEFINED FREEDV_VERSION_TAG)
-set(FREEDV_VERSION_TAG "")
+set(FREEDV_VERSION_TAG "dev")
 
 # Uncomment the below definition to cause the build to expire
 # six months from the day it was built. This should be commented
 # for official releases.
-#add_definitions(-DUNOFFICIAL_RELEASE)
+add_definitions(-DUNOFFICIAL_RELEASE)
 endif(NOT DEFINED FREEDV_VERSION_TAG)
 
 # Prevent in-source builds to protect automake/autoconf config.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -836,6 +836,11 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 # Release Notes
 
+## V2.0.1 TBD 2025
+
+1. Bugfixes:
+    * FreeDV Reporter: Use numeric sort for SNR. (PR #979)
+
 ## V2.0.1 July 2025
 
 1. Bugfixes:

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -45,6 +45,7 @@ extern FreeDVInterface freedvInterface;
 #define LAST_UPDATE_DATE_COL (13)
 #define RIGHTMOST_COL (LAST_UPDATE_DATE_COL + 1)
 
+#define UNKNOWN_SNR_VAL (-99)
 #define UNKNOWN_STR ""
 #define NUM_COLS (LAST_UPDATE_DATE_COL + 1)
 #define RX_ONLY_STATUS "RX Only"
@@ -1747,7 +1748,7 @@ int FreeDVReporterDialog::FreeDVReporterDataModel::Compare (const wxDataViewItem
             result = leftData->lastRxMode.CmpNoCase(rightData->lastRxMode);
             break;
         case SNR_COL:
-            result = leftData->snr.CmpNoCase(rightData->snr);
+            result = leftData->snrVal - rightData->snrVal;
             break;
         case LAST_UPDATE_DATE_COL:
             if (leftData->lastUpdateDate.IsValid() && rightData->lastUpdateDate.IsValid())
@@ -2173,6 +2174,7 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onUserConnectFn_(std::string
         
         temp->lastRxCallsign = UNKNOWN_STR;
         temp->lastRxMode = UNKNOWN_STR;
+        temp->snrVal = UNKNOWN_SNR_VAL;
         temp->snr = UNKNOWN_STR;
         
         // Default to sane colors for rows. If we need to highlight, the timer will change
@@ -2420,6 +2422,7 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onReceiveUpdateFn_(std::stri
                     
                 iter->second->lastRxCallsign = UNKNOWN_STR;
                 iter->second->lastRxMode = UNKNOWN_STR;
+                iter->second->snrVal = UNKNOWN_SNR_VAL;
                 iter->second->snr = UNKNOWN_STR;
                 iter->second->lastRxDate = wxDateTime();
             }
@@ -2427,6 +2430,7 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onReceiveUpdateFn_(std::stri
             {
                 isChanged |=
                     (sortingColumn == parent_->m_listSpots->GetColumn(SNR_COL) && iter->second->snr != snrString);
+                iter->second->snrVal = snr;
                 iter->second->snr = snrString;
                 iter->second->lastRxDate = wxDateTime::Now();
             }

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -245,6 +245,7 @@ class FreeDVReporterDialog : public wxFrame
                 wxString lastRxCallsign;
                 wxString lastRxMode;
                 wxString snr;
+                int snrVal;
                 wxString lastUpdate;
                 wxDateTime lastUpdateDate;
                 wxString userMessage;


### PR DESCRIPTION
Resolves #978 by using numeric sort instead of text sort for the SNR field.