### PR TITLE
Logging: fix incorrect time when using UTC due to DST.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -930,6 +930,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Further improve audio dropouts. (PR #1287)
     * FreeDV Reporter: Fix inability to use mouse wheel on Msg column. (PR #1289)
     * Fix RADE related compiler errors. (PR #1299)
+    * Logging: fix incorrect time when using UTC due to DST. (PR #1302)
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -930,7 +930,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Further improve audio dropouts. (PR #1287)
     * FreeDV Reporter: Fix inability to use mouse wheel on Msg column. (PR #1289)
     * Fix RADE related compiler errors. (PR #1299)
-    * Logging: fix incorrect time when using UTC due to DST. (PR #1302)
+    * Logging: fix incorrect time when using UTC due to DST. (PR #1302) - thanks @barjac!
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1571,6 +1571,12 @@ void MainFrame::OnLogQSO(wxCommandEvent&)
         
         wxString::const_iterator end;
         logTimeObj.ParseDateTime(logTime, &end);
+
+        if (wxGetApp().appConfiguration.reportingConfiguration.useUTCForReporting)
+        {
+            // String was stored in UTC; ParseDateTime assumes local — reinterpret as UTC.
+            logTimeObj.MakeFromTimezone(wxDateTime::UTC);
+        }
         
         if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
         {


### PR DESCRIPTION
Resolves #1301 by applying Claude Code-suggested patch from @barjac.