### PR TITLE
Fix codesign issues on macOS.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -864,7 +864,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 2. Enhancements:
     * Add Mic/Speaker volume control to main window. (PR #980, #1028)
     * Move less used Spectrum plot configuration to free up space on main window. (PR #996)
-    * Further audio performance improvements. (PR #975)
+    * Further audio performance improvements. (PR #975, #1041)
     * Add Automatic Gain Control (AGC) to microphone input. (PR #997, #1024)
     * Linux: Search for and list serial devices from /dev/serial for PTT config. (PR #999)
     * Add RADEV1 sample file and remove samples for unsupported modes. (PR #998)

--- a/generate-univ-pkgs.sh
+++ b/generate-univ-pkgs.sh
@@ -37,12 +37,12 @@ cp ../delocating.py.patched pkg-venv/lib/python3.12/site-packages/delocate/deloc
 
 mkdir arm64
 pip3 download --platform macosx_11_0_arm64 --python-version 3.12 --only-binary=:all: filelock typing-extensions setuptools sympy networkx jinja2 fsspec optree opt-einsum numpy matplotlib
-wget -O arm64/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_arm64.whl https://github.com/tmiw/pytorch-macos-packages/releases/download/20250806/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_arm64.whl
+wget -O arm64/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_arm64.whl https://k6aq.net/freedv-build/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_arm64.whl
 mv *arm64.whl arm64
 
 mkdir x86_64
 pip3 download --platform macosx_11_0_x86_64 --python-version 3.12 --only-binary=:all: filelock typing-extensions setuptools sympy networkx jinja2 fsspec optree opt-einsum numpy matplotlib
-wget -O x86_64/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_x86_64.whl https://github.com/tmiw/pytorch-macos-packages/releases/download/20250806/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_x86_64.whl
+wget -O x86_64/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_x86_64.whl https://k6aq.net/freedv-build/torch-2.7.1a0+gite2d141d-cp312-cp312-macosx_11_0_x86_64.whl
 #rm numpy*
 #wget -O x86_64/numpy-2.3.2-cp312-cp312-macosx_11_0_x86_64.whl https://k6aq.net/freedv-build/numpy-2.3.2-cp312-cp312-macosx_11_0_x86_64.whl
 mv *x86_64.whl x86_64

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ if(APPLE)
         BUNDLE True
         MACOSX_BUNDLE_GUI_IDENTIFIER org.freedv.freedv
         MACOSX_BUNDLE_BUNDLE_NAME FreeDV
-        MACOSX_BNUDLE_COPYRIGHT "Copyright (c) 2021 FreeDV"
+        MACOSX_BNUDLE_COPYRIGHT "Copyright (c) 2025 FreeDV"
         MACOSX_BUNDLE_BUNDLE_VERSION "${FreeDV_VERSION}"
         MACOSX_BUNDLE_BUNDLE_SHORT_VERSION_STRING "${FreeDV_VERSION}"
         MACOSX_BUNDLE_BUNDLE_LONG_VERSION_STRING "${FreeDV_VERSION}"
@@ -163,14 +163,13 @@ if(APPLE)
 
     if (MACOS_CODESIGN_KEYCHAIN_PROFILE)
         add_custom_target(release
-            COMMAND /usr/bin/ditto -c -k --keepParent ./FreeDV.app FreeDV-appbundle.zip
-            COMMAND xcrun notarytool submit ./FreeDV-appbundle.zip --keychain-profile ${MACOS_CODESIGN_KEYCHAIN_PROFILE} --wait 
-            COMMAND rm -rf FreeDV-appbundle.zip
-            COMMAND xcrun stapler staple ./FreeDV.app
             COMMAND mkdir dist_tmp
             COMMAND cp -a FreeDV.app dist_tmp 
             COMMAND ${CMAKE_SOURCE_DIR}/cmake/macos_build_dmg.sh dist_tmp/
             COMMAND rm -rf dist_tmp
+            COMMAND codesign --timestamp -i org.freedv.freedv --sign ${MACOS_CODESIGN_IDENTITY} FreeDV.dmg
+            COMMAND xcrun notarytool submit ./FreeDV.dmg --keychain-profile ${MACOS_CODESIGN_KEYCHAIN_PROFILE} --wait 
+            COMMAND xcrun stapler staple ./FreeDV.dmg
             DEPENDS FreeDV)
     else(MACOS_CODESIGN_KEYCHAIN_PROFILE)
         add_custom_target(release


### PR DESCRIPTION
This PR fixes codesign issues on macOS pre-2.0.2:

1. Use different version of PyTorch that doesn't have Intel libraries as `syspolicy_check` was complaining about those.
2. Update codesigning process to match [Apple recommendations](https://developer.apple.com/forums/thread/128166):
    a. Add codesigning for DMG as well as the .app.
    b. Notarize DMG, not the .app.