### PR TITLE
Flex: Reenable PFFFT to try to get closer to build da50.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -943,7 +943,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix missing Hamlib defines when building from source (PR #1353) - thanks @barjac!
     * FreeDV Reporter: Fix issue preventing mode changes on double-click. (PR #1343)
     * Fix compiler warning/error in EventHandler when using GCC 16.1. (PR #1347)
-    * Improve Flex waveform RX audio quality. (PR #1348)
+    * Improve Flex waveform RX audio quality. (PR #1348, 1356)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/src/3rdparty/r8brain/r8bconf.h
+++ b/src/3rdparty/r8brain/r8bconf.h
@@ -180,7 +180,7 @@
 	 * attenuation higher than 120 dB is not required.
 	 */
 
-	#define R8B_PFFFT 0
+	#define R8B_PFFFT 1
 #else // !defined( R8B_PFFFT )
 	#if R8B_PFFFT && R8B_PFFFT_DOUBLE
 		// Handle the case when both `R8B_PFFFT` and `R8B_PFFFT_DOUBLE` were


### PR DESCRIPTION
Turns out we also need the pffft library enabled for best results on Flex.