### PR TITLE
topFrame: fix TX level/tune context menus on wxGTK < 3.3 (wx3.2)

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -914,7 +914,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 ## V2.3.1 TBD 2026
 
 1. Bugfixes:
-    * TBD
+    * Fix TX/tune level context menus on Linux distros using wxWidgets <= 3.2. (PR #1333)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -941,9 +941,19 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_btnTxLevelPP->Connect(wxEVT_MOUSEWHEEL, wxMouseEventHandler(TopFrame::OnTxLevelMouseWheel), NULL, this);
     m_btnTogTune->Connect(wxEVT_MOUSEWHEEL, wxMouseEventHandler(TopFrame::OnTxLevelMouseWheel), NULL, this);
 
+#if wxCHECK_VERSION(3, 3, 0)
+    // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press for these widget types,
+    // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP instead.
     m_txLevelBox->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTxLevelContextMenu(ctx); });
     m_txtTxLevelNum->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTxLevelContextMenu(ctx); });
     m_btnTogTune->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTuneAttenContextMenu(ctx); });
+#else
+    // wxGTK < 3.3 does not generate RIGHT_UP for windowless widget types
+    // (wxStaticBox, wxStaticText); CONTEXT_MENU works without the dismiss issue.
+    m_txLevelBox->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
+    m_txtTxLevelNum->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
+    m_btnTogTune->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTuneAttenContextMenu), NULL, this);
+#endif
 
     m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
     m_sliderMicSpkrLevel->Connect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
@@ -1045,6 +1055,11 @@ TopFrame::~TopFrame()
     m_btnTxLevelM->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecr), NULL, this);
     m_btnTxLevelP->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelIncr), NULL, this);
     m_btnTxLevelPP->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelIncrBig), NULL, this);
+#if !wxCHECK_VERSION(3, 3, 0)
+    m_txLevelBox->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
+    m_txtTxLevelNum->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
+    m_btnTogTune->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTuneAttenContextMenu), NULL, this);
+#endif
 
     m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);
     m_sliderMicSpkrLevel->Disconnect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnChangeMicSpkrLevel), NULL, this);


### PR DESCRIPTION
Fixes #1332

The RIGHT_UP bindings introduced in #1323 work correctly on wxGTK >= 3.3, but wxGTK < 3.3 (wxWidgets 3.2, as shipped in Mageia 9 and other current distros) does not generate `wxEVT_RIGHT_UP` for windowless widget types such as `wxStaticBox` and `wxStaticText`. As a result the TX level and tune context menus are unreachable on those builds.

This patch version-gates the binding:
- **wx >= 3.3**: keeps `RIGHT_UP` (avoids the button-release dismiss issue fixed in #1323)
- **wx < 3.3**: falls back to `CONTEXT_MENU`, which works correctly on these widget types without the dismiss problem

Tested on Mageia 9 (wxWidgets 3.2.8) and Mageia 10 (wxWidgets 3.3), covering both code paths.