### PR TITLE
Various GUI and FreeDV Reporter optimizations

### DIFF
--- a/src/gui/controls/plot_scalar.h
+++ b/src/gui/controls/plot_scalar.h
@@ -53,7 +53,16 @@ class PlotScalar: public PlotPanel
          void setLogY(int logy) { m_logy = logy; }
 
          void clearSamples();
-         
+        
+    private:
+        struct MinMaxPoints
+        {
+            int y1;
+            int y2;
+        };
+
+        MinMaxPoints* lineMap_;
+ 
     protected:
 
          int      m_channels;

--- a/src/gui/controls/plot_waterfall.h
+++ b/src/gui/controls/plot_waterfall.h
@@ -21,6 +21,7 @@
 #ifndef __FDMDV2_PLOT_WATERFALL__
 #define __FDMDV2_PLOT_WATERFALL__
 
+#include <deque>
 #include <wx/graphics.h>
 
 #include "plot.h"
@@ -72,12 +73,15 @@ class PlotWaterfall : public PlotPanel
         int         m_colour;
         int         m_modem_stats_max_f_hz;
 
-        wxBitmap* m_fullBmp;
         int m_imgHeight;
         int m_imgWidth;
         
+        std::deque<wxBitmap*> waterfallSlices_;
+        
         void        OnDoubleClickCommon(wxMouseEvent& event);
 
+        void cleanupSlices_();
+        
         DECLARE_EVENT_TABLE()
 };
 

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -259,6 +259,9 @@ class FreeDVReporterDialog : public wxFrame
                 bool isPendingDelete;
                 wxDateTime deleteTime;
 
+                // Controls whether this row is pending update
+                bool isPendingUpdate;
+
                 // Controls the current highlight color
                 wxColour foregroundColor;
                 wxColour backgroundColor;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1946,9 +1946,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
     
         // Voice Keyer state machine
         VoiceKeyerProcessEvent(VK_DT);
-
-        // Detect Sync state machine
-        DetectSyncProcessEvent();
     }
 }
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -330,12 +330,6 @@ class MainFrame : public TopFrame
     int                     vk_state;
     void VoiceKeyerProcessEvent(int vk_event);
 
-    // Detect Sync state machine
-
-    int                     ds_state;
-    float                   ds_rx_time;
-    void DetectSyncProcessEvent(void);
-
         void StopPlayFileToMicIn(void);
         void StopPlaybackFileFromRadio();
         void StopRecFileFromRadio();

--- a/src/reporting/FreeDVReporter.h
+++ b/src/reporting/FreeDVReporter.h
@@ -104,12 +104,7 @@ public:
     bool isValidForReporting();
     
 private:
-    // Required elements to implement execution thread for FreeDV Reporter.
-    std::vector<std::function<void()> > fnQueue_;
-    std::mutex fnQueueMutex_;
-    std::condition_variable fnQueueConditionVariable_;
-    bool isExiting_;
-    std::thread fnQueueThread_;
+    std::mutex objMutex_;
     bool isConnecting_;
     std::atomic<bool> isFullyConnected_;
     
@@ -141,7 +136,6 @@ private:
         
     void connect_();
     
-    void threadEntryPoint_();
     void freqChangeImpl_(uint64_t frequency);
     void transmitImpl_(std::string mode, bool tx);
     void sendMessageImpl_(std::string message);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -325,60 +325,6 @@ void resample_for_plot(struct FIFO *plotFifo, short buf[], short* dec_samples, i
     codec2_fifo_write(plotFifo, dec_samples, nSamples);
 }
 
