### PR TITLE
Fix typo in Feature Request form.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -50,7 +50,7 @@ body:
     - type: dropdown
       id: feature-legal
       attributes:
-          label: Non-standard compiler
+          label: Legal worldwide
           description: Is the feature legal for Amateur Radio worldwide? Export Control regulations in many countries limit speech coding to a minimum of 700 bit/s and forbids encryption.
           options:
               - "Yes"


### PR DESCRIPTION
It was noted in #973 that "Non-standard compiler" was listed twice on the GitHub version of the Feature Request form. This PR corrects that error.