### PR TITLE
Enable AGC functionality in Speex.

### DIFF
--- a/src/config/FilterConfiguration.cpp
+++ b/src/config/FilterConfiguration.cpp
@@ -32,6 +32,7 @@ FilterConfiguration::FilterConfiguration()
     , codec2LPCPostFilterGamma("/Filter/codec2LPCPostFilter/Gamma", CODEC2_LPC_PF_GAMMA*100)
     , codec2LPCPostFilterBeta("/Filter/codec2LPCPostFilter/Beta", CODEC2_LPC_PF_BETA*100)
     , speexppEnable("/Filter/speexpp_enable", true)
+    , agcEnabled("/Filter/agcEnable", true)
     , enable700CEqualizer("/Filter/700C_EQ", true)
 {
     std::function<float(float)> gammaBetaSaveProcessor = [](float val) {
@@ -75,6 +76,7 @@ void FilterConfiguration::load(wxConfigBase* config)
     
     load_(config, speexppEnable);
     load_(config, enable700CEqualizer);
+    load_(config, agcEnabled);
 }
 
 void FilterConfiguration::save(wxConfigBase* config)
@@ -89,4 +91,5 @@ void FilterConfiguration::save(wxConfigBase* config)
     
     save_(config, speexppEnable);
     save_(config, enable700CEqualizer);
+    save_(config, agcEnabled);
 }

--- a/src/config/FilterConfiguration.h
+++ b/src/config/FilterConfiguration.h
@@ -89,6 +89,7 @@ public:
     ConfigurationDataElement<float> codec2LPCPostFilterBeta;
     
     ConfigurationDataElement<bool> speexppEnable;
+    ConfigurationDataElement<bool> agcEnabled;
     ConfigurationDataElement<bool> enable700CEqualizer;
     
     virtual void load(wxConfigBase* config) override;

--- a/src/gui/dialogs/dlg_filter.h
+++ b/src/gui/dialogs/dlg_filter.h
@@ -75,6 +75,7 @@ class FilterDlg : public wxDialog
         void    OnBassBoost(wxScrollEvent& event);
 
         void    OnSpeexppEnable(wxScrollEvent& event);
+        void    OnAgcEnable(wxScrollEvent& event);
         void    On700C_EQ(wxScrollEvent& event);
 
         void    OnMicInBassFreqScroll(wxScrollEvent& event) { sliderToFreq(&m_MicInBass, true); }
@@ -115,6 +116,7 @@ class FilterDlg : public wxDialog
 
         wxCheckBox*   m_ckboxSpeexpp;
         wxCheckBox*   m_ckbox700C_EQ;
+        wxCheckBox*   m_ckboxAgcEnabled;
         
         wxStdDialogButtonSizer* m_sdbSizer5;
         wxButton*     m_sdbSizer5OK;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,7 @@ std::atomic<int>   g_tx;
 float g_snr;
 std::atomic<bool>  g_half_duplex;
 std::atomic<bool>  g_voice_keyer_tx;
+std::atomic<bool>  g_agcEnabled;
 SRC_STATE  *g_spec_src;  // sample rate converter for spectrum
 
 // sending and receiving Call Sign data
@@ -659,6 +660,9 @@ void MainFrame::loadConfiguration_()
     {
         SetSize(w, h);
     });
+    
+    // Load AGC state
+    g_agcEnabled = wxGetApp().appConfiguration.filterConfiguration.agcEnabled;
     
     g_txLevel = wxGetApp().appConfiguration.transmitLevel;
     char fmt[15];

--- a/src/pipeline/SpeexStep.h
+++ b/src/pipeline/SpeexStep.h
@@ -50,8 +50,9 @@ private:
     SpeexPreprocessState* speexStateObj_;
     int numSamplesPerSpeexRun_;
     struct FIFO* inputSampleFifo_;
-
     std::shared_ptr<short> outputSamples_;
+    
+    void updateAgcState_();
 };
 
 


### PR DESCRIPTION
This PR resolves #988 by doing the following:

1. Adds AGC setting to Tools->Filter. This is enabled by default and will become disabled unless Speex is also enabled (as the latter is a prerequisite). The updated Filter dialog appears as follows:

<img width="748" height="803" alt="image" src="https://github.com/user-attachments/assets/1d3d7d80-3aa3-4747-b139-bee58d233dab" />

2. Adds logic inside `SpeexStep` to follow changes to (1) in real-time and enable/disable AGC in the Speex library as appropriate.