### PR TITLE
Make Waterfall and Spectrum displays usable and tidy when compressed into a small main window 

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -911,6 +911,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Improve usability of attenuation control in the main window. (PR #1268) - thanks @barjac!
     * Use RNNoise for improved noise canceling during TX. (PR #1276)
     * FreeDV Reporter: Add ability to filter based on individual columns. (PR #1285)
+    * Improve spectrum and waterfall plot appearance on small displays. (PR #1288) - thanks @barjac!
 3. Build system:
     * Update Python to 3.14.3. (PR #1221)
     * Update Hamlib to 4.7.0. (PR #1226)

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -271,7 +271,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
             GetTextExtent(buf, &text_w, &text_h);
             if (!overlappedX)
-                ctx->DrawText(buf, x - text_w/2, PLOT_BORDER);
+                ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + bottomOffset_ - text_h) / 2);
         }
     }
 

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -289,14 +289,14 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
 
     ctx->SetPen(m_penDotDash);
     for(mag=m_min_mag_db; mag<=m_max_mag_db; mag+=STEP_MAG_DB) {
+        if (mag == m_min_mag_db || mag == m_max_mag_db)
+            continue;
         y = -(mag - m_max_mag_db) * mag_dB_to_py;
         y += PLOT_BORDER + bottomOffset_;
         ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
                 (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
         if (!repaintDataOnly)
         {
-            if (mag == m_min_mag_db || mag == m_max_mag_db)
-                continue;
             snprintf(buf, STR_LENGTH, "%3.0fdB", mag);
             GetTextExtent(buf, &text_w, &text_h);
             auto top = y - text_h / 2;
@@ -322,7 +322,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             ctx->SetPen(wxPen(sync_ ? GREEN_COLOR : ORANGE_COLOR, 3));
             x = (m_rxFreq + averageOffset) * freq_hz_to_px;
             x += PLOT_BORDER + leftOffset_;
-            ctx->StrokeLine(x, 0, x, PLOT_BORDER + bottomOffset_);
+            ctx->StrokeLine(x, 0, x, verticalBarLength);
    
             // red rx tuning line
             ctx->SetPen(wxPen(RED_COLOR, 3));

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -322,7 +322,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             ctx->SetPen(wxPen(sync_ ? GREEN_COLOR : ORANGE_COLOR, 3));
             x = (m_rxFreq + averageOffset) * freq_hz_to_px;
             x += PLOT_BORDER + leftOffset_;
-            ctx->StrokeLine(x, 0, x, verticalBarLength);
+            ctx->StrokeLine(x, 0, x, PLOT_BORDER + bottomOffset_ - YBOTTOM_TEXT_OFFSET / 2);
    
             // red rx tuning line
             ctx->SetPen(wxPen(RED_COLOR, 3));

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -322,7 +322,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             ctx->SetPen(wxPen(sync_ ? GREEN_COLOR : ORANGE_COLOR, 3));
             x = (m_rxFreq + averageOffset) * freq_hz_to_px;
             x += PLOT_BORDER + leftOffset_;
-            ctx->StrokeLine(x, 0, x, PLOT_BORDER + bottomOffset_ - YBOTTOM_TEXT_OFFSET / 2);
+            ctx->StrokeLine(x, 0, x, verticalBarLength);
    
             // red rx tuning line
             ctx->SetPen(wxPen(RED_COLOR, 3));

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -119,6 +119,7 @@ void PlotSpectrum::OnSize(wxSizeEvent&) {
         leftOffset_ = std::max(leftOffset_, text_w);
         bottomOffset_ = std::max(bottomOffset_, text_h);
     }
+    bottomOffset_ = std::max(bottomOffset_, (int)YBOTTOM_OFFSET);
 }
 
 //----------------------------------------------------------------
@@ -271,7 +272,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
             GetTextExtent(buf, &text_w, &text_h);
             if (!overlappedX)
-                ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + bottomOffset_ - text_h) / 2);
+                ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + bottomOffset_ - YBOTTOM_TEXT_OFFSET * 2 - text_h) / 2);
         }
     }
 