-// State machine to detect sync
-
-void MainFrame::DetectSyncProcessEvent(void) {
-    int next_state = ds_state;
-
-    switch(ds_state) {
-
-    case DS_IDLE:
-        if (freedvInterface.getSync() == 1) {
-            next_state = DS_SYNC_WAIT;
-            ds_rx_time = 0;
-        }
-        break;
-
-    case DS_SYNC_WAIT:
-
-        // In this state we wait for a few seconds of valid sync.
-
-        if (freedvInterface.getSync() == 0) {
-            next_state = DS_IDLE;
-        } else {
-            ds_rx_time += DT;
-        }
-
-        if (ds_rx_time >= DS_SYNC_WAIT_TIME) {
-            ds_rx_time = 0;
-            next_state = DS_UNSYNC_WAIT;
-        }
-        break;
-
-    case DS_UNSYNC_WAIT:
-
-        // In this state we wait for sync to end
-
-        if (freedvInterface.getSync() == 0) {
-            ds_rx_time += DT;
-            if (ds_rx_time >= DS_SYNC_WAIT_TIME) {
-                next_state = DS_IDLE;
-            }
-        } else {
-            ds_rx_time = 0;
-        }
-        break;
-
-    default:
-        // catch anything we missed
-
-        next_state = DS_IDLE;
-    }
-
-    ds_state = next_state;
-}
-
-
 void MainFrame::executeOnUiThreadAndWait_(std::function<void()> fn)
 {
     std::mutex funcMutex;

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -6,9 +6,15 @@ if(LINUX)
     set(UTIL_LINUX_FILES timespec.c)
 endif(LINUX)
 
+if(APPLE)
+    set(THREADED_OBJECT_FILES ThreadedObject.mm)
+else(APPLE)
+    set(THREADED_OBJECT_FILES ThreadedObject.cpp)
+endif(APPLE)
+
 add_library(fdv_util STATIC
     SocketIoClient.cpp
-    ThreadedObject.cpp
+    ${THREADED_OBJECT_FILES}
     ThreadedTimer.cpp
     TcpConnectionHandler.cpp
     logging/ulog.c

--- a/src/util/SocketIoClient.cpp
+++ b/src/util/SocketIoClient.cpp
@@ -142,16 +142,22 @@ void SocketIoClient::onReceive_(char* buf, int length)
 
 void SocketIoClient::emitImpl_(std::string eventName, nlohmann::json params)
 {
-    nlohmann::json msgEmit = {eventName, params};
-    std::string msgToSend = SOCKET_IO_TX_PREFIX + msgEmit.dump();
-    connection_->send(msgToSend);
+    if (connection_)
+    {
+        nlohmann::json msgEmit = {eventName, params};
+        std::string msgToSend = SOCKET_IO_TX_PREFIX + msgEmit.dump();
+        connection_->send(msgToSend);
+    }
 }
 
 void SocketIoClient::emitImpl_(std::string eventName)
 {
-    nlohmann::json msgEmit = {eventName};
-    std::string msgToSend = SOCKET_IO_TX_PREFIX + msgEmit.dump();
-    connection_->send(msgToSend);
+    if (connection_)
+    {
+        nlohmann::json msgEmit = {eventName};
+        std::string msgToSend = SOCKET_IO_TX_PREFIX + msgEmit.dump();
+        connection_->send(msgToSend);
+    }
 }
 
 void SocketIoClient::handleWebsocketRequest_(WebSocketClient* s, websocketpp::connection_hdl hdl, message_ptr msg)
@@ -197,8 +203,7 @@ void SocketIoClient::handleEngineIoMessage_(char* ptr, int length)
 
             // "ping" -- send pong
             connection_->send("3");
-            pingTimer_.stop();
-            pingTimer_.start();
+            pingTimer_.restart();
             break;
         }
         case '4':

--- a/src/util/TcpConnectionHandler.h
+++ b/src/util/TcpConnectionHandler.h
@@ -51,7 +51,7 @@ protected:
     virtual void onReceive_(char* buf, int length) = 0;
     
 private:
-    ThreadedTimer recvTimer_;
+    std::thread receiveThread_;
     ThreadedTimer reconnectTimer_;
     int socket_;
     std::atomic<bool> ipv4Complete_;

--- a/src/util/ThreadedObject.h
+++ b/src/util/ThreadedObject.h
@@ -23,10 +23,15 @@
 #ifndef THREADED_OBJECT_H
 #define THREADED_OBJECT_H
 
+#if defined(__APPLE__)
+#include <dispatch/dispatch.h>
+#else
 #include <thread>
 #include <mutex>
 #include <condition_variable>
 #include <deque>
+#endif // defined(__APPLE__)
+
 #include <functional>
 
 class ThreadedObject
@@ -35,13 +40,18 @@ public:
     virtual ~ThreadedObject();
 
 protected:
-    ThreadedObject();
+    ThreadedObject(ThreadedObject* parent = nullptr);
     
     // Enqueues some code to run on a different thread.
     // @param timeoutMilliseconds Timeout to wait for lock. Note: if we can't get a lock within the timeout, the function doesn't run!
     void enqueue_(std::function<void()> fn, int timeoutMilliseconds = 0);
     
 private:
+    ThreadedObject* parent_;
+    
+#if defined(__APPLE__)
+    dispatch_queue_t queue_;
+#else
     bool isDestroying_;
     std::thread objectThread_;
     std::deque<std::function<void()> > eventQueue_;
@@ -49,6 +59,7 @@ private:
     std::condition_variable_any eventQueueCV_;
 
     void eventLoop_();
+#endif // defined(__APPLE__)
 };
 
 #endif // THREADED_OBJECT_H

