### PR TITLE
Add Mic/Speaker volume control to main window.

### DIFF
--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -63,6 +63,12 @@ std::shared_ptr<void> MainFrame::designAnEQFilter(const char filterType[], float
 
 void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSampleRate)
 {
+    // Volume can be adjusted via main window without enabling filters
+    if (wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB != 0 && g_nSoundCards > 1)
+    {
+        cb->sbqMicInVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB, 0, txSampleRate);
+    }
+    
     // init Mic In Equaliser Filters
     if (cb->micInEQEnable && g_nSoundCards > 1) {
         assert(cb->sbqMicInBass == nullptr && cb->sbqMicInTreble == nullptr && cb->sbqMicInMid == nullptr);
@@ -70,12 +76,17 @@ void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSam
         cb->sbqMicInBass   = designAnEQFilter("bass", wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassFreqHz, wxGetApp().appConfiguration.filterConfiguration.micInChannel.bassGaindB, txSampleRate);
         cb->sbqMicInTreble = designAnEQFilter("treble", wxGetApp().appConfiguration.filterConfiguration.micInChannel.trebleFreqHz, wxGetApp().appConfiguration.filterConfiguration.micInChannel.trebleGaindB, txSampleRate);
         cb->sbqMicInMid    = designAnEQFilter("equalizer", wxGetApp().appConfiguration.filterConfiguration.micInChannel.midFreqHz, wxGetApp().appConfiguration.filterConfiguration.micInChannel.midGainDB, wxGetApp().appConfiguration.filterConfiguration.micInChannel.midQ, txSampleRate);
-        cb->sbqMicInVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB, 0, txSampleRate);
         
         // Note: vol can be a no-op!
         assert(cb->sbqMicInBass != nullptr && cb->sbqMicInTreble != nullptr && cb->sbqMicInMid != nullptr);
     }
 
+    // Volume can be adjusted via main window without enabling filters
+    if (wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB != 0)
+    {
+        cb->sbqSpkOutVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, 0, rxSampleRate);
+    }
+    
     // init Spk Out Equaliser Filters
 
     if (cb->spkOutEQEnable) {
@@ -85,7 +96,6 @@ void  MainFrame::designEQFilters(paCallBackData *cb, int rxSampleRate, int txSam
         cb->sbqSpkOutBass   = designAnEQFilter("bass", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.bassGaindB, rxSampleRate);
         cb->sbqSpkOutTreble = designAnEQFilter("treble", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.trebleGaindB, rxSampleRate);
         cb->sbqSpkOutMid    = designAnEQFilter("equalizer", wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midFreqHz, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midGainDB, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.midQ, rxSampleRate);
-        cb->sbqSpkOutVol    = designAnEQFilter("vol", 0, wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, 0, rxSampleRate);
         
         // Note: vol can be a no-op!
         assert(cb->sbqSpkOutBass != nullptr && cb->sbqSpkOutTreble != nullptr && cb->sbqSpkOutMid != nullptr);

--- a/src/gui/dialogs/dlg_filter.cpp
+++ b/src/gui/dialogs/dlg_filter.cpp
@@ -442,6 +442,17 @@ EQ FilterDlg::newEQ(wxWindow* parent, wxSizer *bs, wxString eqName, float maxFre
     return eq;
 }
 
+void FilterDlg::syncVolumes()
+{
+    m_MicInVol.gaindB = wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB;
+    m_MicInVol.gaindB = limit(m_MicInVol.gaindB, MIN_GAIN, MAX_GAIN);
+    setGain(&m_MicInVol);
+    
+    m_SpkOutVol.gaindB = wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB;
+    m_SpkOutVol.gaindB = limit(m_SpkOutVol.gaindB, MIN_GAIN, MAX_GAIN);
+    setGain(&m_SpkOutVol);
+}
+
 //-------------------------------------------------------------------------
 // ExchangeData()
 //-------------------------------------------------------------------------
@@ -743,7 +754,7 @@ void FilterDlg::updateControlState()
     m_MicInTreble.sliderFreq->Enable(wxGetApp().appConfiguration.filterConfiguration.micInChannel.eqEnable);
     m_MicInTreble.sliderGain->Enable(wxGetApp().appConfiguration.filterConfiguration.micInChannel.eqEnable);
     
-    m_MicInVol.sliderGain->Enable(wxGetApp().appConfiguration.filterConfiguration.micInChannel.eqEnable);
+    m_MicInVol.sliderGain->Enable(true);
     
     m_MicInDefault->Enable(wxGetApp().appConfiguration.filterConfiguration.micInChannel.eqEnable);
     
@@ -757,7 +768,7 @@ void FilterDlg::updateControlState()
     m_SpkOutTreble.sliderFreq->Enable(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable);
     m_SpkOutTreble.sliderGain->Enable(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable);
     
-    m_SpkOutVol.sliderGain->Enable(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable);
+    m_SpkOutVol.sliderGain->Enable(true);
     
     m_SpkOutDefault->Enable(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable);
     

--- a/src/gui/dialogs/dlg_filter.h
+++ b/src/gui/dialogs/dlg_filter.h
@@ -59,6 +59,8 @@ class FilterDlg : public wxDialog
         ~FilterDlg();
 
         void    ExchangeData(int inout);
+        
+        void syncVolumes();
 
     protected:
         // Handlers for events.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -666,6 +666,11 @@ void MainFrame::loadConfiguration_()
     snprintf(fmt, 15, "%0.1f dB", (double)g_txLevel / 10.0);
     wxString fmtString(fmt);
     m_txtTxLevelNum->SetLabel(fmtString);
+    
+    m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB * 10);
+    snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB);
+    fmtString = fmt;
+    m_txtMicSpkrLevelNum->SetLabel(fmtString);
 
     // Adjust frequency entry labels
     if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
