### PR TITLE
CI: Add Fedora 43 for Linux AppImage tests.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -301,7 +301,9 @@ jobs:
           sudo podman exec fedora-test sudo mkdir -p /run/user/$(id -u)
           sudo podman exec fedora-test sudo chmod 700 /run/user/$(id -u)
           sudo podman exec fedora-test sudo chown github:github /run/user/$(id -u)
-          sudo podman exec fedora-test sudo /workspace/appimage/container-init.sh
+          sudo podman exec fedora-test sudo systemctl restart polkit
+          sudo podman exec fedora-test sudo systemctl enable rtkit-daemon
+          sudo podman exec fedora-test sudo systemctl start rtkit-daemon
           sudo podman exec --env-file ./tmp.env fedora-test su -l -w FREEDV_BINARY,NO_AT_BRIDGE  github /workspace/appimage/container-test.sh | tee tmp.log
           grep "PASS" tmp.log
 

--- a/appimage/container-init.sh
+++ b/appimage/container-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo "github ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/appimage/container-test.sh
+++ b/appimage/container-test.sh
@@ -10,9 +10,6 @@ Xvfb :99 -screen 0 1024x768x16 &
 sleep 5
 export DISPLAY=:99.0
 eval "$(dbus-launch --sh-syntax --exit-with-x11)"
-sudo systemctl restart polkit
-sudo systemctl enable rtkit-daemon
-sudo systemctl start rtkit-daemon
 pipewire &
 pipewire-pulse &
 wireplumber &


### PR DESCRIPTION
Updates CI build to test the AppImage on Fedora 43 as well as Fedora 42.