### PR TITLE
Linux: fix rendering bug for mic/speaker slider when transitioning from TX to RX.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -742,12 +742,12 @@ void MainFrame::loadConfiguration_()
 
     char fmt[15];
     m_sliderTxLevel->SetValue(g_txLevel);
-    snprintf(fmt, 15, "%0.1f dB", (double)g_txLevel / 10.0);
+    snprintf(fmt, 15, "%0.1f%s", (double)g_txLevel / 10.0, "dB");
     wxString fmtString(fmt);
     m_txtTxLevelNum->SetLabel(fmtString);
     
     m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB * 10);
-    snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB);
+    snprintf(fmt, 15, "%0.1f%s", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, "dB");
     fmtString = fmt;
     m_txtMicSpkrLevelNum->SetLabel(fmtString);
 
@@ -1576,7 +1576,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
          if ((sliderVal * 10) != m_sliderMicSpkrLevel->GetValue())
          {
              m_sliderMicSpkrLevel->SetValue(sliderVal * 10);
-             wxString fmt = wxString::Format(wxT("%0.1f dB"), (double)sliderVal);
+             wxString fmt = wxString::Format(wxT("%0.1f%s"), (double)sliderVal, _("dB"));
              m_txtMicSpkrLevelNum->SetLabel(fmt);
          
              if (m_filterDialog != nullptr)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1576,6 +1576,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
          if ((sliderVal * 10) != m_sliderMicSpkrLevel->GetValue())
          {
              m_sliderMicSpkrLevel->SetValue(sliderVal * 10);
+             m_sliderMicSpkrLevel->Refresh();
              wxString fmt = wxString::Format(wxT("%0.1f%s"), (double)sliderVal, _("dB"));
              m_txtMicSpkrLevelNum->SetLabel(fmt);
          

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -707,7 +707,7 @@ void MainFrame::OnChangeTxLevel( wxScrollEvent& event )
     float scaleFactor = exp(dbLoss/20.0 * log(10.0));
     g_txLevelScale.store(scaleFactor, std::memory_order_release);
 
-    snprintf(fmt, 15, "%0.1f dB", (double)(g_txLevel)/10.0);
+    snprintf(fmt, 15, "%0.1f%s", (double)(g_txLevel)/10.0, "dB");
     wxString fmtString(fmt);
     m_txtTxLevelNum->SetLabel(fmtString);
     
@@ -734,7 +734,7 @@ void MainFrame::OnChangeMicSpkrLevel( wxScrollEvent& event )
         m_newSpkOutFilter = true;
     }
     
-    snprintf(fmt, 15, "%0.1f dB", (double)(sliderLevel));
+    snprintf(fmt, 15, "%0.1f%s", (double)(sliderLevel), "dB");
     wxString fmtString(fmt);
     m_txtMicSpkrLevelNum->SetLabel(fmtString);
 }
@@ -999,9 +999,9 @@ void MainFrame::togglePTT(void) {
         g_tx.store(false, std::memory_order_release);
         endingTx = false;
 
-        char fmt[16];
+        char fmt[15];
         m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB * 10);
-        snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB);
+        snprintf(fmt, 15, "%0.1f%s", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, "dB");
         wxString fmtString(fmt);
         m_txtMicSpkrLevelNum->SetLabel(fmtString);
         
@@ -1115,7 +1115,7 @@ void MainFrame::togglePTT(void) {
         
         char fmt[16];
         m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB * 10);
-        snprintf(fmt, 15, "%0.1f dB", (double)wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB);
+        snprintf(fmt, 15, "%0.1f%s", (double)wxGetApp().appConfiguration.filterConfiguration.micInChannel.volInDB, "dB");
         wxString fmtString(fmt);
         m_txtMicSpkrLevelNum->SetLabel(fmtString);
     }

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1001,6 +1001,7 @@ void MainFrame::togglePTT(void) {
 
         char fmt[15];
         m_sliderMicSpkrLevel->SetValue(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB * 10);
+        m_sliderMicSpkrLevel->Refresh();
         snprintf(fmt, 15, "%0.1f%s", (double)wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.volInDB, "dB");
         wxString fmtString(fmt);
         m_txtMicSpkrLevelNum->SetLabel(fmtString);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -673,7 +673,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_sliderTxLevel->SetAccessible(txSliderAccessibility);
 #endif // wxUSE_ACCESSIBILITY
  
-    m_txtTxLevelNum = new wxStaticText(txLevelBox, wxID_ANY, wxT("0 dB"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+    m_txtTxLevelNum = new wxStaticText(txLevelBox, wxID_ANY, wxT("0dB"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
     m_txtTxLevelNum->SetMinSize(wxSize(100,-1));
     txLevelSizer->Add(m_txtTxLevelNum, 0, wxALIGN_CENTER_HORIZONTAL, 0);
     


### PR DESCRIPTION
Resolves #1019 by forcing a redraw of the mic/speaker level slider when transitioning from TX to RX. This PR also removes the space between the numeric value and "dB".