### PR TITLE
Fix waterfall flicker on macOS

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -858,6 +858,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Prevent lockup/crash when testing Hamlib in PTT Config window. (PR #1016)
     * Linux: fix rendering bug for mic/speaker slider when transitioning from TX to RX. (PR #1021)
     * Various unit test fixes to reduce failure rate in CI environment. (PR #1023)
+    * Fix waterfall flicker on macOS. (PR #1037)
 2. Enhancements:
     * Add Mic/Speaker volume control to main window. (PR #980, #1028)
     * Move less used Spectrum plot configuration to free up space on main window. (PR #996)

--- a/src/gui/controls/plot.cpp
+++ b/src/gui/controls/plot.cpp
@@ -173,7 +173,6 @@ void PlotPanel::drawGraticule(wxGraphicsContext* ctx)
     
     int p;
     char buf[STR_LENGTH];
-    wxString s;
 
     wxGraphicsFont tmpFont = ctx->CreateFont(GetFont(), GetForegroundColour());
     ctx->SetFont(tmpFont);

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -200,10 +200,20 @@ bool PlotWaterfall::repaintAll_(wxPaintEvent& evt)
     
 void PlotWaterfall::refreshData()
 {
-    int screenX = PLOT_BORDER + XLEFT_OFFSET;
-    int screenY = PLOT_BORDER + YBOTTOM_OFFSET;
-    RefreshRect(wxRect(screenX, screenY, m_imgWidth, m_imgHeight), false);
-}   
+    // Force redraw of entire control if not using RADE. This is determined
+    // by rxFreq == 0. We need to do this so that the frequency indicators
+    // redraw properly.
+    if (m_rxFreq == 0)
+    {
+        int screenX = PLOT_BORDER + XLEFT_OFFSET;
+        int screenY = PLOT_BORDER + YBOTTOM_OFFSET;
+        RefreshRect(wxRect(screenX, screenY, m_imgWidth, m_imgHeight), false);
+    }
+    else
+    {
+        Refresh();
+    }   
+}
 
 //----------------------------------------------------------------
 // draw()

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -72,6 +72,7 @@ PlotWaterfall::PlotWaterfall(wxWindow* parent, bool graticule, int colour): Plot
     m_Bufsz         = GetMaxClientSize();
     m_newdata       = false;
     m_firstPass     = true;
+    m_rxFreq = 0;
     m_line_color    = 0;
     m_modem_stats_max_f_hz = MODEM_STATS_MAX_F_HZ;
     dyImageData_ = nullptr;
@@ -201,7 +202,7 @@ void PlotWaterfall::refreshData()
 {
     int screenX = PLOT_BORDER + XLEFT_OFFSET;
     int screenY = PLOT_BORDER + YBOTTOM_OFFSET;
-    RefreshRect(wxRect(screenX, screenY, m_imgWidth, m_imgHeight));
+    RefreshRect(wxRect(screenX, screenY, m_imgWidth, m_imgHeight), false);
 }   
 
 //----------------------------------------------------------------
@@ -220,19 +221,6 @@ void PlotWaterfall::draw(wxGraphicsContext* gc, bool repaintDataOnly)
     // we want a bit map the size of m_rGrid
     wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
     
-    float px_per_sec = (float)m_rGrid.GetHeight() / WATERFALL_SECS_Y; 
-    float dy = m_dT * px_per_sec;
-    if (dy > 0 && waterfallSlices_.size() < (m_imgHeight / dy))
-    {
-        // Reset waterfall to black
-        wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
-        gc->SetBrush(ltGraphBkgBrush);
-        gc->SetPen(wxPen(BLACK_COLOR, 0));
-
-        auto alreadyDrawnPx = (dy * waterfallSlices_.size());
-        gc->DrawRectangle(PLOT_BORDER + XLEFT_OFFSET, PLOT_BORDER + YBOTTOM_OFFSET + alreadyDrawnPx, m_imgWidth, m_imgHeight - alreadyDrawnPx); 
-    }
-    
     if(m_newdata)
     {
         m_newdata = false;
@@ -244,7 +232,18 @@ void PlotWaterfall::draw(wxGraphicsContext* gc, bool repaintDataOnly)
     {
         gc->DrawBitmap(*bmp, PLOT_BORDER + XLEFT_OFFSET, yOffset + PLOT_BORDER + YBOTTOM_OFFSET, m_imgWidth, bmp->GetHeight());
         yOffset += bmp->GetHeight();
-    }    
+    }
+
+    if (yOffset < m_imgHeight)
+    {
+        // Reset waterfall to black
+        wxBrush ltGraphBkgBrush = wxBrush(BLACK_COLOR);
+        gc->SetBrush(ltGraphBkgBrush);
+        gc->SetPen(wxPen(BLACK_COLOR, 0));
+
+        //log_info("clearing all except %d px of waterfall", alreadyDrawnPx);
+        gc->DrawRectangle(PLOT_BORDER + XLEFT_OFFSET, PLOT_BORDER + YBOTTOM_OFFSET + yOffset, m_imgWidth, m_imgHeight - yOffset); 
+    }
 
     m_dT = DT;
 
@@ -263,7 +262,6 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
     
     int      x, y, text_w, text_h;
     char     buf[STR_LENGTH];
-    wxString s;
     float    f, time, freq_hz_to_px;
 
     wxBrush ltGraphBkgBrush;
@@ -337,14 +335,17 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
    {
        sum += f;
    }
-   float averageOffset = sum / rxOffsets_.size();
+   float averageOffset = rxOffsets_.size() == 0 ? -1 : sum / rxOffsets_.size();
    
    if (m_rxFreq != 0.0) {
        // get average offset and draw sync tuning line
-       ctx->SetPen(wxPen(sync_ ? GREEN_COLOR : ORANGE_COLOR, 3));
-       x = (m_rxFreq + averageOffset) * freq_hz_to_px;
-       x += PLOT_BORDER + XLEFT_OFFSET;
-       ctx->StrokeLine(x, 0, x, verticalBarLength);
+       if (averageOffset > 0)
+       {
+           ctx->SetPen(wxPen(sync_ ? GREEN_COLOR : ORANGE_COLOR, 3));
+           x = (m_rxFreq + averageOffset) * freq_hz_to_px;
+           x += PLOT_BORDER + XLEFT_OFFSET;
+           ctx->StrokeLine(x, 0, x, verticalBarLength);
+       }
    
        // red rx tuning line
        ctx->SetPen(wxPen(RED_COLOR, 3));

--- a/src/gui/controls/plot_waterfall.h
+++ b/src/gui/controls/plot_waterfall.h
@@ -44,7 +44,19 @@ class PlotWaterfall : public PlotPanel
         ~PlotWaterfall();
         bool checkDT(void);
         void setGreyscale(bool greyscale) { m_greyscale = greyscale; }
-        void setRxFreq(float rxFreq) { m_rxFreq = rxFreq; }
+        void setRxFreq(float rxFreq) {
+            bool zeroTransition = 
+                (rxFreq != 0 && m_rxFreq == 0) ||
+                (rxFreq == 0 && m_rxFreq != 0);
+
+            m_rxFreq = rxFreq; 
+            if (zeroTransition)
+            {
+                // Trigger a full redraw when going to/from RADE mode 
+                // to make sure frequency indicator renders properly.
+                Refresh();
+            }
+        }
         void setFs(int fs) { m_modem_stats_max_f_hz = fs/2; }
         void setColor(int color) { m_colour = color; }
 

--- a/src/os/osx_interface.mm
+++ b/src/os/osx_interface.mm
@@ -75,12 +75,23 @@ void VerifyMicrophonePermissions(std::promise<bool>& microphonePromise)
 
 void ResetMainWindowColorSpace()
 {
-    [NSApp enumerateWindowsWithOptions:NSWindowListOrderedFrontToBack usingBlock:^(NSWindow *win, BOOL *stop) {
-        CGColorSpaceRef cs = CGColorSpaceCreateWithName( kCGColorSpaceSRGB );
-        [win setColorSpace:[[[NSColorSpace alloc]initWithCGColorSpace:cs] autorelease]];
-    
-        assert(cs != nullptr);
-        CGColorSpaceRelease(cs);
+    [NSApp enumerateWindowsWithOptions:NSWindowListOrderedFrontToBack usingBlock:^(NSWindow *win, BOOL *stop) {       
+        NSColorSpace* colorSpace = win.colorSpace;
+        CFStringRef colorSpaceName = CGColorSpaceCopyName(colorSpace.CGColorSpace);
+        bool recreate = colorSpaceName == nil || CFStringCompare(colorSpaceName, kCGColorSpaceSRGB, 0) != kCFCompareEqualTo;
+        if (colorSpaceName != nil)
+        {
+            CFRelease(colorSpaceName);
+        }
+
+        if (recreate)
+        {
+            CGColorSpaceRef cs = CGColorSpaceCreateWithName( kCGColorSpaceSRGB );
+            assert(cs != nullptr);
+
+            [win setColorSpace:[[[NSColorSpace alloc]initWithCGColorSpace:cs] autorelease]];
+            CGColorSpaceRelease(cs);
+        }
     }];
 }
 


### PR DESCRIPTION
This PR fixes several issues discovered during 2.0.2 testing on macOS:

1. The orange "average frequency" line wasn't properly being suppressed on startup. This is due to a division by zero error in the waterfall logic.
2. With some monitors/systems, the waterfall displays in a "pulsing" type manner. This appears to be triggered when the system resets the window color space when unneeded (performance improvement in an older FreeDV release).
3. Clear to black logic in the waterfall was drawing more than needed (performance improvement).