### PR TITLE
Add timeout for TCP recv() so that FreeDV doesn't hang on exit.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -859,6 +859,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Linux: fix rendering bug for mic/speaker slider when transitioning from TX to RX. (PR #1021)
     * Various unit test fixes to reduce failure rate in CI environment. (PR #1023)
     * Fix waterfall flicker on macOS. (PR #1037)
+    * Add timeout for TCP recv() so that FreeDV doesn't hang on exit. (PR #1038)
 2. Enhancements:
     * Add Mic/Speaker volume control to main window. (PR #980, #1028)
     * Move less used Spectrum plot configuration to free up space on main window. (PR #996)

--- a/src/util/TcpConnectionHandler.cpp
+++ b/src/util/TcpConnectionHandler.cpp
@@ -563,12 +563,12 @@ void TcpConnectionHandler::receiveImpl_()
 
     while (socket_ > 0)
     {
+        struct timeval tv = {0, 250000}; // 250ms
         fd_set readSet;
         FD_ZERO(&readSet);
         FD_SET(socket_, &readSet);
 
-again:        
-        int rv = select(socket_ + 1, &readSet, nullptr, nullptr, nullptr);
+        int rv = select(socket_ + 1, &readSet, nullptr, nullptr, &tv);
         if (rv > 0)
         {
             int numRead = 0;
@@ -600,9 +600,6 @@ again:
                         toRead = std::min(receiveBuffer_.numUsed(), READ_SIZE_BYTES);
                     }
                 });
-            
-                // See if there's any other data waiting to be read.
-                goto again;
             } 
             else if (numRead == 0)
             {


### PR DESCRIPTION
Discovered during pre-release testing of 2.0.2. Seems that in some instances, `select()` will wait forever even when the socket no longer exists. Adding a timeout for `select()` will allow it to eventually exit the receive thread on FreeDV termination.