### PR TITLE
Fix Feature Request form so that the contact details are actually required.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,8 +14,9 @@ body:
       attributes:
           label: Contact Details
           description: How many people want the feature? Please supply contacts details for at least 3 of them.
-          placeholder: "ex: email@example.com or GitHub usernames"
+          placeholder: "ex: email@example.com, callsigns or GitHub usernames"
       validations:
+          required: true
     - type: textarea
       id: feature-for-this-project
       attributes:


### PR DESCRIPTION
Apparently GitHub wasn't mandating that the Contact Details field for feature requests be required. This PR hopefully fixes that.