### PR TITLE
Implement proposed fixes to reduce dropouts.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -899,6 +899,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix bugs related to display of Mic/Speaker Level slider. (PR #1281) - thanks @barjac!
     * Fix bug causing main window's menu to disappear when Reporter is displayed. (PR #1282)
     * Flex: Prevent multiple slices from being in FreeDV mode. (PR #1270)
+    * Further improve audio dropouts. (PR #1287)
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)

--- a/src/pipeline/AgcStep.cpp
+++ b/src/pipeline/AgcStep.cpp
@@ -168,9 +168,12 @@ short* AgcStep::execute(short* inputSamples, int numInputSamples, int* numOutput
 
             // Scale samples based on current gain.
             float scaleFactor = exp(currentGainDb_/20.0 * log(10.0));
+            float temp = 0;
             for (auto ctr = 0; ctr < numSamplesPerRun_; ctr++)
             {
-                tmpInput[ctr] *= scaleFactor;
+                ConvertToFloatSampleType_<float, short>(&tmpInput[ctr], &temp, 1);
+                temp *= scaleFactor;
+                ConvertToIntSampleType_<short, float>(&temp, &tmpInput[ctr], 1);
             }
 
             // Run WebRTC to make sure we don't clip.

--- a/src/pipeline/IPipelineStep.h
+++ b/src/pipeline/IPipelineStep.h
@@ -35,6 +35,8 @@
 #ifndef AUDIO_PIPELINE__I_PIPELINE_STEP_H
 #define AUDIO_PIPELINE__I_PIPELINE_STEP_H
 
+#include <cmath>
+#include <limits>
 #include "../util/sanitizers.h"
 
 class IPipelineStep
@@ -58,6 +60,58 @@ public:
     
     // Resets internal state of the pipeline step.
     virtual void reset() FREEDV_NONBLOCKING { /* empty */ }
+
+protected:
+    // Helper method that converts integer samples to floating point samples
+    template<typename DstType, typename SrcType, SrcType SampleDivisor = std::numeric_limits<SrcType>::max()>
+    static void ConvertToFloatSampleType_(SrcType* sourceSamples, DstType* destSamples, size_t numSamples);
+
+    // Helper method that converts floating point samples to integer samples
+    template<typename DstType, typename SrcType, DstType SampleMultiplier = std::numeric_limits<DstType>::max()>
+    static void ConvertToIntSampleType_(SrcType* sourceSamples, DstType* destSamples, size_t numSamples);
 };
+
+template<typename DstType, typename SrcType, SrcType SampleDivisor>
+void IPipelineStep::ConvertToFloatSampleType_(SrcType* sourceSamples, DstType* destSamples, size_t numSamples)
+{
+    // Make sure template types are correct
+    static_assert(std::numeric_limits<DstType>::is_iec559);
+    static_assert(std::numeric_limits<SrcType>::is_integer);
+
+    // Make sure divisor isn't zero
+    static_assert(SampleDivisor != 0);
+
+    // Iterate through samples, performing division (if needed) and typecasting
+    for (size_t index = 0; index < numSamples; index++)
+    {
+        destSamples[index] = (DstType)sourceSamples[index] / ((DstType)SampleDivisor);
+    }
+}
+
+template<typename DstType, typename SrcType, DstType SampleMultiplier>
+void IPipelineStep::ConvertToIntSampleType_(SrcType* sourceSamples, DstType* destSamples, size_t numSamples)
+{
+    // Make sure template types are correct
+    static_assert(std::numeric_limits<SrcType>::is_iec559);
+    static_assert(std::numeric_limits<DstType>::is_integer);
+
+    // Iterate through samples, performing multiplication (if needed) and typecasting
+    for (size_t index = 0; index < numSamples; index++)
+    {
+        SrcType temp = sourceSamples[index] * (SrcType)SampleMultiplier;
+        if (temp <= std::numeric_limits<DstType>::min())
+        {
+            destSamples[index] = std::numeric_limits<DstType>::min();
+        }
+        else if (temp >= std::numeric_limits<DstType>::max())
+        {
+            destSamples[index] = std::numeric_limits<DstType>::max();
+        }
+        else
+        {
+            destSamples[index] = static_cast<DstType>(std::llround(temp));
+        }
+    }
+}
 
 #endif // AUDIO_PIPELINE__I_PIPELINE_STEP_H

--- a/src/pipeline/LevelAdjustStep.cpp
+++ b/src/pipeline/LevelAdjustStep.cpp
@@ -66,9 +66,12 @@ short* LevelAdjustStep::execute(short* inputSamples, int numInputSamples, int* n
     float scaleFactor = scaleFactorFn_();
     short* outPtr = outputSamples_.get();
 
+    float temp = 0;
     for (int index = 0; index < numInputSamples; index++)
     {
-        outPtr[index] = inputSamples[index] * scaleFactor;
+        ConvertToFloatSampleType_<float, short, 1>(&inputSamples[index], &temp, 1);
+        temp *= scaleFactor;
+        ConvertToIntSampleType_<short, float, 1>(&temp, &outPtr[index], 1);
     }
     
     *numOutputSamples = numInputSamples;

--- a/src/pipeline/PlaybackStep.cpp
+++ b/src/pipeline/PlaybackStep.cpp
@@ -50,7 +50,7 @@ extern wxMutex g_mutexProtectingCallbackData;
 
 using namespace std::chrono_literals;
 
-#define NUM_SECONDS_TO_READ 1
+#define NUM_SECONDS_TO_READ 5
 
 PlaybackStep::PlaybackStep(
     int inputSampleRate, std::function<int()> fileSampleRateFn, 

--- a/src/pipeline/PlaybackStep.cpp
+++ b/src/pipeline/PlaybackStep.cpp
@@ -51,6 +51,7 @@ extern wxMutex g_mutexProtectingCallbackData;
 using namespace std::chrono_literals;
 
 #define NUM_SECONDS_TO_READ 5
+#define NUM_SECONDS_PER_OPERATION 1 /* to ensure we don't overflow ResampleStep buffer */
 
 PlaybackStep::PlaybackStep(
     int inputSampleRate, std::function<int()> fileSampleRateFn, 
@@ -147,9 +148,10 @@ void PlaybackStep::nonRtThreadEntry_()
 
             unsigned int nsf = outputFifo_.numFree();
             //log_info("nsf = %d", (int)nsf);
-            if (nsf > 0)
+            while (nsf > 0)
             {
                 int samplesAtSourceRate = nsf * fileSampleRate / inputSampleRate_;
+                samplesAtSourceRate = std::min(samplesAtSourceRate, NUM_SECONDS_PER_OPERATION * fileSampleRate);
                 unsigned int numRead = sf_read_short(playFile, buf.get(), samplesAtSourceRate);
          
                 //log_info("samplesAtSource = %d, numRead = %u", samplesAtSourceRate, numRead);
@@ -186,6 +188,14 @@ void PlaybackStep::nonRtThreadEntry_()
                     fileCompleteFn_();
                     g_mutexProtectingCallbackData.Lock();
                 }
+
+                if ((int)numRead == 0)
+                {
+                    // early break out of loop if nothing more to read
+                    break;
+                }
+
+                nsf = outputFifo_.numFree();
             }
         }
         else if (playbackResampler_ != nullptr)

--- a/src/pipeline/RNNoiseStep.cpp
+++ b/src/pipeline/RNNoiseStep.cpp
@@ -90,10 +90,7 @@ short* RNNoiseStep::execute(short* inputSamples, int numInputSamples, int* numOu
             inputSampleFifo_.read(tmpOutput, RNNOISE_FRAME_SIZE);
 
             float tmpFloat[RNNOISE_FRAME_SIZE];
-            for (int index = 0; index < RNNOISE_FRAME_SIZE; index++)
-            {
-                tmpFloat[index] = (float)tmpOutput[index];
-            }
+            ConvertToFloatSampleType_<float, short, 1>(tmpOutput, tmpFloat, RNNOISE_FRAME_SIZE);
 
             // Note: RNNoise is unlikely to use RT-unsafe constructs in normal operation
             // (per existing RTSan-enabled tests). Verified on 2025-09-30.
@@ -103,10 +100,8 @@ short* RNNoiseStep::execute(short* inputSamples, int numInputSamples, int* numOu
 
             if (!firstFrame_)
             {
-                for (int index = 0; index < RNNOISE_FRAME_SIZE; index++)
-                {
-                    *tmpOutput++ = tmpFloat[index];
-                }
+                ConvertToIntSampleType_<short, float, 1>(tmpFloat, tmpOutput, RNNOISE_FRAME_SIZE);
+                tmpOutput += RNNOISE_FRAME_SIZE;
             }
             firstFrame_ = false;
         }

--- a/src/pipeline/ResampleStep.cpp
+++ b/src/pipeline/ResampleStep.cpp
@@ -164,3 +164,8 @@ short* ResampleStep::execute(short* inputSamples, int numInputSamples, int* numO
     
     return outputSamples_.get();
 }
+
+void ResampleStep::reset() FREEDV_NONBLOCKING
+{
+    src_reset(resampleState_);
+}

--- a/src/pipeline/ResampleStep.h
+++ b/src/pipeline/ResampleStep.h
@@ -49,6 +49,7 @@ public:
     virtual int getInputSampleRate() const FREEDV_NONBLOCKING override;
     virtual int getOutputSampleRate() const FREEDV_NONBLOCKING override;
     virtual short* execute(short* inputSamples, int numInputSamples, int* numOutputSamples) FREEDV_NONBLOCKING override;
+    virtual void reset() FREEDV_NONBLOCKING override;
     
 private:
     int inputSampleRate_;

--- a/src/util/GenericFIFO.h
+++ b/src/util/GenericFIFO.h
@@ -76,6 +76,11 @@ private:
     int nelem;
     bool ownBuffer_;
 
+    // Serializes concurrent reset() calls and signals canWrite_()/canRead_()
+    // to bail out early rather than racing against a partially-reset FIFO.
+    // Kept on its own cache line to avoid false-sharing with pin/pout.
+    alignas(hardware_destructive_interference_size) std::atomic<bool> resetting_;
+
     T* canWrite_(int len) noexcept;
     T* canRead_(int len) noexcept;
 };
@@ -91,6 +96,7 @@ GenericFIFO<T>::GenericFIFO(int len, T* inBuf)
     , resetInCache(false)
     , nelem(len)
     , ownBuffer_(inBuf == nullptr ? true : false)
+    , resetting_(false)
 {
     if (ownBuffer_)
     {
@@ -116,11 +122,12 @@ GenericFIFO<T>::~GenericFIFO() noexcept
 template<typename T>
 GenericFIFO<T>::GenericFIFO(GenericFIFO<T>&& rhs) noexcept
     : buf(rhs.buf)
-    , pin(rhs.pin)
+    , pin(rhs.pin.load())
     , poutCache(rhs.poutCache)
-    , pout(rhs.pout)
+    , pout(rhs.pout.load())
     , pinCache(rhs.pinCache)
     , nelem(rhs.nelem)
+    , resetting_(false)
 {
     rhs.buf = nullptr;
     rhs.pin = nullptr;
@@ -133,10 +140,32 @@ GenericFIFO<T>::GenericFIFO(GenericFIFO<T>&& rhs) noexcept
 template<typename T>
 void GenericFIFO<T>::reset() noexcept
 {
-    pin.store(buf, std::memory_order_release);
-    resetOutCache.store(true, std::memory_order_release);
-    pout.store(buf, std::memory_order_release);
-    resetInCache.store(true, std::memory_order_release);
+    // Serialise concurrent reset() calls.  Two threads calling reset()
+    // simultaneously would interleave their four independent stores, which can
+    // leave the FIFO in a state where one pointer has been reset while the
+    // other still holds an old value.
+    bool expected = false;
+    while (!resetting_.compare_exchange_weak(
+               expected, true,
+               std::memory_order_acquire,
+               std::memory_order_relaxed))
+    {
+        expected = false;
+    }
+
+    // Invalidate both caches BEFORE resetting the pointers.
+    //
+    // If canWrite_() or canRead_() runs between the pointer reset and the flag
+    // set it would pair a freshly-reset pointer against a stale cache value,
+    // producing a nonsensical "used" count.  Setting the flags first forces
+    // both sides to reload from the atomic pin/pout after the pointers land.
+    resetOutCache.store(true, std::memory_order_seq_cst);
+    resetInCache.store(true,  std::memory_order_seq_cst);
+
+    pin.store(buf,  std::memory_order_seq_cst);
+    pout.store(buf, std::memory_order_seq_cst);
+
+    resetting_.store(false, std::memory_order_release);
 }
 
 #define CALCULATE_ENTRIES_USED(in, out, used)     \
@@ -152,6 +181,10 @@ void GenericFIFO<T>::reset() noexcept
 template<typename T>
 T* GenericFIFO<T>::canWrite_(int len) noexcept
 {
+    // Bail immediately if a reset() is in progress.  The write will be lost,
+    // but that is preferable to working with a partially-reset FIFO state.
+    if (resetting_.load(std::memory_order_acquire)) return nullptr;
+
     T *ppin = pin.load(std::memory_order_acquire);
     unsigned int used = 0;
 
@@ -181,6 +214,10 @@ T* GenericFIFO<T>::canWrite_(int len) noexcept
 template<typename T>
 T* GenericFIFO<T>::canRead_(int len) noexcept
 {
+    // Bail immediately if a reset() is in progress.  Returning stale data from
+    // a partially-reset FIFO is worse than returning nothing.
+    if (resetting_.load(std::memory_order_acquire)) return nullptr;
+
     T* ppout = pout.load(std::memory_order_acquire);
     unsigned int used = 0;
 

--- a/src/util/GenericFIFO.h
+++ b/src/util/GenericFIFO.h
@@ -69,9 +69,6 @@ private:
     alignas(hardware_destructive_interference_size) std::atomic<T*> pout;
     T* pinCache;
     std::atomic<bool> resetInCache;
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif // !defined(__clang__) && defined(__cpp_lib_hardware_interference_size)
 
     int nelem;
     bool ownBuffer_;
@@ -80,6 +77,9 @@ private:
     // to bail out early rather than racing against a partially-reset FIFO.
     // Kept on its own cache line to avoid false-sharing with pin/pout.
     alignas(hardware_destructive_interference_size) std::atomic<bool> resetting_;
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // !defined(__clang__) && defined(__cpp_lib_hardware_interference_size)
 
     T* canWrite_(int len) noexcept;
     T* canRead_(int len) noexcept;


### PR DESCRIPTION
Claude Code recommended some fixes to `GenericFIFO` and `PlaybackStep` to reduce dropouts in the GitHub environment. This PR is so we can try these changes out and see if there actually is any improvement.

Also contains some refactoring of short/float sample conversions (based on work originally in #1286).