### PR TITLE
Hamlib: Prevent errors while rapidly turning VFO.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm, ubuntu-24.04]
+        os: [ubuntu-24.04-arm]
         fedora-version: [42, 43]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -256,75 +256,75 @@ jobs:
         path: ${{github.workspace}}/src/integrations/flex/${{ steps.flex-waveform-filename.outputs.FLEX_WAVEFORM_FILENAME }}
         archive: false
 
-  test-appimage-fedora:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04-arm]
-        fedora-version: [42, 43]
+  #test-appimage-fedora:
+  #  strategy:
+  #    fail-fast: false
+  #    matrix:
+  #      os: [ubuntu-24.04, ubuntu-24.04-arm]
+  #      fedora-version: [42, 43]
 
-    runs-on: ${{ matrix.os }}
-    needs: [build-appimage]
-    steps:
-    - uses: actions/checkout@v6
+  #  runs-on: ${{ matrix.os }}
+  #  needs: [build-appimage]
+  #  steps:
+  #  - uses: actions/checkout@v6
 
-    #- name: Setup tmate session
-    #  uses: mxschmitt/action-tmate@v3
-    #  with:
-    #    detached: true
+  #  #- name: Setup tmate session
+  #  #  uses: mxschmitt/action-tmate@v3
+  #  #  with:
+  #  #    detached: true
 
