### PR TITLE
Try some changes to mitigate empty recording bug.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,6 @@ extern int                 g_playFileToMicInEventId;
 
 extern SNDFILE            *g_sfRecFile;
 extern bool                g_recFileFromRadio;
-extern unsigned int        g_recFromRadioSamples;
 extern int                 g_recFileFromRadioEventId;
 extern int                 g_recFileFromDecoderEventId;
 

--- a/src/pipeline/TapStep.cpp
+++ b/src/pipeline/TapStep.cpp
@@ -89,10 +89,7 @@ short* TapStep::execute(short* inputSamples, int numInputSamples, int* numOutput
     assert(tapStep_->getInputSampleRate() == sampleRate_);
     
     tapThreadInput_.write(inputSamples, numInputSamples);
-    if (tapThreadInput_.numUsed() > (100 * sampleRate_ / 1000))
-    {
-        sem_.signal();
-    }
+    sem_.signal();
  
     *numOutputSamples = numInputSamples;
     return inputSamples;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -91,7 +91,6 @@ extern int g_dump_timing;
 extern std::atomic<bool> g_queueResync;
 extern int g_resyncs;
 extern bool g_recFileFromRadio;
-extern unsigned int g_recFromRadioSamples;
 extern std::atomic<bool> g_playFileFromRadio;
 extern int g_sfFs;
 extern bool g_loopPlayFileFromRadio;
@@ -313,13 +312,8 @@ void TxRxThread::initializePipeline_()
         auto recordRadioStep = new RecordStep(
             RECORD_FILE_SAMPLE_RATE, 
             []() { return g_sfRecFile; }, 
-            [](int numSamples) {
-                g_recFromRadioSamples -= numSamples;
-                if (g_recFromRadioSamples <= 0)
-                {
-                    // call stop record menu item, should be thread safe
-                    g_parent->CallAfter(&MainFrame::StopRecFileFromRadio);
-                }
+            [](int) {
+                // empty
             }
         );
         auto recordRadioPipeline = new AudioPipeline(inputSampleRate_, recordRadioStep->getOutputSampleRate());

--- a/src/playrec.cpp
+++ b/src/playrec.cpp
@@ -18,7 +18,6 @@ int                 g_playFileToMicInEventId;
 
 SNDFILE            *g_sfRecFile;
 bool                g_recFileFromRadio;
-unsigned int        g_recFromRadioSamples;
 int                 g_recFileFromRadioEventId;
 
 SNDFILE            *g_sfRecMicFile;
@@ -300,8 +299,6 @@ void MainFrame::OnTogBtnRecord(wxCommandEvent& event)
             
             sfInfo.channels   = 1;
             sfInfo.samplerate = RECORD_FILE_SAMPLE_RATE;
-
-            g_recFromRadioSamples = UINT32_MAX; // record until stopped
 
             if (!recordDialog.isRawRecording())
             {


### PR DESCRIPTION
WIP. This PR is to fix a bug reported on the digitalvoice mailing list where pushing the Record button results in an empty audio file.