### PR TITLE
Fix compiler warning/error in EventHandler when using GCC 16.1.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -941,6 +941,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Hamlib: Detect empty rig name on start. (PR #1339)
     * Disable use of pffft during audio resampling. (PR #1338)
     * FreeDV Reporter: Fix issue preventing mode changes on double-click. (PR #1343)
+    * Fix compiler warning/error in EventHandler when using GCC 16.1. (PR #1347)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/src/rig_control/SerialPortInRigController.cpp
+++ b/src/rig_control/SerialPortInRigController.cpp
@@ -34,7 +34,7 @@ SerialPortInRigController::SerialPortInRigController(std::string serialPort, boo
     , suspendChanges_(false)
 {
     // Perform required initialization on successful connection.
-    onRigConnected += [&](IRigController*) {
+    onRigConnected = [&](IRigController*) {
         // Set RTS and DTR enabled for certain PTT input interfaces.
         raiseRTS_();
         raiseDTR_();
@@ -46,7 +46,7 @@ SerialPortInRigController::SerialPortInRigController(std::string serialPort, boo
         pollThread_ = std::thread(std::bind(&SerialPortInRigController::pollThreadEntry_, this));
     };
 
-    onRigDisconnected += [&](IRigController*) {
+    onRigDisconnected = [&](IRigController*) {
         threadExiting_ = true;
         pollThread_.join();
     };

--- a/src/rig_control/SerialPortOutRigController.cpp
+++ b/src/rig_control/SerialPortOutRigController.cpp
@@ -33,7 +33,7 @@ SerialPortOutRigController::SerialPortOutRigController(std::string serialPort, b
     , rigResponseTime_(0)
 {
     // Ensure that PTT is disabled on successful connect.
-    onRigConnected += [&](IRigController*) {
+    onRigConnected = [&](IRigController*) {
         ptt(false);
     };
 }

--- a/src/util/EventHandler.h
+++ b/src/util/EventHandler.h
@@ -38,6 +38,7 @@ public:
     
     void operator() (FnArgs... args);
     EventHandler<FnArgs...>& operator+=(FnType const& fn);
+    EventHandler<FnArgs...>& operator=(FnType const& fn);
     void clear();
     
 private:
@@ -56,6 +57,14 @@ void EventHandler<FnArgs...>::operator() (FnArgs... args)
 template<typename... FnArgs>
 EventHandler<FnArgs...>& EventHandler<FnArgs...>::operator+=(FnType const& fn)
 {
+    fnList_.push_back(fn);
+    return *this;
+}
+
+template<typename... FnArgs>
+EventHandler<FnArgs...>& EventHandler<FnArgs...>::operator=(FnType const& fn)
+{
+    fnList_.clear();
     fnList_.push_back(fn);
     return *this;
 }


### PR DESCRIPTION
Fixes compiler error due to uninitialized `EventHandler` when using GCC 16.1 to compile. Resolves #1342.