### PR TITLE
WASAPI: Disable HW offload introduced in 2.3.0.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -915,6 +915,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Fix TX/tune level context menus on Linux distros using wxWidgets <= 3.2. (PR #1333) - thanks @barjac!
+    * Fix audio routing problems on Windows due to hardware offloading. (PR #1335)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
 

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -124,7 +124,7 @@ void WASAPIAudioDevice::start()
         // rate/number of channels.
         // NOTE: this should already have been determined valid
         // by the audio engine!
-        hr = client_->GetMixFormat(&streamFormatPtr);
+        HRESULT hr = client_->GetMixFormat(&streamFormatPtr);
         if (SUCCEEDED(hr))
         {
             freeStreamFormat = true;

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -30,7 +30,7 @@
 #include <inttypes.h>
 #include "../util/logging/ulog.h"
 
-#define BLOCK_TIME_NS (20000000)
+#define BLOCK_TIME_NS (10000000)
 
 // Nanoseconds per REFERENCE_TIME unit
 #define NS_PER_REFTIME (100)
@@ -97,13 +97,12 @@ void WASAPIAudioDevice::start()
         WAVEFORMATEX streamFormat;
         bool freeStreamFormat = false;
 
-#if 0        
         // Set AudioClientProperties for stream. Must be done prior to Initialize().
         AudioClientProperties prop;
         prop.cbSize = sizeof(AudioClientProperties);
         prop.bIsOffload = TRUE;
-        prop.eCategory = AudioCategory_Communications;
-        prop.Options = AUDCLNT_STREAMOPTIONS_NONE;
+        prop.eCategory = AudioCategory_Other;
+        prop.Options = AUDCLNT_STREAMOPTIONS_RAW;
         HRESULT hr = client_->SetClientProperties(&prop);
         if (FAILED(hr))
         {
@@ -118,13 +117,12 @@ void WASAPIAudioDevice::start()
                 log_warn(ss.str().c_str());
             }
         }
-#endif // 0
         
         // Populate stream format based on requested sample
         // rate/number of channels.
         // NOTE: this should already have been determined valid
         // by the audio engine!
-        HRESULT hr = client_->GetMixFormat(&streamFormatPtr);
+        hr = client_->GetMixFormat(&streamFormatPtr);
         if (SUCCEEDED(hr))
         {
             freeStreamFormat = true;

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -100,22 +100,16 @@ void WASAPIAudioDevice::start()
         // Set AudioClientProperties for stream. Must be done prior to Initialize().
         AudioClientProperties prop;
         prop.cbSize = sizeof(AudioClientProperties);
-        prop.bIsOffload = TRUE;
+        prop.bIsOffload = FALSE;
         prop.eCategory = AudioCategory_Other;
         prop.Options = AUDCLNT_STREAMOPTIONS_RAW;
         HRESULT hr = client_->SetClientProperties(&prop);
         if (FAILED(hr))
         {
-            // Try disabling offload as not all devices support it.
-            prop.bIsOffload = FALSE;
-            hr = client_->SetClientProperties(&prop);
-            if (FAILED(hr))
-            {
-                // Non-critical error, can continue without setting properties.
-                std::stringstream ss;
-                ss << "Could not set AudioClient properties (hr = " << hr << ")";
-                log_warn(ss.str().c_str());
-            }
+            // Non-critical error, can continue without setting properties.
+            std::stringstream ss;
+            ss << "Could not set AudioClient properties (hr = " << hr << ")";
+            log_warn(ss.str().c_str());
         }
         
         // Populate stream format based on requested sample

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -96,7 +96,8 @@ void WASAPIAudioDevice::start()
         WAVEFORMATEX* streamFormatPtr = nullptr;
         WAVEFORMATEX streamFormat;
         bool freeStreamFormat = false;
-        
+
+#if 0        
         // Set AudioClientProperties for stream. Must be done prior to Initialize().
         AudioClientProperties prop;
         prop.cbSize = sizeof(AudioClientProperties);
@@ -117,6 +118,7 @@ void WASAPIAudioDevice::start()
                 log_warn(ss.str().c_str());
             }
         }
+#endif // 0
         
         // Populate stream format based on requested sample
         // rate/number of channels.


### PR DESCRIPTION
Disables hardware offload of audio on Windows (for audio devices that support it). This is due to audio quality issues reported by a few people on Windows since 2.3.0 release.