### PR TITLE
Use different Ubuntu mirror as workaround for failing build.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
+           sudo sed -i 's@http://ports.ubuntu.com/ubuntu-ports@http://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install codespell libpulse-dev libspeexdsp-dev sox git portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb at-spi2-core libebur128-dev libwxgtk3.2-dev python3-numpy python3-numpy-dev python3-dev
 
@@ -110,7 +110,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
+           sudo sed -i 's@http://ports.ubuntu.com/ubuntu-ports@http://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -355,7 +355,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
+           sudo sed -i 's@http://ports.ubuntu.com/ubuntu-ports@http://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -491,7 +491,7 @@ jobs:
     - name: Install LLVM/Clang >=20.0 
       if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm' }}
       run: |
-        sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
+        sudo sed -i 's@http://ports.ubuntu.com/ubuntu-ports@http://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 21

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install codespell libpulse-dev libspeexdsp-dev sox git portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb at-spi2-core libebur128-dev libwxgtk3.2-dev python3-numpy python3-numpy-dev python3-dev
 
@@ -110,7 +110,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -355,7 +355,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
-           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -491,7 +491,7 @@ jobs:
     - name: Install LLVM/Clang >=20.0 
       if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm' }}
       run: |
-        sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
+        sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 21

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install codespell libpulse-dev libspeexdsp-dev sox git portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb at-spi2-core libebur128-dev libwxgtk3.2-dev python3-numpy python3-numpy-dev python3-dev
 
@@ -109,6 +110,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -117,11 +119,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-           sudo apt-get update
-           sudo apt install software-properties-common -y
-           sudo add-apt-repository ppa:deadsnakes/ppa -y
-           sudo apt update
-           sudo apt-get install libpulse-dev sox git libasound2-dev libao-dev libgsm1-dev xvfb pulseaudio pulseaudio-utils metacity at-spi2-core libdbus-1-dev libgtk-3-dev python3.14 python3.14-dev python3.14-venv libebur128-dev pkg-config
+           sudo apt-get install libpulse-dev sox git libasound2-dev libao-dev libgsm1-dev xvfb pulseaudio pulseaudio-utils metacity at-spi2-core libdbus-1-dev libgtk-3-dev python3 python3-dev python3-venv libebur128-dev pkg-config
            mkdir -p ~/.config/pulse
            echo "default-sample-rate = 48000" >~/.config/pulse/daemon.conf
            sudo sed 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa -i
@@ -131,7 +129,7 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
-          python3.14 -m venv rade-venv
+          python3 -m venv rade-venv
           . ./rade-venv/bin/activate
           pip3 install torch==${{ env.TORCH_RELEASE }} --index-url https://download.pytorch.org/whl/cpu
           pip3 install matplotlib
@@ -357,6 +355,7 @@ jobs:
     - name: Install rtkit for RT threading
       shell: bash
       run: |
+           sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
            sudo apt-get update
            sudo apt-get install dbus-x11 rtkit libdbus-1-dev polkitd
            sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy 
@@ -492,6 +491,7 @@ jobs:
     - name: Install LLVM/Clang >=20.0 
       if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm' }}
       run: |
+        sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports' /etc/apt/sources.list
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 21
@@ -538,10 +538,7 @@ jobs:
     - name: Install common packages
       shell: bash
       run: |
-           sudo apt install software-properties-common -y
-           sudo add-apt-repository ppa:deadsnakes/ppa -y
-           sudo apt update
-           sudo apt-get install libpulse-dev libspeexdsp-dev sox git portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pulseaudio-utils metacity at-spi2-core libebur128-dev python3.14 python3.14-dev python3.14-venv
+           sudo apt-get install libpulse-dev libspeexdsp-dev sox git portaudio19-dev libhamlib-dev libasound2-dev libao-dev libgsm1-dev libsndfile-dev xvfb pulseaudio-utils metacity at-spi2-core libebur128-dev python3 python3-dev python3-venv
 
     - name: Install version-specific packages
       if: ${{ matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm' }}
@@ -563,7 +560,7 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}
       run: |
-          python3.14 -m venv rade-venv 
+          python3 -m venv rade-venv 
 
     - name: Install Python required modules
       shell: bash

--- a/.github/workflows/update_freedv_manual.yml
+++ b/.github/workflows/update_freedv_manual.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pandoc package
         run: |
-             sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
+             sudo sed -i 's@http://ports.ubuntu.com/ubuntu-ports@http://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
              sudo apt-get update
              sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive-fonts-extra
            

--- a/.github/workflows/update_freedv_manual.yml
+++ b/.github/workflows/update_freedv_manual.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install pandoc package
         run: |
+             sudo sed -i 's@https://ports.ubuntu.com/ubuntu-ports@https://mirrors.mit.edu/ubuntu-ports@g' /etc/apt/sources.list
              sudo apt-get update
              sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive-fonts-extra
            


### PR DESCRIPTION
Ubuntu servers are under a "sustained cross-border attack", so we need to force use of a different mirror on GitHub runners in order for CI to run successfully. This also removes the Python 3.14 install in the GH runners as FreeDV no longer includes Python.