### PR TITLE
Fix segfault on fresh install with no prior Hamlib rig config

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -938,7 +938,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Fix TX/tune level context menus on Linux distros using wxWidgets <= 3.2. (PR #1333) - thanks @barjac!
     * Fix audio routing problems on Windows due to hardware offloading. (PR #1335)
-    * Hamlib: Detect empty rig name on start. (PR #1339)
+    * Hamlib: Detect empty rig name on start. (PR #1339, #1351) - thanks @barjac!
     * Disable use of pffft during audio resampling. (PR #1338)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -540,7 +540,10 @@ void EasySetupDialog::ExchangePttDeviceData(int inout)
             m_hamlibBox->Show();
             m_serialBox->Hide();
 
-            m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
+            if (wxGetApp().m_intHamlibRig >= 0)
+            {
+                m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
+            }
             resetIcomCIVStatus_();
             
             auto selected = m_cbRigName->GetCurrentSelection();
@@ -698,8 +701,17 @@ void EasySetupDialog::HamlibRigNameChanged(wxCommandEvent&)
 
 void EasySetupDialog::resetIcomCIVStatus_()
 {
-    std::string rigName = m_cbRigName->GetString(m_cbRigName->GetCurrentSelection()).ToStdString();
-    if (rigName.find("Icom") == 0)
+    bool icomFound = false;
+    if (m_cbRigName->GetCurrentSelection() >= 0)
+    {
+        std::string rigName = m_cbRigName->GetString(m_cbRigName->GetCurrentSelection()).ToStdString();
+        if (rigName.find("Icom") == 0)
+        {
+            icomFound = true;
+        }
+    }
+
+    if (icomFound)
     {
         m_stIcomCIVHex->Show();
         m_tcIcomCIVHex->Show();
@@ -1128,7 +1140,10 @@ void EasySetupDialog::updateHamlibDevices_()
     {
         m_cbRigName->Append(HamlibRigController::RigIndexToName(index));
     }
-    m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
+    if (wxGetApp().m_intHamlibRig >= 0)
+    {
+        m_cbRigName->SetSelection(wxGetApp().m_intHamlibRig);
+    }
     
     /* populate Hamlib serial rate combo box */
     updateHamlibSerialRates_();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -869,7 +869,10 @@ void MainFrame::loadConfiguration_()
     if (wxGetApp().appConfiguration.rigControlConfiguration.hamlibRigName == wxT(""))
     {
         wxGetApp().m_intHamlibRig = pConfig->ReadLong("/Hamlib/RigName", -1);
-        wxGetApp().appConfiguration.rigControlConfiguration.hamlibRigName = HamlibRigController::RigIndexToName(wxGetApp().m_intHamlibRig);
+        if (wxGetApp().m_intHamlibRig >= 0)
+        {
+            wxGetApp().appConfiguration.rigControlConfiguration.hamlibRigName = HamlibRigController::RigIndexToName(wxGetApp().m_intHamlibRig);
+        }
     }
     else
     {

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -283,6 +283,10 @@ int HamlibRigController::RigNameToIndex(std::string const& rigName)
 std::string HamlibRigController::RigIndexToName(unsigned int rigIndex)
 {
     InitializeHamlibLibrary();
+    if (rigIndex >= RigNameList_.size())
+    {
+        return "";
+    }
     return RigNameList_[rigIndex];
 }
 


### PR DESCRIPTION
## Summary

- `ReadLong("/Hamlib/RigName", -1)` returns `-1` when the key is absent (fresh install); passing that to `RigIndexToName(unsigned int)` silently promotes it to `UINT_MAX` and crashes on the vector subscript
- Guard the call site in `loadConfiguration_()` so the lookup is skipped when no legacy rig index is stored
- Add a bounds check inside `RigIndexToName()` so any out-of-range index returns `""` safely rather than crashing

## Test plan

- [ ] Fresh PiOS Trixie install on RPi4 — confirmed no segfault on startup (tested by reporter)
- [ ] Existing install with a saved Hamlib rig — verify rig name still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)