### PR TITLE
WASAPI: Partially revert IAudioClient3-based init.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -934,6 +934,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Logging: fix incorrect time when using UTC due to DST. (PR #1302) - thanks @barjac!
     * Ensure that PTT is actually off when opening Hamlib connection. (PR #1308)
     * Fix race condition preventing frequency/mode from changing on start with SmartSDR 4.2. (PR #1314, #1320, #1321, #1322)
+    * Fix inability to open web browser in AppImages (e.g. when viewing callsign info). (PR #1326)
 2. Enhancements:
     * FreeDV Reporter: Use ItemsAdded/ItemsDeleted instead of Cleared() for performance. (PR #1212)
     * Optimize "From XXX" plot performance. (PR #1238, #1239)

--- a/appimage/AppRun-FlexRadio.sh
+++ b/appimage/AppRun-FlexRadio.sh
@@ -1,13 +1,8 @@
 #!/bin/bash -e
 echo "In AppImage AppRun"
 export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin"
+export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
 echo "PATH=$PATH"
-export PYTHONHOME="$APPDIR/usr"
-export PYTHONPATH="$APPDIR/rade_src:$APPDIR/rade-venv/lib/python3.14/site-packages"
-echo "PYTHONPATH=$PYTHONPATH"
-echo "PYTHONHOME=$PYTHONHOME"
-export PYTHONMALLOC=mimalloc
 cd "$APPDIR"
 echo "#### after import"
 "$APPDIR/usr/bin/freedv-flex" "$@"

--- a/appimage/AppRun-KA9Q.sh
+++ b/appimage/AppRun-KA9Q.sh
@@ -1,13 +1,8 @@
 #!/bin/bash -e
 echo "In AppImage AppRun"
 export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin"
+export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
 echo "PATH=$PATH"
-export PYTHONHOME="$APPDIR/usr"
-export PYTHONPATH="$APPDIR/rade_src:$APPDIR/rade-venv/lib/python3.14/site-packages"
-echo "PYTHONPATH=$PYTHONPATH"
-echo "PYTHONHOME=$PYTHONHOME"
-export PYTHONMALLOC=mimalloc
 cd "$APPDIR"
 echo "#### after import"
 "$APPDIR/usr/bin/freedv-ka9q" "$@"

--- a/appimage/AppRun.sh
+++ b/appimage/AppRun.sh
@@ -1,13 +1,8 @@
 #!/bin/bash -e
 echo "In AppImage AppRun"
 export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin"
+export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
 echo "PATH=$PATH"
-export PYTHONHOME="$APPDIR/usr"
-export PYTHONPATH="$APPDIR/rade_src:$APPDIR/rade-venv/lib/python3.14/site-packages"
-export PYTHONMALLOC=mimalloc
-echo "PYTHONPATH=$PYTHONPATH"
-echo "PYTHONHOME=$PYTHONHOME"
 cd "$APPDIR"
 echo "#### after import"
 "$APPDIR/usr/bin/freedv" "$@"

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -210,64 +210,16 @@ void WASAPIAudioDevice::start()
 
         if (!initialized_)
         {
-            //REFERENCE_TIME desiredRefTime = BLOCK_TIME_NS / NS_PER_REFTIME; // REFERENCE_TIME is in 100ns units
-            UINT32 defaultPeriodInFrames = 0;
-            UINT32 fundamentalPeriodInFrames = 0;
-            UINT32 minPeriodInFrames = 0;
-            UINT32 maxPeriodInFrames = 0;
-            hr = client_->GetSharedModeEnginePeriod(
-                streamFormatPtr,
-                &defaultPeriodInFrames,
-                &fundamentalPeriodInFrames,
-                &minPeriodInFrames,
-                &maxPeriodInFrames);
-            if (FAILED(hr))
-            {
-                std::stringstream ss;
-                ss << "Could not get audio engine period (hr = " << hr << ")";
-                log_error(ss.str().c_str());
-                if (onAudioErrorFunction)
-                {
-                    onAudioErrorFunction(*this, ss.str(), onAudioErrorState);
-                }
-                prom->set_value();
-                return;
-            }
-
-            log_info(
-                "Default period: %d, fundamental period: %d, minPeriod: %d, maxPeriod: %d",
-                defaultPeriodInFrames,
-                fundamentalPeriodInFrames,
-                minPeriodInFrames,
-                maxPeriodInFrames);
-              
-            // Initialize the audio client with the above format
-            hr = client_->InitializeSharedAudioStream(
-                AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-                defaultPeriodInFrames,
+            REFERENCE_TIME desiredRefTime = BLOCK_TIME_NS / NS_PER_REFTIME; // REFERENCE_TIME is in 100ns units
+            hr = client_->Initialize(
+                AUDCLNT_SHAREMODE_SHARED,
+                AUDCLNT_STREAMFLAGS_EVENTCALLBACK | 
+                    AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                    AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+                desiredRefTime,
+                0,
                 streamFormatPtr,
                 nullptr);
-            if (AUDCLNT_E_ENGINE_PERIODICITY_LOCKED == hr)
-            {
-                // Try again with actual period
-                WAVEFORMATEX* tempFormat = nullptr;
-                hr = client_->GetCurrentSharedModeEnginePeriod(
-                    &tempFormat,
-                    &defaultPeriodInFrames);
-                (void)tempFormat; // ignore warnings
-                if (FAILED(hr))
-                {
-                    std::stringstream ss;
-                    ss << "Could not get current engine period (hr = " << hr << ")";
-                    log_warn(ss.str().c_str());
-                }
-
-                hr = client_->InitializeSharedAudioStream(
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-                    defaultPeriodInFrames,
-                    streamFormatPtr,
-                    nullptr);
-            }
 
             if (freeStreamFormat)
             {

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -702,14 +702,6 @@ void WASAPIAudioDevice::captureAudio_(ComPtr<IAudioCaptureClient> captureClient)
             }
             else
             {
-                if (flags & AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY)
-                {
-                    log_warn("Audio data discontinuity detected");
-                    if (onAudioOverflowFunction)
-                    {
-                        onAudioOverflowFunction(*this, onAudioOverflowState);
-                    }
-                }
                 copyFromWindowsBuffer_(data, numFramesAvailable);
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2312,6 +2312,7 @@ void MainFrame::OnChangeTxMode( wxCommandEvent& event )
 void MainFrame::performFreeDVOn_()
 {
     log_debug("Start .....");
+    isModemRunning.store(false, std::memory_order_release);
     g_queueResync.store(false, std::memory_order_release);
     endingTx.store(false, std::memory_order_release);
     g_voice_keyer_tx.store(false, std::memory_order_release);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -526,10 +526,14 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
             // on the radio side). Note that this also causes reporting to not fire 
             // by m_cboReportFrequency's change handler, so we should fire off reporting
             // here.
+            auto oldFreq = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
             wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = freq;
-            for (auto& ptr : wxGetApp().m_reporters)
+            if (oldFreq != freq)
             {
-                ptr->freqChange(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
+                for (auto& ptr : wxGetApp().m_reporters)
+                {
+                    ptr->freqChange(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
+                }
             }
             
             m_cboReportFrequency->SetValue(freqString);


### PR DESCRIPTION
Partially reverts changes from #1300 due to causing problems with certain audio devices with the limited test group that is testing 2.3.0.