@@ -294,17 +295,11 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
                 (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
         if (!repaintDataOnly)
         {
+            if (mag == m_min_mag_db || mag == m_max_mag_db)
+                continue;
             snprintf(buf, STR_LENGTH, "%3.0fdB", mag);
             GetTextExtent(buf, &text_w, &text_h);
             auto top = y - text_h / 2;
-            if (mag == m_min_mag_db)
-            {
-                top -= text_h/2;
-            }
-            else if (mag == m_max_mag_db)
-            {
-                top += text_h/2;
-            }
             if (!overlappedY)
                  ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET, top);
         }

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -280,7 +280,8 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
-        ctx->StrokeLine(x, PLOT_BORDER + bottomOffset_, x, PLOT_BORDER + bottomOffset_ - YBOTTOM_TEXT_OFFSET);
+        int tickLen = (fmodf(f, (float)STEP_F_HZ) < 1.0f) ? YBOTTOM_TEXT_OFFSET * 2 : YBOTTOM_TEXT_OFFSET;
+        ctx->StrokeLine(x, PLOT_BORDER + bottomOffset_, x, PLOT_BORDER + bottomOffset_ - tickLen);
     }
 
     // Horizontal gridlines

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -252,11 +252,10 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
 
     int textXStep = STEP_F_HZ*freq_hz_to_px;
     int textYStep = STEP_MAG_DB*mag_dB_to_py;
-    snprintf(buf, STR_LENGTH, "%4.0fHz", (float)MAX_F_HZ - STEP_F_HZ);
+    snprintf(buf, STR_LENGTH, "%.1fk", ((float)MAX_F_HZ - STEP_F_HZ)/1000.0f);
     GetTextExtent(buf, &text_w, &text_h);
-    int overlappedText = (text_w > textXStep) || (text_h > textYStep);
-    //printf("text_w: %d textXStep: %d text_h: %d textYStep: %d  overlappedText: %d\n", text_w, textXStep, 
-    //      text_h, textYStep, overlappedText);
+    int overlappedX = (text_w > textXStep);
+    int overlappedY = (text_h > textYStep);
 
     // Vertical gridlines
 
@@ -269,28 +268,28 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
 
         if (!repaintDataOnly)
         {
-            snprintf(buf, STR_LENGTH, "%4.0fHz", f);
+            snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
             GetTextExtent(buf, &text_w, &text_h);
-            if (!overlappedText)
+            if (!overlappedX)
                 ctx->DrawText(buf, x - text_w/2, PLOT_BORDER);
         }
     }
 
     ctx->SetPen(wxPen(foregroundColor, 1));
-    for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ) 
+    for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ)
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
         ctx->StrokeLine(x, PLOT_BORDER + bottomOffset_, x, PLOT_BORDER + bottomOffset_ - YBOTTOM_TEXT_OFFSET);
     }
-    
+
     // Horizontal gridlines
 
     ctx->SetPen(m_penDotDash);
     for(mag=m_min_mag_db; mag<=m_max_mag_db; mag+=STEP_MAG_DB) {
         y = -(mag - m_max_mag_db) * mag_dB_to_py;
         y += PLOT_BORDER + bottomOffset_;
-        ctx->StrokeLine(PLOT_BORDER + leftOffset_, y, 
+        ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
                 (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
         if (!repaintDataOnly)
         {
@@ -305,7 +304,7 @@ void PlotSpectrum::drawGraticuleFast(wxGraphicsContext* ctx, bool repaintDataOnl
             {
                 top += text_h/2;
             }
-            if (!overlappedText)
+            if (!overlappedY)
                  ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET, top);
         }
     }

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -327,7 +327,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
         GetTextExtent(buf, &text_w, &text_h);
         if (!overlappedX)
-            ctx->DrawText(buf, x - text_w/2, (YBOTTOM_TEXT_OFFSET/2) - 5);
+            ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + 8 - text_h) / 2);
     }
 
     for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ)

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -308,13 +308,13 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
 
     int textXStep = STEP_F_HZ * freq_hz_to_px;
     int textYStep = WATERFALL_SECS_STEP * Y_PER_SECOND;
