### PR TITLE
Fix bug preventing frequency change after changing on the radio.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -945,6 +945,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix compiler warning/error in EventHandler when using GCC 16.1. (PR #1347)
     * Improve Flex waveform RX audio quality. (PR #1348, 1356)
     * Flex: Use version number without Git hash for waveform registration. (PR #1359)
+    * Hamlib: Fix bug preventing frequency change after changing on the radio. (PR #1363)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1758,7 +1758,9 @@ void MainFrame::OnChangeReportFrequency( wxCommandEvent& )
     }
 
     if (freqStr != oldFreqString)
-    {      
+    {
+        log_info("Request frequency change to %" PRIu64 " Hz", wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency.get());
+
         // Report current frequency to reporters
         for (auto& ptr : wxGetApp().m_reporters)
         {

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -601,6 +601,7 @@ void HamlibRigController::setFrequencyImpl_(uint64_t frequencyHz)
 
     if (currFreq_ == frequencyHz)
     {
+        log_warn("Attempting to set to same frequency (%" PRIu64 " Hz), ignoring", frequencyHz);
         return;
     }
     
@@ -834,6 +835,14 @@ freqAttempt:
             {
                 origFreq_ = freq;
                 origMode_ = mode;
+            }
+            else
+            {
+                // currFreq_ should only be set after initial retrieval of frequency/mode
+                // as the user could specify a frequency to change to on startup. Otherwise,
+                // that would be overwritten and the frequency change would not happen.
+                currFreq_ = freq;
+                currMode_ = mode;
             }
             
             // Reset get freq/mode error count since we don't want intermittent errors


### PR DESCRIPTION
Resolves #1362 by ensuring that the Hamlib object always knows the current frequency and mode when retrieved from the radio. Previously, it was only set when setting the current frequency to something else, so it would have no visibility as to changes from the radio (and thus inappropriately conclude that the user was trying to change to the same frequency as already set on the radio).