--- a/src/util/ThreadedObject.mm
+++ b/src/util/ThreadedObject.mm
@@ -1,0 +1,56 @@
+//=========================================================================
+// Name:            ThreadedObject.mm
+// Purpose:         macOS-specific implementation of ThreadedObject using GCD.
+//
+// Authors:         Mooneer Salem
+// License:
+//
+//  All rights reserved.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//=========================================================================
+
+#include <cassert>
+
+#include "ThreadedObject.h"
+
+ThreadedObject::ThreadedObject(ThreadedObject* parent)
+    : parent_(parent)
+{
+    dispatch_queue_t parentQueue;
+    
+    if (parent_ != nullptr)
+    {
+        parentQueue = parent_->queue_;
+    }
+    else
+    {
+        parentQueue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+    }
+    
+    queue_ = dispatch_queue_create_with_target(nullptr, DISPATCH_QUEUE_SERIAL, parentQueue);
+    assert(queue_ != nil);
+}
+
+ThreadedObject::~ThreadedObject()
+{
+    // empty
+}
+
+void ThreadedObject::enqueue_(std::function<void()> fn, int timeoutMilliseconds)
+{
+    // note: timeout not implemented
+    dispatch_async(queue_, ^() {
+        fn();
+    });
+}

--- a/src/util/ThreadedTimer.h
+++ b/src/util/ThreadedTimer.h
@@ -44,11 +44,13 @@ public:
     
     void start();
     void stop();
+    void restart();
     
     bool isRunning();
     
 private:
     bool isDestroying_;
+    bool isRestarting_;
     std::thread objectThread_;
     std::mutex timerMutex_;
     std::condition_variable timerCV_;


### PR DESCRIPTION
This PR ports over the GUI and FreeDV Reporter optimizations done during #975 development for individual review. This is being done as (a) these changes have value individually but do not appear to impact ctest pass rates (the primary goal of the previously mentioned PR) and (b) to reduce the scope of the previous PR.

Changes made:

* `PlotScalar` (used for "Mic In" plot during TX): Use different algorithm for drawing lines to reduce the amount of drawing required.
* `PlotWaterfall`: Cache previously drawn waterfall slices to reduce the amount of drawing required.
* FreeDV Reporter:
    * Only trigger redraw if content of a row (excluding "Last Update") has changed *and* if the window is visible.
    * Remove inheritance from `ThreadedObject` in favor of using `std::mutex` to enforce access control. (Reduces overhead from unnecessary threads.)
* `TcpConnectionHandler`: 
    * Remove unnecessary timer in favor of long-running thread to handle data RX.
    * Reduce number of events enqueued from RX thread to main object thread to reduce context switching.
* `ThreadedObject`:
    * (macOS-only) Use Grand Central Dispatch instead of `std::thread` to take advantage of existing threads that are auto-created.
    * Feature enhancement: Allow objects to run in the context of parent `ThreadedObject` instances. (Currently unused.)
* `ThreadedTimer`: add `restart()` method to prevent repeatedly destroying and recreating threads.