### PR TITLE
Update Linux/macOS audio code to match Windows implementation more closely.

### DIFF
--- a/src/audio/MacAudioDevice.cpp
+++ b/src/audio/MacAudioDevice.cpp
@@ -867,7 +867,8 @@ void MacAudioDevice::startRealTimeWork()
 
 void MacAudioDevice::stopRealTimeWork(bool fastMode)
 {
-    dispatch_semaphore_wait(sem_, dispatch_time(DISPATCH_TIME_NOW, (AUDIO_SAMPLE_BLOCK_MSEC * MS_TO_NSEC) >> (fastMode ? 1 : 0)));
+    auto timeToWaitMilliseconds = ((1000 * chosenFrameSize_) / sampleRate_) >> (fastMode ? 1 : 0);
+    dispatch_semaphore_wait(sem_, dispatch_time(DISPATCH_TIME_NOW, MS_TO_NSEC * timeToWaitMilliseconds));
 }
 
 void MacAudioDevice::clearHelperRealTime()

--- a/src/audio/PulseAudioDevice.cpp
+++ b/src/audio/PulseAudioDevice.cpp
@@ -279,14 +279,15 @@ void PulseAudioDevice::setHelperRealTime()
 void PulseAudioDevice::startRealTimeWork()
 {
     sleepFallback_ = false;
+}
 
+void PulseAudioDevice::stopRealTimeWork(bool fastMode)
+{
     if (clock_gettime(CLOCK_MONOTONIC, &ts_) == -1)
     {
         sleepFallback_ = true;
     }
-}
-void PulseAudioDevice::stopRealTimeWork(bool fastMode)
-{
+
     if (sleepFallback_)
     {
         // Fallback to simple sleep.


### PR DESCRIPTION
Updates Linux and macOS audio code to begin the wait time interval during `stopRealTimeWork()` (and to calculate wait time similarly to what's done on Windows).