### PR TITLE
Fix various locale related bugs.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include <wx/cmdline.h>
 #include <wx/stdpaths.h>
 #include <wx/uiaction.h>
+#include <wx/uilocale.h>
 
 #include "git_version.h"
 #include "main.h"
@@ -515,7 +516,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
 bool MainApp::OnInit()
 {
     // Initialize locale.
-    m_locale.Init();
+    wxUILocale::UseDefault();
 
     m_reporters.clear();
     m_reportCounter = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -220,8 +220,6 @@ class MainApp : public wxApp
         
         std::shared_ptr<LinkStep> linkStep;
 
-        wxLocale m_locale;
-
         int m_reportCounter;
     protected:
     private:


### PR DESCRIPTION
Per #1009, this PR fixes various bugs related to locales:

* macOS: Fix spurious error on startup when changing locales (tested with `src/FreeDV.app/Contents/MacOS/FreeDV -AppleLanguages “en-US” -AppleLocale “de-DE”` per https://forum.xojo.com/t/start-app-in-a-different-language-with-different-locale-settings/25219)
* Linux: TBD