### PR TITLE
Flex: Use version number without Git hash for waveform registration.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -944,6 +944,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * FreeDV Reporter: Fix issue preventing mode changes on double-click. (PR #1343)
     * Fix compiler warning/error in EventHandler when using GCC 16.1. (PR #1347)
     * Improve Flex waveform RX audio quality. (PR #1348, 1356)
+    * Flex: Use version number without Git hash for waveform registration. (PR #1359)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/cmake/CheckGit.cmake
+++ b/cmake/CheckGit.cmake
@@ -55,6 +55,7 @@ function(CheckGitVersion)
     else()
         set(FREEDV_VERSION "${FreeDV_VERSION}")
     endif()
+    set(FREEDV_VERSION_CLEAN "${FreeDV_VERSION}")
     file(WRITE ${CMAKE_BINARY_DIR}/freedv-version.txt ${FREEDV_VERSION})
 
     # Only update the git_version.cpp if the hash has changed. This will

--- a/cmake/git_version.cpp.in
+++ b/cmake/git_version.cpp.in
@@ -22,3 +22,8 @@ std::string GetFreeDVVersion()
 {
     return "@FREEDV_VERSION@";
 }
+
+std::string GetFreeDVVersionClean()
+{
+    return "@FREEDV_VERSION_CLEAN@";
+}

--- a/cmake/git_version.h
+++ b/cmake/git_version.h
@@ -27,5 +27,6 @@
 
 extern const char* FREEDV_GIT_HASH;
 std::string GetFreeDVVersion();
+std::string GetFreeDVVersionClean();
 
 #endif // GIT_HASH_H

--- a/src/integrations/flex/FlexTcpTask.cpp
+++ b/src/integrations/flex/FlexTcpTask.cpp
@@ -217,7 +217,7 @@ void FlexTcpTask::createWaveform_(std::string const& name, std::string const& sh
     sendRadioCommand_(std::string("waveform remove ") + name);
 
     // Actually create the waveform.
-    std::string waveformCommand = "waveform create name=" + name + " mode=" + shortName + " underlying_mode=" + underlyingMode + " version=" + GetFreeDVVersion();
+    std::string waveformCommand = "waveform create name=" + name + " mode=" + shortName + " underlying_mode=" + underlyingMode + " version=" + GetFreeDVVersionClean();
     std::string setPrefix = "waveform set " + name + " ";
     sendRadioCommand_(waveformCommand, [&, setPrefix](unsigned int rv, std::string const& res) {
         if (rv == 0)


### PR DESCRIPTION
While investigating another waveform issue, I found that the `waveform register` command in the Flex API doesn't like version numbers with dashes (i.e. 2.3.1-dev-1abc). This PR only passes the base version number to the radio to allow development builds to be used. (Note: the version number shown in the Waveform window in SmartSDR uses a different mechanism and is unaffected by including the Git hash.)