### PR TITLE
Hamlib: additional fixes to prevent ping-ponging frequencies.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -933,7 +933,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix RADE related compiler errors. (PR #1299)
     * Logging: fix incorrect time when using UTC due to DST. (PR #1302) - thanks @barjac!
     * Ensure that PTT is actually off when opening Hamlib connection. (PR #1308)
-    * Fix race condition preventing frequency/mode from changing on start with SmartSDR 4.2. (PR #1314)
+    * Fix race condition preventing frequency/mode from changing on start with SmartSDR 4.2. (PR #1314, #1320)
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -521,6 +521,11 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
                 freqString = wxNumberFormatter::ToString(freq / 1000.0 / 1000.0, 4);
             }
             
+            // Set internal reporting frequency to ensure we don't immediately request
+            // a frequency change from the radio (i.e. if rapidly changing frequency
+            // on the radio side).
+            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = freq;
+            
             m_cboReportFrequency->SetValue(freqString);
         }
         m_txtModeStatus->Refresh();

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -906,7 +906,7 @@ freqAttempt:
         currFreq_ = frequencyHz;
         if (!destroying_)
         {
-            requestCurrentFrequencyMode();
+            requestCurrentFrequencyModeImpl_();
         }
     }
 }
@@ -962,7 +962,7 @@ modeAttempt:
         currMode_ = mode;
         if (!destroying_)
         {
-            requestCurrentFrequencyMode();
+            requestCurrentFrequencyModeImpl_();
         }
     }
 }


### PR DESCRIPTION
Additional tweaks to hopefully prevent FreeDV from cycling between old and new frequencies on rapid change of the dial frequency from the radio side.