### PR TITLE
Improve Flex waveform RX audio quality

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -942,6 +942,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Disable use of pffft during audio resampling. (PR #1338)
     * FreeDV Reporter: Fix issue preventing mode changes on double-click. (PR #1343)
     * Fix compiler warning/error in EventHandler when using GCC 16.1. (PR #1347)
+    * Improve Flex waveform RX audio quality. (PR #1348)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/src/pipeline/IPipelineStep.h
+++ b/src/pipeline/IPipelineStep.h
@@ -37,6 +37,7 @@
 
 #include <cmath>
 #include <limits>
+#include <algorithm>
 #include "../util/sanitizers.h"
 
 class IPipelineStep
@@ -82,24 +83,9 @@ void IPipelineStep::ConvertToFloatSampleType_(SrcType* sourceSamples, DstType* d
     static_assert(SampleDivisor != 0);
 
     // Iterate through samples, performing division (if needed) and typecasting
-    if (SampleDivisor == 1)
+    for (std::size_t index = 0; index < numSamples; index++)
     {
-        for (std::size_t index = 0; index < numSamples; index++)
-        {
-            destSamples[index] = (DstType)sourceSamples[index];
-        }
-    }
-    else
-    {
-        auto divider = SampleDivisor + 1;
-        if (SampleDivisor != std::numeric_limits<DstType>::max())
-        {
-            divider = SampleDivisor;
-        }
-        for (std::size_t index = 0; index < numSamples; index++)
-        {
-            destSamples[index] = (DstType)sourceSamples[index] * ((DstType)1.0 / divider);
-        }
+        destSamples[index] = (DstType)sourceSamples[index] * ((DstType)1.0 / SampleDivisor);
     }
 }
 
@@ -111,34 +97,11 @@ void IPipelineStep::ConvertToIntSampleType_(SrcType* sourceSamples, DstType* des
     static_assert(std::numeric_limits<DstType>::is_integer);
 
     // Iterate through samples, performing multiplication (if needed) and typecasting
-    if (SampleMultiplier == 1)
+    constexpr auto MIN_DST_TYPE_VAL = std::numeric_limits<DstType>::min();
+    constexpr auto MAX_DST_TYPE_VAL = std::numeric_limits<DstType>::max();
+    for (std::size_t index = 0; index < numSamples; index++)
     {
-        for (std::size_t index = 0; index < numSamples; index++)
-        {
-            destSamples[index] = (DstType)sourceSamples[index];
-        }
-    }
-    else
-    {
-        constexpr auto MIN_DST_TYPE_VAL = std::numeric_limits<DstType>::min();
-        constexpr auto MAX_DST_TYPE_VAL = std::numeric_limits<DstType>::max();
-        constexpr auto multiplier = (SampleMultiplier != MAX_DST_TYPE_VAL) ? SampleMultiplier : (SampleMultiplier + 1);
-        for (std::size_t index = 0; index < numSamples; index++)
-        {
-            SrcType temp = sourceSamples[index] * multiplier;
-            if (temp <= MIN_DST_TYPE_VAL)
-            {
-                destSamples[index] = MIN_DST_TYPE_VAL;
-            }
-            else if (temp >= MAX_DST_TYPE_VAL)
-            {
-                destSamples[index] = MAX_DST_TYPE_VAL;
-            }
-            else
-            {
-                destSamples[index] = static_cast<DstType>(std::lrint(temp));
-            }
-        }
+        destSamples[index] = (DstType)floor(.5 + std::min((SrcType)MAX_DST_TYPE_VAL, std::max((SrcType)MIN_DST_TYPE_VAL, MAX_DST_TYPE_VAL*sourceSamples[index])));
     }
 }
 

--- a/src/pipeline/IPipelineStep.h
+++ b/src/pipeline/IPipelineStep.h
@@ -37,7 +37,6 @@
 
 #include <cmath>
 #include <limits>
-#include <algorithm>
 #include "../util/sanitizers.h"
 
 class IPipelineStep
@@ -83,9 +82,24 @@ void IPipelineStep::ConvertToFloatSampleType_(SrcType* sourceSamples, DstType* d
     static_assert(SampleDivisor != 0);
 
     // Iterate through samples, performing division (if needed) and typecasting
-    for (std::size_t index = 0; index < numSamples; index++)
+    if (SampleDivisor == 1)
     {
-        destSamples[index] = (DstType)sourceSamples[index] * ((DstType)1.0 / SampleDivisor);
+        for (std::size_t index = 0; index < numSamples; index++)
+        {
+            destSamples[index] = (DstType)sourceSamples[index];
+        }
+    }
+    else
+    {
+        auto divider = SampleDivisor + 1;
+        if (SampleDivisor != std::numeric_limits<DstType>::max())
+        {
+            divider = SampleDivisor;
+        }
+        for (std::size_t index = 0; index < numSamples; index++)
+        {
+            destSamples[index] = (DstType)sourceSamples[index] * ((DstType)1.0 / divider);
+        }
     }
 }
 
@@ -97,11 +111,34 @@ void IPipelineStep::ConvertToIntSampleType_(SrcType* sourceSamples, DstType* des
     static_assert(std::numeric_limits<DstType>::is_integer);
 
     // Iterate through samples, performing multiplication (if needed) and typecasting
-    constexpr auto MIN_DST_TYPE_VAL = std::numeric_limits<DstType>::min();
-    constexpr auto MAX_DST_TYPE_VAL = std::numeric_limits<DstType>::max();
-    for (std::size_t index = 0; index < numSamples; index++)
+    if (SampleMultiplier == 1)
     {
-        destSamples[index] = (DstType)floor(.5 + std::min((SrcType)MAX_DST_TYPE_VAL, std::max((SrcType)MIN_DST_TYPE_VAL, MAX_DST_TYPE_VAL*sourceSamples[index])));
+        for (std::size_t index = 0; index < numSamples; index++)
+        {
+            destSamples[index] = (DstType)sourceSamples[index];
+        }
+    }
+    else
+    {
+        constexpr auto MIN_DST_TYPE_VAL = std::numeric_limits<DstType>::min();
+        constexpr auto MAX_DST_TYPE_VAL = std::numeric_limits<DstType>::max();
+        constexpr auto multiplier = (SampleMultiplier != MAX_DST_TYPE_VAL) ? SampleMultiplier : (SampleMultiplier + 1);
+        for (std::size_t index = 0; index < numSamples; index++)
+        {
+            SrcType temp = sourceSamples[index] * multiplier;
+            if (temp <= MIN_DST_TYPE_VAL)
+            {
+                destSamples[index] = MIN_DST_TYPE_VAL;
+            }
+            else if (temp >= MAX_DST_TYPE_VAL)
+            {
+                destSamples[index] = MAX_DST_TYPE_VAL;
+            }
+            else
+            {
+                destSamples[index] = static_cast<DstType>(std::lrint(temp));
+            }
+        }
     }
 }
 

--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -203,7 +203,6 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
         // demod per frame processing
         for(int i=0; i<nin; i++)
         {
-            //ConvertToFloatSampleType_<float, short>(&inputBuf_[i], &inputBufCplx_[i].real, 1);
             inputBufCplx_[i].real = inputBuf_[i] / 32767.0;
             inputBufCplx_[i].imag = 0.0;
         }
@@ -256,8 +255,6 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
                     {
                         pcm[i] = (int)floor(.5 + std::min(32767.f, std::max(-32767.f, 32768.f*fpcm[i])));
                     }
-
-                    //ConvertToIntSampleType_<short, float>(fpcm, pcm, LPCNET_FRAME_SIZE);
 
                     *numOutputSamples += LPCNET_FRAME_SIZE;
                     outputSampleFifo_.write(pcm, LPCNET_FRAME_SIZE);

--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -203,8 +203,7 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
         // demod per frame processing
         for(int i=0; i<nin; i++)
         {
-            //ConvertToFloatSampleType_<float, short>(&inputBuf_[i], &inputBufCplx_[i].real, 1);
-            inputBufCplx_[i].real = inputBuf_[i] / 32767.0;
+            ConvertToFloatSampleType_<float, short>(&inputBuf_[i], &inputBufCplx_[i].real, 1);
             inputBufCplx_[i].imag = 0.0;
         }
 
@@ -252,12 +251,7 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
                     fargan_synthesize(fargan_, fpcm, pendingFeatures_);
                     FREEDV_END_VERIFIED_SAFE 
 
-                    for (int i = 0; i < LPCNET_FRAME_SIZE; i++) 
-                    {
-                        pcm[i] = (int)floor(.5 + std::min(32767.f, std::max(-32767.f, 32768.f*fpcm[i])));
-                    }
-
-                    //ConvertToIntSampleType_<short, float>(fpcm, pcm, LPCNET_FRAME_SIZE);
+                    ConvertToIntSampleType_<short, float>(fpcm, pcm, LPCNET_FRAME_SIZE);
 
                     *numOutputSamples += LPCNET_FRAME_SIZE;
                     outputSampleFifo_.write(pcm, LPCNET_FRAME_SIZE);

--- a/src/pipeline/RADEReceiveStep.cpp
+++ b/src/pipeline/RADEReceiveStep.cpp
@@ -203,7 +203,8 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
         // demod per frame processing
         for(int i=0; i<nin; i++)
         {
-            ConvertToFloatSampleType_<float, short>(&inputBuf_[i], &inputBufCplx_[i].real, 1);
+            //ConvertToFloatSampleType_<float, short>(&inputBuf_[i], &inputBufCplx_[i].real, 1);
+            inputBufCplx_[i].real = inputBuf_[i] / 32767.0;
             inputBufCplx_[i].imag = 0.0;
         }
 
@@ -251,7 +252,12 @@ short* RADEReceiveStep::execute(short* inputSamples, int numInputSamples, int* n
                     fargan_synthesize(fargan_, fpcm, pendingFeatures_);
                     FREEDV_END_VERIFIED_SAFE 
 
-                    ConvertToIntSampleType_<short, float>(fpcm, pcm, LPCNET_FRAME_SIZE);
+                    for (int i = 0; i < LPCNET_FRAME_SIZE; i++) 
+                    {
+                        pcm[i] = (int)floor(.5 + std::min(32767.f, std::max(-32767.f, 32768.f*fpcm[i])));
+                    }
+
+                    //ConvertToIntSampleType_<short, float>(fpcm, pcm, LPCNET_FRAME_SIZE);
 
                     *numOutputSamples += LPCNET_FRAME_SIZE;
                     outputSampleFifo_.write(pcm, LPCNET_FRAME_SIZE);


### PR DESCRIPTION
This PR fixes RX audio quality issues reported by users since 2.3.0's release. The last known build with acceptable audio quality was da50 per reports.