@@ -1368,7 +1373,29 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         }
      }
      else
-     {         
+     {
+         // Synchronize changes with Filter dialog
+         auto sliderVal = 0.0;
+         if (g_tx)
+         {
+             sliderVal = wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB;
+         }
+         else
+         {
+             sliderVal = wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB;
+         }
+         char fmt[16];
+         m_sliderMicSpkrLevel->SetValue(sliderVal * 10);
+         snprintf(fmt, 15, "%0.1f dB", (double)sliderVal);
+         wxString fmtString(fmt);
+         m_txtMicSpkrLevelNum->SetLabel(fmtString);
+         
+         if (m_filterDialog != nullptr)
+         {
+             // Sync Filter dialog as well
+             m_filterDialog->syncVolumes();
+         }
+         
         int r;
 
         if (m_panelWaterfall->checkDT()) {

--- a/src/main.h
+++ b/src/main.h
@@ -426,6 +426,8 @@ class MainFrame : public TopFrame
         
         void OnChangeTxLevel( wxScrollEvent& event ) override;
         
+        void OnChangeMicSpkrLevel( wxScrollEvent& event ) override;
+        
         void OnChangeReportFrequency( wxCommandEvent& event ) override;
         void OnChangeReportFrequencyVerify( wxCommandEvent& event ) override;
         

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -699,12 +699,38 @@ void MainFrame::OnCmdSliderScroll(wxScrollEvent& event)
 void MainFrame::OnChangeTxLevel( wxScrollEvent& event )
 {
     char fmt[15];
+    
     g_txLevel = m_sliderTxLevel->GetValue();
     snprintf(fmt, 15, "%0.1f dB", (double)(g_txLevel)/10.0);
     wxString fmtString(fmt);
     m_txtTxLevelNum->SetLabel(fmtString);
     
     wxGetApp().appConfiguration.transmitLevel = g_txLevel;
+}
+
+//-------------------------------------------------------------------------
+// OnChangeMicSpkrLevel()
+//-------------------------------------------------------------------------
+void MainFrame::OnChangeMicSpkrLevel( wxScrollEvent& event )
+{
+    char fmt[15];
+    
+    auto sliderLevel = (double)m_sliderMicSpkrLevel->GetValue() / 10.0;
+    
+    if (g_tx)
+    {
+        wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB = sliderLevel;
+        m_newMicInFilter = true;
+    }
+    else
+    {
+        wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB = sliderLevel;
+        m_newSpkOutFilter = true;
+    }
+    
+    snprintf(fmt, 15, "%0.1f dB", (double)(sliderLevel));
+    wxString fmtString(fmt);
+    m_txtMicSpkrLevelNum->SetLabel(fmtString);
 }
 
 //-------------------------------------------------------------------------
@@ -967,6 +993,12 @@ void MainFrame::togglePTT(void) {
         g_tx = false;
         endingTx = false;
 
+        char fmt[16];
+        m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB * 10);
+        snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB);
+        wxString fmtString(fmt);
+        m_txtMicSpkrLevelNum->SetLabel(fmtString);
+        
         // tx-> rx transition, swap to the page we were on for last rx
         m_auiNbookCtrl->ChangeSelection(wxGetApp().appConfiguration.currentNotebookTab);
         
@@ -1068,6 +1100,12 @@ void MainFrame::togglePTT(void) {
         // g_tx governs when audio actually goes out during TX, so don't set to true until
         // after the delay occurs.
         g_tx = true;
+        
+        char fmt[16];
+        m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB * 10);
+        snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB);
+        wxString fmtString(fmt);
+        m_txtMicSpkrLevelNum->SetLabel(fmtString);
     }
 }
 