-    - name: Disable AppArmor (needed for Fedora systemd)
-      run: |
-          sudo apparmor_parser -R /etc/apparmor.d/* || true
+  #  - name: Disable AppArmor (needed for Fedora systemd)
+  #    run: |
+  #        sudo apparmor_parser -R /etc/apparmor.d/* || true
 
-    - name: Save correct architecture
-      id: save-arch
-      run: |
-        echo "APPIMAGE_ARCH=$(uname -m)" >> "$GITHUB_OUTPUT"
-    
-    - uses: actions/download-artifact@v8
-      with:
-        merge-multiple: true
-        pattern: FreeDV-2*-${{ steps.save-arch.outputs.APPIMAGE_ARCH }}.AppImage
-        path: ${{github.workspace}}
+  #  - name: Save correct architecture
+  #    id: save-arch
+  #    run: |
+  #      echo "APPIMAGE_ARCH=$(uname -m)" >> "$GITHUB_OUTPUT"
+  #  
+  #  - uses: actions/download-artifact@v8
+  #    with:
+  #      merge-multiple: true
+  #      pattern: FreeDV-2*-${{ steps.save-arch.outputs.APPIMAGE_ARCH }}.AppImage
+  #      path: ${{github.workspace}}
 
-    - name: Start Fedora container
-      shell: bash
-      run: |
-          sudo podman run -d --name fedora-test --systemd=always --privileged -v ${{github.workspace}}:/workspace docker.io/jrei/systemd-fedora:${{ matrix.fedora-version }}
+  #  - name: Start Fedora container
+  #    shell: bash
+  #    run: |
+  #        sudo podman run -d --name fedora-test --systemd=always --privileged -v ${{github.workspace}}:/workspace docker.io/jrei/systemd-fedora:${{ matrix.fedora-version }}
 
-    - name: Install rtkit for RT threading
-      shell: bash
-      run: |
-          sudo podman exec fedora-test sudo dnf -y update 
-          sudo podman exec fedora-test sudo dnf -y install dbus dbus-x11 dbus-tools rtkit dbus-devel polkit
-          sudo podman exec fedora-test sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy
+  #  - name: Install rtkit for RT threading
+  #    shell: bash
+  #    run: |
+  #        sudo podman exec fedora-test sudo dnf -y update 
+  #        sudo podman exec fedora-test sudo dnf -y install dbus dbus-x11 dbus-tools rtkit dbus-devel polkit
+  #        sudo podman exec fedora-test sudo sed -i 's/no/yes/g' /usr/share/polkit-1/actions/org.freedesktop.RealtimeKit1.policy
 
-    - name: Install required packages for audio/display
-      shell: bash
-      run: |
-          sudo podman exec fedora-test sudo dnf -y install sox xorg-x11-server-Xvfb pipewire pipewire-pulseaudio pulseaudio-libs-devel pulseaudio-utils wireplumber metacity python3-matplotlib python3-torch sox git
+  #  - name: Install required packages for audio/display
+  #    shell: bash
+  #    run: |
+  #        sudo podman exec fedora-test sudo dnf -y install sox xorg-x11-server-Xvfb pipewire pipewire-pulseaudio pulseaudio-libs-devel pulseaudio-utils wireplumber metacity python3-matplotlib python3-torch sox git
 
-    - name: Sanity check RADE
-      shell: bash
-      working-directory: ${{github.workspace}}
-      run: |
-          chmod +x *.AppImage
-          echo "FREEDV_BINARY=./$(echo -n *.AppImage) --appimage-extract-and-run" > tmp.env
-          echo "NO_AT_BRIDGE=${{ env.NO_AT_BRIDGE }}" >> tmp.env
-          sudo podman exec fedora-test sudo groupadd -g $(id -g) $(id -gn)
-          sudo podman exec fedora-test sudo useradd -m -u $(id -u) -g $(id -g) $(id -un)
-          sudo podman exec fedora-test sudo passwd -d $(id -un)
-          sudo podman exec fedora-test sudo mkdir -p /run/user/$(id -u)
-          sudo podman exec fedora-test sudo chmod 700 /run/user/$(id -u)
-          sudo podman exec fedora-test sudo chown $(id -un):$(id -gn) /run/user/$(id -u)
-          sudo podman exec fedora-test sudo systemctl restart systemd-logind
-          sudo podman exec fedora-test sudo systemctl restart polkit
-          sudo podman exec fedora-test sudo systemctl enable rtkit-daemon
-          sudo podman exec fedora-test sudo systemctl start rtkit-daemon
-          sudo podman exec fedora-test sudo systemctl start user@$(id -u)
-          sudo podman exec --env-file ./tmp.env fedora-test su -l -w FREEDV_BINARY,NO_AT_BRIDGE $(id -un) /workspace/appimage/container-test.sh | tee tmp.log
-          grep "PASS" tmp.log
+  #  - name: Sanity check RADE
+  #    shell: bash
+  #    working-directory: ${{github.workspace}}
+  #    run: |
+  #        chmod +x *.AppImage
+  #        echo "FREEDV_BINARY=./$(echo -n *.AppImage) --appimage-extract-and-run" > tmp.env
+  #        echo "NO_AT_BRIDGE=${{ env.NO_AT_BRIDGE }}" >> tmp.env
+  #        sudo podman exec fedora-test sudo groupadd -g $(id -g) $(id -gn)
+  #        sudo podman exec fedora-test sudo useradd -m -u $(id -u) -g $(id -g) $(id -un)
+  #        sudo podman exec fedora-test sudo passwd -d $(id -un)
+  #        sudo podman exec fedora-test sudo mkdir -p /run/user/$(id -u)
+  #        sudo podman exec fedora-test sudo chmod 700 /run/user/$(id -u)
+  #        sudo podman exec fedora-test sudo chown $(id -un):$(id -gn) /run/user/$(id -u)
+  #        sudo podman exec fedora-test sudo systemctl restart systemd-logind
+  #        sudo podman exec fedora-test sudo systemctl restart polkit
+  #        sudo podman exec fedora-test sudo systemctl enable rtkit-daemon
+  #        sudo podman exec fedora-test sudo systemctl start rtkit-daemon
+  #        sudo podman exec fedora-test sudo systemctl start user@$(id -u)
+  #        sudo podman exec --env-file ./tmp.env fedora-test su -l -w FREEDV_BINARY,NO_AT_BRIDGE $(id -un) /workspace/appimage/container-test.sh | tee tmp.log
+  #        grep "PASS" tmp.log
 
   test-appimage-ubuntu:
     strategy:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm]
+        os: [ubuntu-24.04-arm, ubuntu-24.04]
         fedora-version: [42, 43]
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,5 +1,94 @@
 # Changes in older releases
 
+## V2.2.1 February 2026
+
+1. Bugfixes:
+    * Fix UBSan/TSan errors from 2.2.0 build. (PR #1200, #1208)
+    * Fix compile error when trying to use Hamlib 5.0-git. (PR #1202)
+    * Fix bug causing PTT input to be initially ignored until pushing the PTT button. (PR #1203)
+    * FlexRadio: Fix command format for UDP port. (PR #1205; thanks @amcdermond!)
+    * Cache PTT response time to minimize first TX reporting issues. (PR #1207)
+    * Hamlib: Add checking prior to retrieving minimum/maximum baud rates. (PR #1209)
+    * Autosize columns in main window drop-down list. (PR #1213)
+    * PulseAudio/pipewire: Use fixed wait time between processing cycles. (PR #1216)
+    * Slow down waterfall display when waterfall is small (i.e. displayed with other plots). (PR #1216)
+    * FlexRadio: Terminate on SIGHUP to avoid hangs on exit. (PR #1214)
+2. Build system:
+    * macOS: Fix dylibbundler call for compilation. (PR #1204)
+    * macOS: Add /Applications shortcut to generated DMG. (PR #1206)
+
+## V2.2.0 January 2026
+
+1. Bugfixes:
+    * Radio integrations:
+        * KA9Q: Need to divide read() rval with sizeof(short). (PR #1120)
+        * Flex/KA9Q: Only report to FreeDV Reporter if user is not hidden from former. (PR #1140)
+        * Flex: use poll() instead of select(). (PR #1143)
+        * Flex: use tanh() for audio limiting. (PR #1156)
+        * Flex/KA9Q: Fix problem preventing running of AppImages on Raspberry Pi OS/Debian bookworm. (PR #1158)
+        * Flex: set SO_REUSEADDR to allow NodeRed, etc. to work with the waveform. (PR #1161)
+        * Flex/KA9Q: Make sure each argument to AppImage is quote-escaped. (PR #1168)
+    * FreeDV Reporter:
+        * Left-align cardinal directions. (PR #1139)
+        * Defer row adds and removes until timer fires to reduce flicker. (PR #1162)
+    * Update VC Redistributable and suppress reboots during its installation. (PR #1102)
+    * Reduce RADE RX losses due to resampling. (PR #1094)
+    * Use same sample rate for both recording RX and TX. (PR #1107)
+    * Fix intermittent crash on FreeDV Reporter connection loss. (PR #1112, #1115, #1178)
+    * Suppress background for fake rightmost column. (PR #1116)
+    * Emit VOX tone only when PTT is enabled. (PR #1122)
+    * OmniRig: Fix crash when using Test button in CAT config dialog. (PR #1126)
+    * Fix hidden/clipped axis labels on plots. (PR #1110)
+    * Work around deadlock bug in tty0tty. (PR #1134) - thanks @barjac!
+    * Zero out waterfall when transmitting and not in full duplex. (PR #1136)
+    * Avoid data race when terminating application. (PR #1140)
+    * Fix issue saving frequency list on non-English systems. (PR #1152)
+    * Suspend PTT input changes while transitioning TX<->RX. (PR #1151)
+    * Fix memory corruption when stopping and starting different playback files. (PR #1157)
+    * Update unit test infrastructure to fix initial (within ~2-3s) RADE desyncs. (PR #1167)
+    * Windows: disable microphone check on start. (PR #1191)
+    * UdpHandler: fix crash when unable to resolve DNS. (PR #1193)
+    * Prevent reset of FreeDV Reporter connection while running. (PR #1193)
+    * Disable UDP Reporting checkbox when running. (PR #1193)
+    * Fix waterfall rendering issue with multiple plots displayed at once. (PR #1193)
+    * Fix inconsistent behavior when selecting/deselecting rows from the main window drop-down list. (PR #1184)
+    * OmniRig: Don't suppresss frequency updates on initial connect. (PR #1184)
+    * Hamlib: increase timeout to 625ms. (PR #1195)
+2. Enhancements:
+    * FlexRadio support:
+        * Report FreeDV SNR using SmartSDR Meter API. (PR #1119)
+        * Use random port for VITA socket after connect. (PR #1141)
+        * Allow Ctrl-C to clean up the waveform. (PR #1144, #1146, #1160) - thanks @arodland!
+        * Allow FreeDV Reporter parameters to be overridden via command line. (PR #1154)
+        * Add command line option to adjust RX volume. (PR #1159)
+        * Allow user-configurable spot timeout (default 10 minutes). (PR #1169)
+        * Report SNR in spots added to SmartSDR. (PR #1179)
+    * KA9Q/SDR support:
+        * Allow user message to be reported to FreeDV Reporter. (PR #1179)
+    * FreeDV Reporter:
+        * Allow columns to be rearranged and/or made invisible. (PR #1132)
+        * Sort empty user messages below non-empty ones. (PR #1105)
+        * Add idle filter. (PR #1142, #1180, #1183, #1189)
+        * Add right-click menu for callsign lookups. (PR #1171, #1185)
+        * Add filtered indicator to bottom of window. (PR #1166)
+    * Upgrade Python to 3.14.2. (PR #1109, #1118, #1124, #1174)
+    * Add support for BBWENet bandwidth expander for received RADE audio. (PR #1113)
+    * Reduce CPU usage rendering "scalar" plots (i.e. From Mic). (PR #1133)
+    * Linux: List /dev/rfcomm* serial devices when configuring. (PR #1106) - thanks @NespaLa!
+    * Hamlib: Allow selection of baud rates greater than 115200. (PR #1125)
+    * Add support for loggers that support the WSJT-X networking protocol. (PR #1129, #1153, #1184, #1196)
+    * Add support for recording decoded audio. (PR #1145, #1184)
+    * Display Hamlib version in Help->About. (PR #1169)
+3. Build system:
+    * Use Clang to build AppImages for better performance. (PR #1149)
+    * Enable link-time optimization for AppImages, DMGs and Windows builds. (PR #1163)
+    * Enable profile-guided optimation for AppImages. (PR #1173)
+4. Other:
+    * Remove 5.3665 MHz as a default frequency. (PR #1187)
+
+*Note: Legacy modes (700D, 700E, 1600) are now hidden by default. (PR #1108) You can show them
+again by going to Tools->Options->Modem and selecting "Enable Legacy Modes".*
+
 ## V2.1.0 November 2025
 
 1. Bugfixes:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -933,7 +933,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix RADE related compiler errors. (PR #1299)
     * Logging: fix incorrect time when using UTC due to DST. (PR #1302) - thanks @barjac!
     * Ensure that PTT is actually off when opening Hamlib connection. (PR #1308)
-    * Fix race condition preventing frequency/mode from changing on start with SmartSDR 4.2. (PR #1314, #1320)
+    * Fix race condition preventing frequency/mode from changing on start with SmartSDR 4.2. (PR #1314, #1320, #1321)
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)
@@ -967,95 +967,6 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Update FlexRadio waveform README to reflect SmartSDR 4.2 release. (PR #1311)
 5. Other:
     * Audio resampling logic consolidated in one location for ease of maintenance. (PR #1286, #1307)
-
-## V2.2.1 February 2026
-
-1. Bugfixes:
-    * Fix UBSan/TSan errors from 2.2.0 build. (PR #1200, #1208)
-    * Fix compile error when trying to use Hamlib 5.0-git. (PR #1202)
-    * Fix bug causing PTT input to be initially ignored until pushing the PTT button. (PR #1203)
-    * FlexRadio: Fix command format for UDP port. (PR #1205; thanks @amcdermond!)
-    * Cache PTT response time to minimize first TX reporting issues. (PR #1207)
-    * Hamlib: Add checking prior to retrieving minimum/maximum baud rates. (PR #1209)
-    * Autosize columns in main window drop-down list. (PR #1213)
-    * PulseAudio/pipewire: Use fixed wait time between processing cycles. (PR #1216)
-    * Slow down waterfall display when waterfall is small (i.e. displayed with other plots). (PR #1216)
-    * FlexRadio: Terminate on SIGHUP to avoid hangs on exit. (PR #1214)
-2. Build system:
-    * macOS: Fix dylibbundler call for compilation. (PR #1204)
-    * macOS: Add /Applications shortcut to generated DMG. (PR #1206)
-
-## V2.2.0 January 2026
-
-1. Bugfixes:
-    * Radio integrations:
-        * KA9Q: Need to divide read() rval with sizeof(short). (PR #1120)
-        * Flex/KA9Q: Only report to FreeDV Reporter if user is not hidden from former. (PR #1140)
-        * Flex: use poll() instead of select(). (PR #1143)
-        * Flex: use tanh() for audio limiting. (PR #1156)
-        * Flex/KA9Q: Fix problem preventing running of AppImages on Raspberry Pi OS/Debian bookworm. (PR #1158)
-        * Flex: set SO_REUSEADDR to allow NodeRed, etc. to work with the waveform. (PR #1161)
-        * Flex/KA9Q: Make sure each argument to AppImage is quote-escaped. (PR #1168)
-    * FreeDV Reporter:
-        * Left-align cardinal directions. (PR #1139)
-        * Defer row adds and removes until timer fires to reduce flicker. (PR #1162)
-    * Update VC Redistributable and suppress reboots during its installation. (PR #1102)
-    * Reduce RADE RX losses due to resampling. (PR #1094)
-    * Use same sample rate for both recording RX and TX. (PR #1107)
-    * Fix intermittent crash on FreeDV Reporter connection loss. (PR #1112, #1115, #1178)
-    * Suppress background for fake rightmost column. (PR #1116)
-    * Emit VOX tone only when PTT is enabled. (PR #1122)
-    * OmniRig: Fix crash when using Test button in CAT config dialog. (PR #1126)
-    * Fix hidden/clipped axis labels on plots. (PR #1110)
-    * Work around deadlock bug in tty0tty. (PR #1134) - thanks @barjac!
-    * Zero out waterfall when transmitting and not in full duplex. (PR #1136)
-    * Avoid data race when terminating application. (PR #1140)
-    * Fix issue saving frequency list on non-English systems. (PR #1152)
-    * Suspend PTT input changes while transitioning TX<->RX. (PR #1151)
-    * Fix memory corruption when stopping and starting different playback files. (PR #1157)
-    * Update unit test infrastructure to fix initial (within ~2-3s) RADE desyncs. (PR #1167)
-    * Windows: disable microphone check on start. (PR #1191)
-    * UdpHandler: fix crash when unable to resolve DNS. (PR #1193)
-    * Prevent reset of FreeDV Reporter connection while running. (PR #1193)
-    * Disable UDP Reporting checkbox when running. (PR #1193)
-    * Fix waterfall rendering issue with multiple plots displayed at once. (PR #1193)
-    * Fix inconsistent behavior when selecting/deselecting rows from the main window drop-down list. (PR #1184)
-    * OmniRig: Don't suppresss frequency updates on initial connect. (PR #1184)
-    * Hamlib: increase timeout to 625ms. (PR #1195)
-2. Enhancements:
-    * FlexRadio support:
-        * Report FreeDV SNR using SmartSDR Meter API. (PR #1119)
-        * Use random port for VITA socket after connect. (PR #1141)
-        * Allow Ctrl-C to clean up the waveform. (PR #1144, #1146, #1160) - thanks @arodland!
-        * Allow FreeDV Reporter parameters to be overridden via command line. (PR #1154)
-        * Add command line option to adjust RX volume. (PR #1159)
-        * Allow user-configurable spot timeout (default 10 minutes). (PR #1169)
-        * Report SNR in spots added to SmartSDR. (PR #1179)
-    * KA9Q/SDR support:
-        * Allow user message to be reported to FreeDV Reporter. (PR #1179)
-    * FreeDV Reporter:
-        * Allow columns to be rearranged and/or made invisible. (PR #1132)
-        * Sort empty user messages below non-empty ones. (PR #1105)
-        * Add idle filter. (PR #1142, #1180, #1183, #1189)
-        * Add right-click menu for callsign lookups. (PR #1171, #1185)
-        * Add filtered indicator to bottom of window. (PR #1166)
-    * Upgrade Python to 3.14.2. (PR #1109, #1118, #1124, #1174)
-    * Add support for BBWENet bandwidth expander for received RADE audio. (PR #1113)
-    * Reduce CPU usage rendering "scalar" plots (i.e. From Mic). (PR #1133)
-    * Linux: List /dev/rfcomm* serial devices when configuring. (PR #1106) - thanks @NespaLa!
-    * Hamlib: Allow selection of baud rates greater than 115200. (PR #1125)
-    * Add support for loggers that support the WSJT-X networking protocol. (PR #1129, #1153, #1184, #1196)
-    * Add support for recording decoded audio. (PR #1145, #1184)
-    * Display Hamlib version in Help->About. (PR #1169)
-3. Build system:
-    * Use Clang to build AppImages for better performance. (PR #1149)
-    * Enable link-time optimization for AppImages, DMGs and Windows builds. (PR #1163)
-    * Enable profile-guided optimation for AppImages. (PR #1173)
-4. Other:
-    * Remove 5.3665 MHz as a default frequency. (PR #1187)
-
-*Note: Legacy modes (700D, 700E, 1600) are now hidden by default. (PR #1108) You can show them
-again by going to Tools->Options->Modem and selecting "Enable Legacy Modes".*
 
 ## Earlier than V2.2.0
 

--- a/src/audio/WASAPIAudioEngine.cpp
+++ b/src/audio/WASAPIAudioEngine.cpp
@@ -63,6 +63,12 @@ void WASAPIAudioEngine::start()
     auto prom = std::make_shared<std::promise<void> >();
     auto fut = prom->get_future();
     enqueue_([&]() {
+        // Prevent sleep while audio is in use
+        SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_AWAYMODE_REQUIRED);
+
+        // Request highest resolution timers
+        timeBeginPeriod(1);
+
         // Get device enumerator
         HRESULT hr = CoCreateInstance(
            CLSID_MMDeviceEnumerator, NULL,
@@ -125,6 +131,12 @@ void WASAPIAudioEngine::stop()
     auto prom = std::make_shared<std::promise<void> >();
     auto fut = prom->get_future();
     enqueue_([&]() {
+        // Regular sleep behavior can resume
+        SetThreadExecutionState(ES_CONTINUOUS);
+
+        // No longer need high resolution timing
+        timeEndPeriod(1);
+
         devEnumerator_ = nullptr;
         inputDeviceList_ = nullptr;
         outputDeviceList_ = nullptr;

--- a/src/gui/util/wxMessageBoxWrapper.h
+++ b/src/gui/util/wxMessageBoxWrapper.h
@@ -41,7 +41,7 @@ inline int wxMessageBoxWrapper(const wxString& message,
         log_fatal("wxMessageBox called during test '%s': %s",
                   (const char*)testName.ToUTF8(),
                   (const char*)message.ToUTF8());
-        exit(1);
+        exit(1); // NOLINT
     }
     return wxMessageBox(message, caption, style, parent, x, y);
 }

--- a/src/gui/util/wxMessageBoxWrapper.h
+++ b/src/gui/util/wxMessageBoxWrapper.h
@@ -1,0 +1,51 @@
+//==========================================================================
+// Name:            wxMessageBoxWrapper.h
+//
+// Purpose:         Wraps wxMessageBox to fail tests when called during a
+//                  test run (i.e. testName is non-empty).
+//
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+#ifndef __WX_MESSAGE_BOX_WRAPPER__
+#define __WX_MESSAGE_BOX_WRAPPER__
+
+#include "wx/wx.h"
+#include "util/logging/ulog.h"
+
+extern wxString testName;
+
+// NOTE: This function is defined before the #define below so that the call to
+// wxMessageBox inside its body resolves to the real wx function, not this
+// wrapper (the macro is not yet active during preprocessing of this body).
+inline int wxMessageBoxWrapper(const wxString& message,
+                                const wxString& caption = wxMessageBoxCaptionStr,
+                                int style = wxOK | wxCENTRE,
+                                wxWindow* parent = NULL,
+                                int x = wxDefaultCoord,
+                                int y = wxDefaultCoord)
+{
+    if (!testName.empty())
+    {
+        log_fatal("wxMessageBox called during test '%s': %s",
+                  (const char*)testName.ToUTF8(),
+                  (const char*)message.ToUTF8());
+        exit(1);
+    }
+    return wxMessageBox(message, caption, style, parent, x, y);
+}
+
+#define wxMessageBox wxMessageBoxWrapper
+
+#endif // __WX_MESSAGE_BOX_WRAPPER__

--- a/src/main.h
+++ b/src/main.h
@@ -92,6 +92,7 @@
 #include "pipeline/paCallbackData.h"
 #include "pipeline/LinkStep.h"
 #include "util/sanitizers.h"
+#include "gui/util/wxMessageBoxWrapper.h"
 
 #define _USE_TIMER              1
 #define _USE_ONIDLE             1

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1715,6 +1715,16 @@ void MainFrame::OnChangeReportFrequency( wxCommandEvent& )
     wxString freqStr = m_cboReportFrequency->GetValue();
     auto oldFreq = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
 
+    wxString oldFreqString;            
+    if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
+    {
+        oldFreqString = wxNumberFormatter::ToString(oldFreq / 1000.0, 1);
+    }
+    else
+    {
+        oldFreqString = wxNumberFormatter::ToString(oldFreq / 1000.0 / 1000.0, 4);
+    }
+
     if (freqStr.Length() > 0)
     {
         double tmp = 0;
@@ -1755,7 +1765,7 @@ void MainFrame::OnChangeReportFrequency( wxCommandEvent& )
         m_cboReportFrequency->SetForegroundColour(wxColor(*wxRED));
     }
 
-    if (oldFreq != wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency)
+    if (freqStr != oldFreqString)
     {      
         // Report current frequency to reporters
         for (auto& ptr : wxGetApp().m_reporters)

--- a/src/pipeline/IPipelineStep.h
+++ b/src/pipeline/IPipelineStep.h
@@ -120,21 +120,19 @@ void IPipelineStep::ConvertToIntSampleType_(SrcType* sourceSamples, DstType* des
     }
     else
     {
-        auto multiplier = SampleMultiplier + 1;
-        if (SampleMultiplier != std::numeric_limits<DstType>::max())
-        {
-            multiplier = SampleMultiplier;
-        }
+        constexpr auto MIN_DST_TYPE_VAL = std::numeric_limits<DstType>::min();
+        constexpr auto MAX_DST_TYPE_VAL = std::numeric_limits<DstType>::max();
+        constexpr auto multiplier = (SampleMultiplier != MAX_DST_TYPE_VAL) ? SampleMultiplier : (SampleMultiplier + 1);
         for (std::size_t index = 0; index < numSamples; index++)
         {
             SrcType temp = sourceSamples[index] * multiplier;
-            if (temp <= std::numeric_limits<DstType>::min())
+            if (temp <= MIN_DST_TYPE_VAL)
             {
-                destSamples[index] = std::numeric_limits<DstType>::min();
+                destSamples[index] = MIN_DST_TYPE_VAL;
             }
-            else if (temp >= std::numeric_limits<DstType>::max())
+            else if (temp >= MAX_DST_TYPE_VAL)
             {
-                destSamples[index] = std::numeric_limits<DstType>::max();
+                destSamples[index] = MAX_DST_TYPE_VAL;
             }
             else
             {

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -91,6 +91,7 @@ HamlibRigController::HamlibRigController(std::string rigName, std::string serial
     , destroying_(false)
     , rigResponseTime_(0)
     , errorEncountered_(false)
+    , getFreqModeErrorCount_(0)
 {
     // Perform initial load of rig list if this is our first time being created.
     InitializeHamlibLibrary();
@@ -118,6 +119,7 @@ HamlibRigController::HamlibRigController(int rigIndex, std::string serialPort, c
     , destroying_(false)
     , rigResponseTime_(0)
     , errorEncountered_(false)
+    , getFreqModeErrorCount_(0)
 {
     // Perform initial load of rig list if this is our first time being created.
     InitializeHamlibLibrary();
@@ -325,6 +327,7 @@ void HamlibRigController::connectImpl_()
     origFreq_ = 0;
     origMode_ = RIG_MODE_NONE;
     errorEncountered_ = false;
+    getFreqModeErrorCount_ = 0;
 
     auto tmpRig = rig_init(RigList_[rigIndex]->rig_model);
     if (!tmpRig) 
@@ -747,7 +750,8 @@ modeAttempt:
     if (result != RIG_OK && currVfo == RIG_VFO_CURR)
     {
         log_debug("rig_get_mode: error = %s ", rigerror(result));
-        if (!errorEncountered_)
+        getFreqModeErrorCount_++;
+        if (!errorEncountered_ && getFreqModeErrorCount_ > MAX_GET_FREQUENCY_ERR_COUNT)
         {
             std::string errMsg = std::string("Could not retrieve current radio mode: ") + HAMLIB_FRIENDLY_ERROR_FN(result);
             onRigError(this, errMsg);
@@ -771,7 +775,9 @@ freqAttempt:
         {
             log_debug("rig_get_freq: error = %s ", rigerror(result));
             
-            if (!errorEncountered_)
+            getFreqModeErrorCount_++;
+
+            if (!errorEncountered_ && getFreqModeErrorCount_ > MAX_GET_FREQUENCY_ERR_COUNT)
             {
                 std::string errMsg = std::string("Could not get current frequency: ") + HAMLIB_FRIENDLY_ERROR_FN(result);
                 onRigError(this, errMsg);
@@ -826,6 +832,10 @@ freqAttempt:
                 origMode_ = mode;
             }
             
+            // Reset get freq/mode error count since we don't want intermittent errors
+            // to cause a popup.
+            getFreqModeErrorCount_ = 0;
+
             onFreqModeChange(this, freq, currMode);
         }
     }

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -96,10 +96,19 @@ private:
     bool destroying_;
     
     int rigResponseTime_;
-    
+  
     // Tracks errors encountered during/after rig_open() so that
     // we only display the error box once.
     bool errorEncountered_;
+
+    // Number of frequency/mode retrieval errors seen.
+    // This is so that we have a bit of leeway before showing the error
+    // box, as errors can sometimes be emitted yet no problems exist
+    // (example: rapidly spinning the dial on the radio side)
+    int getFreqModeErrorCount_;
+
+    // 2 or more errors while retrieving freq/mode should cause the popup to appear
+    const int MAX_GET_FREQUENCY_ERR_COUNT = 1;
     
     vfo_t getCurrentVfo_();
     void setFrequencyHelper_(vfo_t currVfo, uint64_t frequencyHz);

--- a/test/test_rade_loss.sh
+++ b/test/test_rade_loss.sh
@@ -104,24 +104,27 @@ FDV_PID=$!
 #wpctl status
 #pw-top -b -n 5
 wait $FDV_PID
+FREEDV_EXIT_CODE=$?
 cat tmp.log
 
 # Stop recording, play back in RX mode
 kill $RECORD_PID
 #cp $(pwd)/gmon.out $(pwd)/gmon.out.tx
 
-$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav -rxfeaturefile $(pwd)/rxfeatures.f32 >tmp.log 2>&1 &
-FDV_PID=$!
+if [ $FREEDV_EXIT_CODE -eq 0 ]; then
+    $FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav -rxfeaturefile $(pwd)/rxfeatures.f32 >tmp.log 2>&1 &
+    FDV_PID=$!
 
-#if [ "$OPERATING_SYSTEM" != "Linux" ]; then
-#    xctrace record --template "Audio System Trace" --instrument "Time Profiler" --window 3m --output "instruments_trace_rx_${FDV_PID}.trace" --attach $FDV_PID
-#fi
-wait $FDV_PID
-FREEDV_EXIT_CODE=$?
-cat tmp.log
+    #if [ "$OPERATING_SYSTEM" != "Linux" ]; then
+    #    xctrace record --template "Audio System Trace" --instrument "Time Profiler" --window 3m --output "instruments_trace_rx_${FDV_PID}.trace" --attach $FDV_PID
+    #fi
+    wait $FDV_PID
+    FREEDV_EXIT_CODE=$?
+    cat tmp.log
 
-# Run feature files through loss tool
-$PYTHON_BINARY $(pwd)/rade_src/loss.py txfeatures.f32 rxfeatures.f32 --loss_test 0.15
+    # Run feature files through loss tool
+    $PYTHON_BINARY $(pwd)/rade_src/loss.py txfeatures.f32 rxfeatures.f32 --loss_test 0.15
+fi
 
 # Clean up PulseAudio virtual devices
 if [ "$OPERATING_SYSTEM" == "Linux" ]; then

--- a/test/test_rade_reporting.sh
+++ b/test/test_rade_reporting.sh
@@ -113,32 +113,35 @@ FDV_PID=$!
 #wpctl status
 #pw-top -b -n 5
 wait $FDV_PID
+FREEDV_EXIT_CODE=$?
 cat tmp.log
 
 # Stop recording, play back in RX mode
 kill $RECORD_PID
 
-if [ "$1" != "" ]; then
-    FADING_DIR="$SCRIPTPATH/fading"
+if [ $FREEDV_EXIT_CODE -eq 0 ]; then
+    if [ "$1" != "" ]; then
+        FADING_DIR="$SCRIPTPATH/fading"
 
-    # Add noise to recording to test performance
-    if [ "$2" == "mpp" ]; then
-        sox $(pwd)/test.wav -t raw -r 8000 -c 1 -e signed-integer -b 16 - | $1/src/ch - - --No -25 --mpp --fading_dir $FADING_DIR | sox -t raw -r 8000 -c 1 -e signed-integer -b 16 - -t wav $(pwd)/testwithnoise.wav
-    elif [ "$2" == "awgn" ]; then
-        sox $(pwd)/test.wav -t raw -r 8000 -c 1 -e signed-integer -b 16 - | $1/src/ch - - --No -18 | sox -t raw -r 8000 -c 1 -e signed-integer -b 16 - -t wav $(pwd)/testwithnoise.wav
+        # Add noise to recording to test performance
+        if [ "$2" == "mpp" ]; then
+            sox $(pwd)/test.wav -t raw -r 8000 -c 1 -e signed-integer -b 16 - | $1/src/ch - - --No -25 --mpp --fading_dir $FADING_DIR | sox -t raw -r 8000 -c 1 -e signed-integer -b 16 - -t wav $(pwd)/testwithnoise.wav
+        elif [ "$2" == "awgn" ]; then
+            sox $(pwd)/test.wav -t raw -r 8000 -c 1 -e signed-integer -b 16 - | $1/src/ch - - --No -18 | sox -t raw -r 8000 -c 1 -e signed-integer -b 16 - -t wav $(pwd)/testwithnoise.wav
+        fi
+        mv $(pwd)/testwithnoise.wav $(pwd)/test.wav
     fi
-    mv $(pwd)/testwithnoise.wav $(pwd)/test.wav
+
+    $FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav >tmp.log 2>&1 &
+    FDV_PID=$!
+
+    #if [ "$OPERATING_SYSTEM" != "Linux" ]; then
+    #    xctrace record --template "Audio System Trace" --window 2m --output "instruments_trace_${FDV_PID}.trace" --attach $FDV_PID
+    #fi
+    wait $FDV_PID
+    FREEDV_EXIT_CODE=$?
+    cat tmp.log
 fi
-
-$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav >tmp.log 2>&1 &
-FDV_PID=$!
-
-#if [ "$OPERATING_SYSTEM" != "Linux" ]; then
-#    xctrace record --template "Audio System Trace" --window 2m --output "instruments_trace_${FDV_PID}.trace" --attach $FDV_PID
-#fi
-wait $FDV_PID
-FREEDV_EXIT_CODE=$?
-cat tmp.log
 
 # Clean up PulseAudio virtual devices
 if [ "$OPERATING_SYSTEM" == "Linux" ]; then


### PR DESCRIPTION
Followup PR from yesterday (2026-05-02) to further improve fixes to Hamlib logic to prevent intermittent errors during frequency/mode retrieval while rapidly turning the radio VFO.

Note: some code implemented using Claude Code.