### PR TITLE
Workaround radio crash in cleanup code

### DIFF
--- a/src/integrations/flex/FlexTcpTask.cpp
+++ b/src/integrations/flex/FlexTcpTask.cpp
@@ -186,10 +186,10 @@ void FlexTcpTask::cleanupWaveform_()
         return;
     }
     
-    sendRadioCommand_("unsub gps all");
-    sendRadioCommand_("unsub slice all");
-    sendRadioCommand_("waveform remove FreeDV-USB");
-    sendRadioCommand_("waveform remove FreeDV-LSB", [&](unsigned int, std::string const&) {
+    // We shouldn't really have to do this, but the radio seems to get confused by a client registering
+    // more than one waveform, and only cleans up the last one created.
+    // Even more interestingly, if we try to remove FreeDV-LSB as well, the radio will crash.
+    sendRadioCommand_("waveform remove FreeDV-USB", [&](unsigned int, std::string const&) {
         // We can disconnect after we've fully unregistered the waveforms.
         socketFinalCleanup_(false);
     });


### PR DESCRIPTION
The SmartSDR API seems a little bit unpolished when it comes to waveforms.

The branch this is based off of will crash the radio when it does a clean shutdown, apparently because sending `waveform remove FreeDV-LSB` causes something like a double-free internally.

By Flex's usual reference-counting conventions, it wouldn't be necessary to send `waveform remove`, waveforms would get removed automatically when the creating client disconnects. But for FreeDV that seems to be only half-true: it creates two waveforms and only the one it creates _last_ is automatically removed.

If we remove 0 waveforms, we get one left behind (FDVU uselessly sitting in the menu when the waveform isn't running).
If we remove 2 waveforms, we crash the radio.
The only alternative left seems to be to remove 1 waveform.