--- a/src/pipeline/EqualizerStep.cpp
+++ b/src/pipeline/EqualizerStep.cpp
@@ -62,12 +62,17 @@ std::shared_ptr<short> EqualizerStep::execute(std::shared_ptr<short> inputSample
 {
     memcpy(outputSamples_.get(), inputSamples.get(), sizeof(short)*numInputSamples);
     
+    std::shared_ptr<void> tmpVolFilter = *volFilter_;
+    if (tmpVolFilter != nullptr)
+    {
+        sox_biquad_filter(tmpVolFilter.get(), outputSamples_.get(), outputSamples_.get(), numInputSamples);
+    }
+    
     if (*enableFilter_)
     {
         std::shared_ptr<void> tmpBassFilter = *bassFilter_;
         std::shared_ptr<void> tmpTrebleFilter = *trebleFilter_;
         std::shared_ptr<void> tmpMidFilter = *midFilter_;
-        std::shared_ptr<void> tmpVolFilter = *volFilter_;
         if (tmpBassFilter != nullptr)
         {
             sox_biquad_filter(tmpBassFilter.get(), outputSamples_.get(), outputSamples_.get(), numInputSamples);
@@ -79,10 +84,6 @@ std::shared_ptr<short> EqualizerStep::execute(std::shared_ptr<short> inputSample
         if (tmpMidFilter != nullptr)
         {
             sox_biquad_filter(tmpMidFilter.get(), outputSamples_.get(), outputSamples_.get(), numInputSamples);
-        }
-        if (tmpVolFilter != nullptr)
-        {
-            sox_biquad_filter(tmpVolFilter.get(), outputSamples_.get(), outputSamples_.get(), numInputSamples);
         }
     }
     

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -678,6 +678,28 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     
     rightSizer->Add(txLevelSizer, 2, wxALL | wxEXPAND, 2);
     
+    // Mic/Speaker Level slider
+    wxBoxSizer* micSpeakerLevelSizer = new wxStaticBoxSizer(new wxStaticBox(m_panel, wxID_ANY, _("Mic/Spkr &Level"), wxDefaultPosition, wxSize(100,-1)), wxVERTICAL);
+    
+    // Sliders are integer values, so we're multiplying min/max by 10 here to allow 1 decimal precision.
+    m_sliderMicSpkrLevel = new wxSlider(m_panel, wxID_ANY, 0, -200, 200, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS);
+    m_sliderMicSpkrLevel->SetMinSize(wxSize(150,-1));
+    micSpeakerLevelSizer->Add(m_sliderMicSpkrLevel, 1, wxALIGN_CENTER_HORIZONTAL, 0);
+
+#if wxUSE_ACCESSIBILITY 
+    // Add accessibility class so that the values are read back correctly.
+    auto micSpkrSliderAccessibility = new LabelOverrideAccessible([&]() {
+        return m_txtMicSpkrLevelNum->GetLabel();
+    });
+    m_sliderMicSpkrLevel->SetAccessible(micSpkrSliderAccessibility);
+#endif // wxUSE_ACCESSIBILITY
+ 
+    m_txtMicSpkrLevelNum = new wxStaticText(m_panel, wxID_ANY, wxT("0 dB"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+    m_txtMicSpkrLevelNum->SetMinSize(wxSize(100,-1));
+    micSpeakerLevelSizer->Add(m_txtMicSpkrLevelNum, 0, wxALIGN_CENTER_HORIZONTAL, 0);
+    
+    rightSizer->Add(micSpeakerLevelSizer, 2, wxALL | wxEXPAND, 2);
+    
     /* new --- */
 
     //------------------------------
@@ -850,6 +872,18 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_sliderTxLevel->Connect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnChangeTxLevel), NULL, this);
     m_sliderTxLevel->Connect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeTxLevel), NULL, this);
     
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_LINEUP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_PAGEUP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    
     m_cboReportFrequency->Connect(wxEVT_TEXT_ENTER, wxCommandEventHandler(TopFrame::OnChangeReportFrequency), NULL, this);
     m_cboReportFrequency->Connect(wxEVT_TEXT, wxCommandEventHandler(TopFrame::OnChangeReportFrequencyVerify), NULL, this);
     m_cboReportFrequency->Connect(wxEVT_COMBOBOX, wxCommandEventHandler(TopFrame::OnChangeReportFrequency), NULL, this);
@@ -927,6 +961,18 @@ TopFrame::~TopFrame()
     m_sliderTxLevel->Disconnect(wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler(TopFrame::OnChangeTxLevel), NULL, this);
     m_sliderTxLevel->Disconnect(wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler(TopFrame::OnChangeTxLevel), NULL, this);
     m_sliderTxLevel->Disconnect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnChangeTxLevel), NULL, this);
