### PR TITLE
AppImage: Remove custom AppRun scripts.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -946,6 +946,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Improve Flex waveform RX audio quality. (PR #1348, 1356)
     * Flex: Use version number without Git hash for waveform registration. (PR #1359)
     * Hamlib: Fix bug preventing frequency change after changing on the radio. (PR #1363)
+    * KA9Q: Remove custom AppRun script causing audio distortion. (PR #1364)
 2. Enhancements:
     * Allow use of a custom key for PTT. (PR #1309)
     * Improve Reporter message list usability. (PR #1310) - thanks @barjac!

--- a/appimage/AppRun-FlexRadio.sh
+++ b/appimage/AppRun-FlexRadio.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-echo "In AppImage AppRun"
-export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
-echo "PATH=$PATH"
-cd "$APPDIR"
-echo "#### after import"
-"$APPDIR/usr/bin/freedv-flex" "$@"

--- a/appimage/AppRun-KA9Q.sh
+++ b/appimage/AppRun-KA9Q.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-echo "In AppImage AppRun"
-export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
-echo "PATH=$PATH"
-cd "$APPDIR"
-echo "#### after import"
-"$APPDIR/usr/bin/freedv-ka9q" "$@"

--- a/appimage/AppRun.sh
+++ b/appimage/AppRun.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-echo "In AppImage AppRun"
-export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-export PATH="$APPDIR/usr/bin:$APPDIR/rade-venv/bin:$PATH"
-echo "PATH=$PATH"
-cd "$APPDIR"
-echo "#### after import"
-"$APPDIR/usr/bin/freedv" "$@"

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -5,18 +5,12 @@ TARGET=${1:-all}
 if [[ "${TARGET}" == "all" ]]; then
     export APPNAME="FreeDV"
     export APPEXEC=../build_linux/src/freedv
-    export APPRUN="AppRun.sh"
-    export RADE_SRC="rade_src"
 elif [[ "${TARGET}" == "freedv-flex" ]]; then
     export APPNAME="FreeDV-FlexRadio"
     export APPEXEC=../build_linux/src/integrations/flex/freedv-flex
-    export APPRUN="AppRun-FlexRadio.sh"
-    export RADE_SRC="rade_integ_src"
 elif [[ "${TARGET}" == "freedv-ka9q" ]]; then
     export APPNAME="FreeDV-KA9Q"
     export APPEXEC=../build_linux/src/integrations/ka9q/freedv-ka9q
-    export APPRUN="AppRun-KA9Q.sh"
-    export RADE_SRC="rade_integ_src"
 fi
 
 DESKTOP_FILE="$APPNAME.desktop"
@@ -49,7 +43,6 @@ fi
 --executable "$APPEXEC" \
 --appdir "$APPDIR" \
 --icon-file ../contrib/freedv256x256.png \
---custom-apprun=$APPRUN \
 --desktop-file $DESKTOP_FILE
 
 # Create the output


### PR DESCRIPTION
Resolves #1318 by removing custom AppRun scripts (these were originally needed when we included Python, but are no longer necessary and in fact are causing output audio to be distorted for freedv-ka9q).