### PR TITLE
Move Spectrum plot averaging setting to Tools->Options.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -846,6 +846,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix compile failure when compiling from tarball.(PR #985)
 2. Enhancements:
     * Add Mic/Speaker volume control to main window. (PR #980)
+    * Move less used Spectrum plot configuration to free up space on main window. (PR #996)
 3. Build system:
     * Update Hamlib to v4.6.4. (PR #989)
 

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -341,6 +341,30 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
 
     sizerDisplay->Add(sbSizer_reporterColor, 0, wxALL | wxEXPAND, 5);
     
+    // Plot settings
+    wxStaticBox* sb_PlotSettings = new wxStaticBox(m_displayTab, wxID_ANY, _("Plot settings"));
+    wxStaticBoxSizer* sbSizer_PlotSettings =  new wxStaticBoxSizer(sb_PlotSettings, wxVERTICAL);
+
+    wxBoxSizer* spectrumPanelControlSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    wxStaticText* labelAveraging = new wxStaticText(sb_PlotSettings, wxID_ANY, wxT("Average spectrum plot across"), wxDefaultPosition, wxDefaultSize, 0);
+    spectrumPanelControlSizer->Add(labelAveraging, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    wxString samplingChoices[] = {
+        "1",
+        "2",
+        "3"
+    };
+    m_cbxNumSpectrumAveraging = new wxComboBox(sb_PlotSettings, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 3, samplingChoices, wxCB_DROPDOWN | wxCB_READONLY);
+    m_cbxNumSpectrumAveraging->SetSelection(wxGetApp().appConfiguration.currentSpectrumAveraging);
+    spectrumPanelControlSizer->Add(m_cbxNumSpectrumAveraging, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    wxStaticText* labelSamples = new wxStaticText(sb_PlotSettings, wxID_ANY, wxT("sample(s)"), wxDefaultPosition, wxDefaultSize, 0);
+    spectrumPanelControlSizer->Add(labelSamples, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    
+    sbSizer_PlotSettings->Add(spectrumPanelControlSizer, 0, wxALL | wxEXPAND, 5);
+    sizerDisplay->Add(sbSizer_PlotSettings, 0, wxALL | wxEXPAND, 5);
+    
     m_displayTab->SetSizer(sizerDisplay);
     
     // Voice Keyer tab
@@ -847,6 +871,9 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_ckboxNoFreqModeChanges->SetValue(!wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges && !wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly);
         m_ckboxFrequencyEntryAsKHz->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz);
         
+        /* Plot settings */
+        m_cbxNumSpectrumAveraging->SetSelection(wxGetApp().appConfiguration.currentSpectrumAveraging);
+         
         /* Voice Keyer */
 
         m_txtCtrlVoiceKeyerWaveFilePath->SetValue(wxGetApp().appConfiguration.voiceKeyerWaveFilePath);
@@ -1009,6 +1036,9 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.halfDuplexMode = m_ckHalfDuplex->GetValue();
         wxGetApp().appConfiguration.multipleReceiveEnabled = m_ckboxMultipleRx->GetValue();
         wxGetApp().appConfiguration.multipleReceiveOnSingleThread = m_ckboxSingleRxThread->GetValue();
+        
+        /* Plot settings */
+        wxGetApp().appConfiguration.currentSpectrumAveraging = m_cbxNumSpectrumAveraging->GetSelection();
         
         /* Voice Keyer */
 

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -107,6 +107,9 @@ class OptionsDlg : public wxDialog
         wxColourPickerCtrl* m_freedvReporterRxForegroundColor;
         wxColourPickerCtrl* m_freedvReporterMsgBackgroundColor;
         wxColourPickerCtrl* m_freedvReporterMsgForegroundColor;
+        
+        /* Spectrum plot averaging */
+        wxComboBox*             m_cbxNumSpectrumAveraging;
 
         /* Voice Keyer */
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -937,39 +937,11 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     // Add Spectrum Plot window
     wxPanel* spectrumPanel = new wxPanel(m_auiNbookCtrl);
     
-    wxFlexGridSizer* spectrumPanelSizer = new wxFlexGridSizer(2, 1, 5, 5);
-    wxBoxSizer* spectrumPanelControlSizer = new wxBoxSizer(wxHORIZONTAL);
-    spectrumPanelSizer->AddGrowableRow(0);
-    spectrumPanelSizer->AddGrowableCol(0);
-    
     // Actual Spectrum plot
     m_panelSpectrum = new PlotSpectrum(spectrumPanel, g_avmag,
                                        MODEM_STATS_NSPEC*((float)MAX_F_HZ/MODEM_STATS_MAX_F_HZ));
-    m_panelSpectrum->SetToolTip(_("Double click to tune, middle click to re-center"));
-    spectrumPanelSizer->Add(m_panelSpectrum, 0, wxALL | wxEXPAND, 5);
-    
-    // Spectrum plot control interface
-    wxStaticText* labelAveraging = new wxStaticText(spectrumPanel, wxID_ANY, wxT("Average across"), wxDefaultPosition, wxDefaultSize, 0);
-    spectrumPanelControlSizer->Add(labelAveraging, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-    
-    wxString samplingChoices[] = {
-        "1",
-        "2",
-        "3"
-    };
-    m_cbxNumSpectrumAveraging = new wxComboBox(spectrumPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 3, samplingChoices, wxCB_DROPDOWN | wxCB_READONLY);
-    m_cbxNumSpectrumAveraging->SetSelection(wxGetApp().appConfiguration.currentSpectrumAveraging);
-    spectrumPanelControlSizer->Add(m_cbxNumSpectrumAveraging, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-    
-    m_cbxNumSpectrumAveraging->Connect(wxEVT_TEXT, wxCommandEventHandler(MainFrame::OnAveragingChange), NULL, this);
-    
-    wxStaticText* labelSamples = new wxStaticText(spectrumPanel, wxID_ANY, wxT("sample(s)"), wxDefaultPosition, wxDefaultSize, 0);
-    spectrumPanelControlSizer->Add(labelSamples, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-    
-    spectrumPanelSizer->Add(spectrumPanelControlSizer, 0, wxALL | wxEXPAND, 5);
-    spectrumPanel->SetSizerAndFit(spectrumPanelSizer);
-    
-    m_auiNbookCtrl->AddPage(spectrumPanel, _("Spectrum"), false, wxNullBitmap);
+    m_panelSpectrum->SetToolTip(_("Double click to tune, middle click to re-center"));    
+    m_auiNbookCtrl->AddPage(m_panelSpectrum, _("Spectrum"), false, wxNullBitmap);
 
     // Add Demod Input window
     m_panelDemodIn = new PlotScalar((wxFrame*) m_auiNbookCtrl, 1, WAVEFORM_PLOT_TIME, 1.0/WAVEFORM_PLOT_FS, -1, 1, 1, 0.2, "%2.1f", 0);
@@ -1270,7 +1242,6 @@ MainFrame::~MainFrame()
     wxGetApp().appConfiguration.currentFreeDVMode = mode;
     wxGetApp().appConfiguration.save(pConfig);
 
-    m_cbxNumSpectrumAveraging->Disconnect(wxEVT_TEXT, wxCommandEventHandler(MainFrame::OnAveragingChange), NULL, this);
     m_togBtnOnOff->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnOnOffUI), NULL, this);
     m_togBtnAnalog->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnAnalogClickUI), NULL, this);
 
@@ -1334,11 +1305,6 @@ MainFrame::~MainFrame()
 void MainFrame::OnIdle(wxIdleEvent &evt) {
 }
 #endif
-
-void MainFrame::OnAveragingChange(wxCommandEvent& event)
-{
-    wxGetApp().appConfiguration.currentSpectrumAveraging = m_cbxNumSpectrumAveraging->GetSelection();
-}
 
 #ifdef _USE_TIMER
 //----------------------------------------------------------------
@@ -1425,7 +1391,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         
         // Note: each element in this combo box is a numeric value starting from 1,
         // so just incrementing the selected index should get us the correct results.
-        m_panelSpectrum->setNumAveraging(m_cbxNumSpectrumAveraging->GetSelection() + 1);
+        m_panelSpectrum->setNumAveraging(wxGetApp().appConfiguration.currentSpectrumAveraging + 1);
         m_panelSpectrum->addOffset(freedvInterface.getCurrentRxModemStats()->foff);
         m_panelSpectrum->setSync(freedvInterface.getSync() ? true : false);
         m_panelSpectrum->m_newdata = true;

--- a/src/main.h
+++ b/src/main.h
@@ -295,7 +295,6 @@ class MainFrame : public TopFrame
         PlotScalar*             m_panelDemodIn;
         PlotScalar*             m_panelTestFrameErrors;
         PlotScalar*             m_panelTestFrameErrorsHist;
-        wxComboBox*             m_cbxNumSpectrumAveraging;
 
         bool                    m_RxRunning;
 
@@ -352,8 +351,6 @@ class MainFrame : public TopFrame
         virtual void topFrame_OnClose( wxCloseEvent& event ) override;
         virtual void OnCloseFrame(wxCloseEvent& event);
         void OnExitClick(wxCommandEvent& event);
-        
-        void OnAveragingChange(wxCommandEvent& event);
 
         void startTxStream();
         void startRxStream();


### PR DESCRIPTION
Based on comments in #967, this PR moves the Spectrum plot averaging control to Tools->Options to free up some space. This was done as this control is not used often.