### PR TITLE
Prevent lockup/crash when testing Hamlib in PTT Config window.

### DIFF
--- a/src/gui/dialogs/dlg_ptt.h
+++ b/src/gui/dialogs/dlg_ptt.h
@@ -117,6 +117,8 @@ protected:
         
 private:
         void updateControlState();
+        
+        bool isTesting_;
     
 };
 


### PR DESCRIPTION
Per reports from off GitHub, this PR fixes an issue where FreeDV crashes if a user attempts to test PTT on the PTT Config window with an invalid configuration.