### PR TITLE
Fix issues with default config loading in Windows.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -940,7 +940,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * TBD
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
-    * Load last-used config file on restarts. (PR #1365)
+    * Load last-used config file on restarts. (PR #1365, #1371)
 3. Other:
     * FlexRadio/KA9Q integrations moved to freedv-integrations repo. (PR #1368)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,7 +219,7 @@ static const wxChar* const LAST_USED_CONFIG_KEY     = wxT("/LastUsedConfigFile")
 
 wxString getLastUsedConfigPath()
 {
-    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_STATE_VENDOR_NAME);
+    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_VENDOR_NAME);
     wxString path;
     stateConfig.Read(LAST_USED_CONFIG_KEY, &path, wxEmptyString);
     return path;
@@ -227,14 +227,14 @@ wxString getLastUsedConfigPath()
 
 void saveLastUsedConfigPath(const wxString& path)
 {
-    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_STATE_VENDOR_NAME);
+    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_VENDOR_NAME);
     stateConfig.Write(LAST_USED_CONFIG_KEY, path);
     stateConfig.Flush();
 }
 
 void clearLastUsedConfigPath()
 {
-    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_STATE_VENDOR_NAME);
+    wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_VENDOR_NAME);
     stateConfig.DeleteEntry(LAST_USED_CONFIG_KEY);
     stateConfig.Flush();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,8 +235,7 @@ void saveLastUsedConfigPath(const wxString& path)
 void clearLastUsedConfigPath()
 {
     wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_STATE_VENDOR_NAME);
-    stateConfig.SetPath(wxT("/"));
-    stateConfig.DeleteEntry(wxT("LastUsedConfigFile"));
+    stateConfig.DeleteEntry(LAST_USED_CONFIG_KEY);
     stateConfig.Flush();
 }
 
@@ -603,7 +602,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
     if (parser.Found("f", &configPath))
     {
         log_info("Loading configuration from %s", (const char*)configPath.ToUTF8());
-        pConfig = new wxFileConfig(wxT("FreeDV"), wxT("CODEC2-Project"), configPath, configPath, wxCONFIG_USE_LOCAL_FILE);
+        pConfig = new wxFileConfig(wxT("FreeDV"), FREEDV_VENDOR_NAME, configPath, configPath, wxCONFIG_USE_LOCAL_FILE);
         wxConfigBase::Set(pConfig);
         
         // On Linux/macOS, this replaces $HOME with "~" to shorten the title a bit.
@@ -658,7 +657,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
             // Need to explicitly create the wxFileConfig on Linux so that we can force wxWidgets
             // to load configuration files under a subdirectory. Otherwise, simply FileLayout_XDG
             // above will use ~/.config/freedv.conf.
-            pConfig = new wxFileConfig(wxT("FreeDV"), wxT("CODEC2-Project"), newFileLocation, newFileLocation, wxCONFIG_USE_LOCAL_FILE | wxCONFIG_USE_SUBDIR | wxCONFIG_USE_XDG);
+            pConfig = new wxFileConfig(wxT("FreeDV"), FREEDV_VENDOR_NAME, newFileLocation, newFileLocation, wxCONFIG_USE_LOCAL_FILE | wxCONFIG_USE_SUBDIR | wxCONFIG_USE_XDG);
 
             wxConfigBase::Set(pConfig);
             defaultConfigFilePath = tempNewFile.GetPath();
@@ -676,7 +675,7 @@ bool MainApp::OnCmdLineParsed(wxCmdLineParser& parser)
             {
                 log_info("Restoring last-used configuration from %s",
                          (const char*)lastUsedPath.ToUTF8());
-                pConfig = new wxFileConfig(wxT("FreeDV"), wxT("CODEC2-Project"),
+                pConfig = new wxFileConfig(wxT("FreeDV"), FREEDV_VENDOR_NAME,
                                            lastUsedPath, lastUsedPath,
                                            wxCONFIG_USE_LOCAL_FILE);
                 wxConfigBase::Set(pConfig);
@@ -780,7 +779,7 @@ bool MainApp::OnInit()
     {
         return false;
     }
-    SetVendorName(wxT("CODEC2-Project"));
+    SetVendorName(FREEDV_VENDOR_NAME);
     SetAppName(wxT("FreeDV"));      // not needed, it's the default value
     
     golay23_init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,7 +214,7 @@ wxConfigBase *pConfig = NULL;
 // active).  On Windows this becomes HKCU\Software\CODEC2-Project\FreeDV-State;
 // on macOS/Linux it becomes a file in the per-user config directory.
 static const wxChar* const FREEDV_STATE_APP_NAME    = wxT("FreeDV-State");
-static const wxChar* const FREEDV_STATE_VENDOR_NAME = wxT("CODEC2-Project");
+static const wxChar* const FREEDV_VENDOR_NAME = wxT("CODEC2-Project");
 static const wxChar* const LAST_USED_CONFIG_KEY     = wxT("/LastUsedConfigFile");
 
 wxString getLastUsedConfigPath()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,7 +235,7 @@ void saveLastUsedConfigPath(const wxString& path)
 void clearLastUsedConfigPath()
 {
     wxConfig stateConfig(FREEDV_STATE_APP_NAME, FREEDV_VENDOR_NAME);
-    stateConfig.DeleteEntry(LAST_USED_CONFIG_KEY);
+    stateConfig.Write(LAST_USED_CONFIG_KEY, wxEmptyString);
     stateConfig.Flush();
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -2049,8 +2049,8 @@ void MainFrame::OnToolsLoadDefaultConfig(wxCommandEvent& event)
     // On Windows this uses the registry (wxRegConfig); on macOS/Linux it
     // uses the default file location (wxFileConfig).  This becomes the
     // active pConfig going forward — no need to restore the old one.
-    wxConfigBase* defaultConfig = new wxConfig(wxT("FreeDV"), wxT("CODEC2-Project"));
-
+    wxConfigBase* defaultConfig = wxConfigBase::Create();
+    
     setConfiguration_(defaultConfig);
 
     // Remove the last-used config path so startup reverts to the default next time.


### PR DESCRIPTION
Resolves errors on Windows while loading default config. For example:

<img width="388" height="378" alt="image" src="https://github.com/user-attachments/assets/6089089f-4ee2-4132-8574-514956cafcc0" />
