### PR TITLE
Hamlib: allow retries on connect timeout.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -937,7 +937,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 ## V2.4.0 TBD 2026
 
 1. Bugfixes:
-    * TBD
+    * Hamlib: Allow one timeout during connection process to allow Icom marine radios to behave better. (PR #1369)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Load last-used config file on restarts. (PR #1365)

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -445,12 +445,16 @@ void HamlibRigController::connectImpl_()
         log_info("Setting rig timeout to %s ms", MAX_TIMEOUT);
         rig_set_conf(tmpRig, rig_token_lookup(tmpRig, HAMLIB_TIMEOUT_TOKEN_NAME), MAX_TIMEOUT);
     }
-    rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "0");
-    rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "0");
+    rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "1");
+    rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "1");
             
     result = rig_open(tmpRig);
     if (result == RIG_OK) 
     {
+        // Reset retry to 0 since we've now connected.
+        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "0");
+        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "0");
+
         log_debug("hamlib: rig_open() OK");
         onRigConnected(this);
         

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -451,10 +451,6 @@ void HamlibRigController::connectImpl_()
     result = rig_open(tmpRig);
     if (result == RIG_OK) 
     {
-        // Reset retry to 0 since we've now connected.
-        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "0");
-        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "0");
-
         log_debug("hamlib: rig_open() OK");
         onRigConnected(this);
         
@@ -491,6 +487,10 @@ void HamlibRigController::connectImpl_()
             currMode_ = RIG_MODE_NONE; // to make setModeImpl_ actually run
             setModeImpl_(pendingMode_);
         }
+
+        // Reset retry to 0 since we've now connected.
+        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "0");
+        rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "0");
     
         return;
     }

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -445,6 +445,11 @@ void HamlibRigController::connectImpl_()
         log_info("Setting rig timeout to %s ms", MAX_TIMEOUT);
         rig_set_conf(tmpRig, rig_token_lookup(tmpRig, HAMLIB_TIMEOUT_TOKEN_NAME), MAX_TIMEOUT);
     }
+
+    // Initially allow one retry if we time out while sending commands. This is needed
+    // to better support Icom marine radios due to their ability to power themselves on
+    // when rig_open is called (they're unable to immediately respond to commands while
+    // powering up and thus results in spurious Hamlib errors being displayed to users).
     rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "1");
     rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "1");
             
@@ -488,7 +493,9 @@ void HamlibRigController::connectImpl_()
             setModeImpl_(pendingMode_);
         }
 
-        // Reset retry to 0 since we've now connected.
+        // Disable timeouts. Now that we're able to connect and send the initial
+        // commands required by FreeDV, if we somehow have an issue sending commands 
+        // later we want to let the user know ASAP.
         rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "retry"), "0");
         rig_set_conf(tmpRig, rig_token_lookup(tmpRig, "timeout_retry"), "0");
     


### PR DESCRIPTION
Certain Icom marine radios (ex: IC-M802) will actually turn on when FreeDV tries to connect to them while off. However, since it takes longer than the default Hamlib timeout of 500ms to be available to accept commands, FreeDV ends up producing error message popups. This PR allows Hamlib to retry sending commands during `rig_open()`.