-    snprintf(buf, STR_LENGTH, "%4.0fHz", (float)MAX_F_HZ - STEP_F_HZ);
+    snprintf(buf, STR_LENGTH, "%.1fk", ((float)MAX_F_HZ - STEP_F_HZ)/1000.0f);
     GetTextExtent(buf, &text_w, &text_h);
-    int overlappedText = (text_w > textXStep) || (text_h > textYStep);
+    int overlappedX = (text_w > textXStep);
+    int overlappedY = (text_h > textYStep);
 
     // Major Vertical gridlines and legend
-    //dc.SetPen(m_penShortDash);
-    for(f=STEP_F_HZ; f<MAX_F_HZ; f+=STEP_F_HZ) 
+    for(f=STEP_F_HZ; f<MAX_F_HZ; f+=STEP_F_HZ)
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
@@ -323,28 +323,28 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
             ctx->StrokeLine(x, m_imgHeight + PLOT_BORDER, x, PLOT_BORDER);
         else
             ctx->StrokeLine(x, PLOT_BORDER + 8, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
-            
-        snprintf(buf, STR_LENGTH, "%4.0fHz", f);
+
+        snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
         GetTextExtent(buf, &text_w, &text_h);
-        if (!overlappedText)
+        if (!overlappedX)
             ctx->DrawText(buf, x - text_w/2, (YBOTTOM_TEXT_OFFSET/2) - 5);
     }
 
-    for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ) 
+    for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ)
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
         ctx->StrokeLine(x, PLOT_BORDER + 13, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
     }
-    
+
     // Horizontal gridlines
     ctx->SetPen(m_penDotDash);
-    for(y = PLOT_BORDER + YBOTTOM_TEXT_OFFSET, time=0; 
-        y < m_rGrid.GetHeight(); 
-        time += WATERFALL_SECS_STEP, y += Y_PER_SECOND * WATERFALL_SECS_STEP) 
+    for(y = PLOT_BORDER + YBOTTOM_TEXT_OFFSET, time=0;
+        y < m_rGrid.GetHeight();
+        time += WATERFALL_SECS_STEP, y += Y_PER_SECOND * WATERFALL_SECS_STEP)
     {
         if (m_graticule)
-            ctx->StrokeLine(PLOT_BORDER + leftOffset_, y, 
+            ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
                         (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
         snprintf(buf, STR_LENGTH, "%3.0fs", time);
         GetTextExtent(buf, &text_w, &text_h);
@@ -353,7 +353,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         {
             top += text_h;
         }
-        if (!overlappedText)
+        if (!overlappedY)
             ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET, top);
    }
    

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -322,19 +322,19 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         if (m_graticule)
             ctx->StrokeLine(x, m_imgHeight + PLOT_BORDER, x, PLOT_BORDER);
         else
-            ctx->StrokeLine(x, PLOT_BORDER + 8, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+            ctx->StrokeLine(x, PLOT_BORDER + YBOTTOM_OFFSET, x, PLOT_BORDER + YBOTTOM_OFFSET / 2);
 
         snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
         GetTextExtent(buf, &text_w, &text_h);
         if (!overlappedX)
-            ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + 8 - text_h) / 2);
+            ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + YBOTTOM_OFFSET / 2 - text_h) / 2);
     }
 
     for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ)
     {
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
-        ctx->StrokeLine(x, PLOT_BORDER + 13, x, PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5);
+        ctx->StrokeLine(x, PLOT_BORDER + YBOTTOM_OFFSET, x, PLOT_BORDER + YBOTTOM_OFFSET * 3 / 4);
     }
 
     // Horizontal gridlines

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -307,7 +307,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
     // Check if small screen size means text will overlap
 
     int textXStep = STEP_F_HZ * freq_hz_to_px;