+    
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_LINEUP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_PAGEUP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
+    m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
     
     m_cboReportFrequency->Disconnect(wxEVT_TEXT_ENTER, wxCommandEventHandler(TopFrame::OnChangeReportFrequency), NULL, this);
     m_cboReportFrequency->Disconnect(wxEVT_TEXT, wxCommandEventHandler(TopFrame::OnChangeReportFrequencyVerify), NULL, this);

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -106,6 +106,8 @@ class TopFrame : public wxFrame
 
         wxStaticText* m_txtTxLevelNum;
         wxSlider* m_sliderTxLevel;
+        wxSlider* m_sliderMicSpkrLevel;
+        wxStaticText* m_txtMicSpkrLevelNum;
         
         wxSlider* m_sliderSQ;        
         wxCheckBox* m_ckboxSQ;
@@ -203,6 +205,8 @@ class TopFrame : public wxFrame
         virtual void OnChangeTxMode( wxCommandEvent& event ) { event.Skip(); }
         
         virtual void OnChangeTxLevel( wxScrollEvent& event ) { event.Skip(); }
+        
+        virtual void OnChangeMicSpkrLevel( wxScrollEvent& event ) { event.Skip(); }
         
         virtual void OnChangeReportFrequency( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnChangeReportFrequencyVerify( wxCommandEvent& event ) { event.Skip(); }


### PR DESCRIPTION
Resolves #952 by adding a volume control to the main window for microphone/speaker volume, tied to the equivalent controls in the Filter dialog. These controls were also made so that they're always enabled (no need to enable the equalizer in the Filter dialog to use).

Note: an alternate solution (hide the graph on the Filter dialog to make it smaller) was originally agreed to by the PLT, but given additional user feedback, was switched to adding the additional control instead.