### PR TITLE
Add pkgconf dependency for macOS instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,24 @@ one to build FreeDV for ARM as well as for Intel Windows systems.
 Using MacPorts, most of the appropriate dependencies can be installed by:
 
 ```
-$ sudo port install automake git libtool sox +universal cmake wget
+$ sudo port install automake git libtool sox +universal cmake wget pkgconf
 ```
 
 and on Homebrew:
 
 ```
-$ brew install automake libtool git sox cmake wget
+$ brew install automake libtool git sox cmake wget pkgconf
 ```
 
 Once the dependencies are installed, you can then run the `build_osx.sh` script inside the source tree to build
 FreeDV and associated libraries (codec2, hamlib). A FreeDV.app app bundle will be created inside the build_osx/src
 folder which can be copied to your system's Applications folder.
+
+*Note: for distribution, code signing is required. The following commands can be run to enable this:*
+
+```
+CODESIGN_IDENTITY=[identity in your keychain] UNIV_BUILD=1 ./build_osx.sh
+cd build_osx
+make release
+```
+

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -857,6 +857,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 3. Build system:
     * Update Hamlib to v4.6.4. (PR #989)
     * macOS: Upgrade PyTorch to 2.7 (and NumPy to 2.3). (PR #1003)
+4. Documentation:
+    * Add pkgconf dependency for macOS instructions. (PR #1013)
 
 ## V2.0.1 July 2025
 


### PR DESCRIPTION
Resolves #1012 by adding pkgconf as a dependency in the macOS build instructions.