### PR TITLE
Fix compile failure when compiling from tarball.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -840,6 +840,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * FreeDV Reporter: Use numeric sort for SNR. (PR #979)
+    * Fix compile failure when compiling from tarball.(PR #985)
 2. Enhancements:
     * Add Mic/Speaker volume control to main window. (PR #980)
 

--- a/cmake/CheckGit.cmake
+++ b/cmake/CheckGit.cmake
@@ -30,7 +30,12 @@ function(CheckGitVersion)
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE GIT_HASH
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE GIT_RESULT
         )
+
+    if (GIT_RESULT)
+        set(GIT_HASH "None")
+    endif (GIT_RESULT)
 
     CheckGitRead(GIT_HASH_CACHE)
     if (NOT EXISTS ${post_configure_dir})


### PR DESCRIPTION
Resolves #981 by adding an additional check for the return value of the `git` call that FreeDV does during the build process. If `git` fails, we then use "None" instead of the git hash.