### PR TITLE
Update Hamlib to v4.6.4.

### DIFF
--- a/cmake/BuildHamlib.cmake
+++ b/cmake/BuildHamlib.cmake
@@ -16,7 +16,7 @@ endif(MINGW AND CMAKE_CROSSCOMPILING)
 
 include(ExternalProject)
 ExternalProject_Add(build_hamlib
-    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.6.3.zip
+    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.6.4.zip
     BUILD_IN_SOURCE 1
     INSTALL_DIR external/dist
     PATCH_COMMAND ${HAMLIB_PATCH_CMD}


### PR DESCRIPTION
Just noticed that [4.6.4 came out a couple of weeks ago](https://github.com/Hamlib/Hamlib/releases/tag/4.6.4), so this PR updates the Linux and macOS builds accordingly.