-    int textYStep = WATERFALL_SECS_STEP * Y_PER_SECOND;
+    int textYStep = Y_PER_SECOND; // labels at 1s intervals
     snprintf(buf, STR_LENGTH, "%.1fk", ((float)MAX_F_HZ - STEP_F_HZ)/1000.0f);
     GetTextExtent(buf, &text_w, &text_h);
     int overlappedX = (text_w > textXStep);
@@ -337,25 +337,36 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         ctx->StrokeLine(x, PLOT_BORDER + YBOTTOM_OFFSET, x, PLOT_BORDER + YBOTTOM_OFFSET * 3 / 4);
     }
 
-    // Horizontal gridlines
+    int dataY0   = PLOT_BORDER + YBOTTOM_OFFSET;
+    int dataYEnd = dataY0 + m_imgHeight;
+
+    // Horizontal gridlines at 5s intervals (graticule mode only)
     ctx->SetPen(m_penDotDash);
-    for(y = PLOT_BORDER + YBOTTOM_TEXT_OFFSET, time=0;
-        y < m_rGrid.GetHeight();
+    for(y = dataY0, time=0;
+        y < dataYEnd;
         time += WATERFALL_SECS_STEP, y += Y_PER_SECOND * WATERFALL_SECS_STEP)
     {
         if (m_graticule)
             ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
                         (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
+    }
+
+    // Y axis ticks and labels at 1s intervals
+    ctx->SetPen(wxPen(foregroundColor, 1));
+    for(y = dataY0, time=0;
+        y < dataYEnd;
+        time += 1.0f, y += Y_PER_SECOND)
+    {
+        bool isMajor = (fmodf(time, (float)WATERFALL_SECS_STEP) < 0.5f);
+        ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
+                        PLOT_BORDER + leftOffset_ + (isMajor ? 8 : 4), y);
+
         snprintf(buf, STR_LENGTH, "%3.0fs", time);
         GetTextExtent(buf, &text_w, &text_h);
-        auto top = y - text_h / 2;
-        if (time == 0)
-        {
-            top += text_h;
-        }
         if (!overlappedY)
-            ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET, top);
-   }
+            ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET,
+                          y - text_h / 2);
+    }
    
    float verticalBarLength = PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5;
    

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -307,11 +307,21 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
     // Check if small screen size means text will overlap
 
     int textXStep = STEP_F_HZ * freq_hz_to_px;
-    int textYStep = Y_PER_SECOND; // labels at 1s intervals
     snprintf(buf, STR_LENGTH, "%.1fk", ((float)MAX_F_HZ - STEP_F_HZ)/1000.0f);
     GetTextExtent(buf, &text_w, &text_h);
     int overlappedX = (text_w > textXStep);
-    int overlappedY = (text_h > textYStep);
+
+    // Pick the coarsest Y label interval that still shows at least 4 labels
+    static const int labelStepPresets[] = {5, 2, 1};
+    int labelSecs = labelStepPresets[2]; // default finest
+    for (int preset : labelStepPresets)
+    {
+        if (m_imgHeight / (preset * Y_PER_SECOND) >= 4)
+        {
+            labelSecs = preset;
+            break;
+        }
+    }
 
     // Major Vertical gridlines and legend
     for(f=STEP_F_HZ; f<MAX_F_HZ; f+=STEP_F_HZ)
@@ -363,7 +373,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
 
         snprintf(buf, STR_LENGTH, "%3.0fs", time);
         GetTextExtent(buf, &text_w, &text_h);
-        if (!overlappedY)
+        if ((int)(time + 0.5f) % labelSecs == 0)
             ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET,
                           y - text_h / 2);
     }


### PR DESCRIPTION
This updates the Waterfall and Spectrum graph displays to accept more size compression whilst keeping axis labels tidy and readable.

Ideas by me, coding by Claude AI :)

<img width="1280" height="318" alt="Screenshot_20260409_202841" src="https://github.com/user-attachments/assets/c97cc8ec-2495-47d4-ad82-a3e1add5fdec" />

Below is current master branch at the same size:

<img width="1280" height="307" alt="Screenshot_20260409_210822" src="https://github.com/user-attachments/assets/94d5ed24-e99d-4edf-bfc6-3a06264645a8" />

