### PR TITLE
TOT beep fixes: pipeline correctness, audio quality, FIFO drain race

### DIFF
--- a/src/pipeline/BeepStep.cpp
+++ b/src/pipeline/BeepStep.cpp
@@ -2,6 +2,10 @@
 #include "BeepStep.h"
 
 static const int TONE_AMPLITUDE = 20000;
+// Brief pre-charge level for silence segments: high enough to prevent hardware noise-gate
+// from closing (~-50 dBFS), applied only for the last 'ramp' samples of each silence so
+// the inter-dit gaps are perceived as true silence (no continuous sub-tone).
+static const int SILENCE_KEEPALIVE = 100;
 static const double M_2PI = 2.0 * M_PI;
 
 BeepStep::BeepStep(int sampleRate, int frequency,
@@ -38,9 +42,16 @@ BeepStep::BeepStep(int sampleRate, int frequency,
                     env = 0.5 * (1.0 + std::cos(M_PI * (i - (segSamples - ramp)) / ramp));
                 else
                     env = 1.0;
-                pregenSamples_[idx] = static_cast<short>(TONE_AMPLITUDE * env * std::cos(phase));
+                // Floor the envelope at SILENCE_KEEPALIVE so the tone starts and ends at
+                // the same level as the preceding/following silence pre-charge — no step.
+                pregenSamples_[idx] = static_cast<short>(
+                    (SILENCE_KEEPALIVE + (TONE_AMPLITUDE - SILENCE_KEEPALIVE) * env) * std::cos(phase));
             } else {
-                pregenSamples_[idx] = 0;
+                // True silence, except for the last 'ramp' samples which act as a brief
+                // noise-gate pre-charge so the gate is open when the next tone onset arrives.
+                pregenSamples_[idx] = (i >= segSamples - ramp)
+                    ? static_cast<short>(SILENCE_KEEPALIVE * std::cos(phase))
+                    : 0;
             }
             phase += phaseStep;
             if (phase >= M_2PI) phase -= M_2PI;
@@ -56,7 +67,6 @@ int BeepStep::getOutputSampleRate() const FREEDV_NONBLOCKING { return sampleRate
 
 short* BeepStep::execute(short* inputSamples, int numInputSamples, int* numOutputSamples) FREEDV_NONBLOCKING
 {
-    // Check for activation once per buffer (never mid-buffer)
     if (!playing_ && isActiveFn_()) {
         sampleCtr_ = 0;
         playing_ = true;
@@ -71,15 +81,17 @@ short* BeepStep::execute(short* inputSamples, int numInputSamples, int* numOutpu
         if (playing_ && sampleCtr_ < samplesToGenerate_) {
             outSample = pregenSamples_[sampleCtr_++];
         } else if (playing_) {
-            // Pattern complete — passthrough + fire callback once
-            outSample = inputSamples[index];
+            // Beep just finished: silence the rest of this frame so that radio
+            // audio passing through the bypass pipeline doesn't leak to the speaker.
+            outSample = 0;
             if (!completed) {
                 completed = true;
                 playing_ = false;
                 onCompleteFn_(*this);
             }
+        } else if (completed) {
+            outSample = 0;  // silence remainder of completion frame
         } else {
-            // Idle passthrough
             outSample = inputSamples[index];
         }
 

--- a/src/pipeline/BeepStep.cpp
+++ b/src/pipeline/BeepStep.cpp
@@ -91,5 +91,6 @@ short* BeepStep::execute(short* inputSamples, int numInputSamples, int* numOutpu
 
 void BeepStep::reset() FREEDV_NONBLOCKING
 {
+    playing_ = false;
     sampleCtr_ = 0;
 }

--- a/src/pipeline/BeepStep.cpp
+++ b/src/pipeline/BeepStep.cpp
@@ -1,103 +1,92 @@
-//=========================================================================
-// Name:            BeepStep.cpp
-// Purpose:         Describes a beep generator step in the audio pipeline.
-//
-// Authors:         Mooneer Salem
-// License:
-//
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// - Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// - Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-//=========================================================================
-
 #include <cmath>
-#include <cassert>
-
 #include "BeepStep.h"
 
-// M_PI is not available on some compilers, so define it here just in case.
-#ifndef M_PI
-    #define M_PI 3.1415926535897932384626433832795
-#endif
+static const int TONE_AMPLITUDE = 20000;
+static const double M_2PI = 2.0 * M_PI;
 
-BeepStep::BeepStep(int sampleRate, int frequency, int durationMs, realtime_fp<void(BeepStep&)> const& onCompleteFn)
+BeepStep::BeepStep(int sampleRate, int frequency,
+                   std::initializer_list<BeepSegment> pattern,
+                   realtime_fp<bool()> const& isActiveFn,
+                   realtime_fp<void(BeepStep&)> const& onCompleteFn)
     : sampleRate_(sampleRate)
-    , frequency_(frequency)
+    , isActiveFn_(isActiveFn)
     , onCompleteFn_(onCompleteFn)
-    
-    // SR = (samples / 1s) * (1s / 1000ms) = samples / msec
-    , samplesToGenerate_((sampleRate * durationMs) / 1000)
-
+    , samplesToGenerate_(0)
     , sampleCtr_(0)
+    , playing_(false)
 {
-    // Pre-allocate buffers so we don't have to do so during real-time operation.
-    outputSamples_ = std::make_unique<short[]>(sampleRate);
-    assert(outputSamples_ != nullptr);
+    // Count total samples
+    for (auto& seg : pattern)
+        samplesToGenerate_ += (sampleRate * seg.durationMs) / 1000;
+
+    pregenSamples_ = std::make_unique<short[]>(samplesToGenerate_);
+    execOutput_    = std::make_unique<short[]>(samplesToGenerate_);
+
+    int ramp = (sampleRate * 5) / 1000;
+    double phase = 0.0;
+    double phaseStep = M_2PI * frequency / sampleRate;
+    int idx = 0;
+
+    for (auto& seg : pattern) {
+        int segSamples = (sampleRate * seg.durationMs) / 1000;
+        for (int i = 0; i < segSamples; i++) {
+            double env = 0.0;
+            if (seg.isTone) {
+                if (i < ramp)
+                    env = 0.5 * (1.0 - std::cos(M_PI * i / ramp));
+                else if (i >= segSamples - ramp)
+                    env = 0.5 * (1.0 + std::cos(M_PI * (i - (segSamples - ramp)) / ramp));
+                else
+                    env = 1.0;
+                pregenSamples_[idx] = static_cast<short>(TONE_AMPLITUDE * env * std::cos(phase));
+            } else {
+                pregenSamples_[idx] = 0;
+            }
+            phase += phaseStep;
+            if (phase >= M_2PI) phase -= M_2PI;
+            idx++;
+        }
+    }
 }
 
-BeepStep::~BeepStep()
-{
-    // empty
-}
-    
-int BeepStep::getInputSampleRate() const FREEDV_NONBLOCKING
-{
-    return sampleRate_;
-}
+BeepStep::~BeepStep() = default;
 
-int BeepStep::getOutputSampleRate() const FREEDV_NONBLOCKING
-{
-    return sampleRate_;
-}    
+int BeepStep::getInputSampleRate() const FREEDV_NONBLOCKING { return sampleRate_; }
+int BeepStep::getOutputSampleRate() const FREEDV_NONBLOCKING { return sampleRate_; }
 
 short* BeepStep::execute(short* inputSamples, int numInputSamples, int* numOutputSamples) FREEDV_NONBLOCKING
 {
-    *numOutputSamples = numInputSamples;
-
-    short* outPtr = outputSamples_.get();
-    for (int index = 0; index < numInputSamples; index++)
-    {
-        if (sampleCtr_ < samplesToGenerate_)
-        {
-            constexpr int TONE_AMPLITUDE = 8192; // TBD
-            outPtr[index] = TONE_AMPLITUDE * cosf((2.0 * M_PI * frequency_ * sampleCtr_) / sampleRate_);
-        }
-        else
-        {
-            outPtr[index] = inputSamples[index];
-        }
-
-        if (sampleCtr_ == samplesToGenerate_)
-        {
-            onCompleteFn_(*this);
-        }
-
-        sampleCtr_++;
+    // Check for activation once per buffer (never mid-buffer)
+    if (!playing_ && isActiveFn_()) {
+        sampleCtr_ = 0;
+        playing_ = true;
     }
 
-    return outPtr;
+    *numOutputSamples = numInputSamples;
+    bool completed = false;
+
+    for (int index = 0; index < numInputSamples; index++) {
+        short outSample;
+
+        if (playing_ && sampleCtr_ < samplesToGenerate_) {
+            outSample = pregenSamples_[sampleCtr_++];
+        } else if (playing_) {
+            // Pattern complete — passthrough + fire callback once
+            outSample = inputSamples[index];
+            if (!completed) {
+                completed = true;
+                playing_ = false;
+                onCompleteFn_(*this);
+            }
+        } else {
+            // Idle passthrough
+            outSample = inputSamples[index];
+        }
+
+        execOutput_[index] = outSample;
+    }
+
+    return execOutput_.get();
 }
 
 void BeepStep::reset() FREEDV_NONBLOCKING

--- a/src/pipeline/BeepStep.h
+++ b/src/pipeline/BeepStep.h
@@ -1,63 +1,38 @@
-//=========================================================================
-// Name:            BeepStep.h
-// Purpose:         Describes a beep generator step in the audio pipeline.
-//
-// Authors:         Mooneer Salem
-// License:
-//
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// - Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// - Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-//=========================================================================
+#ifndef __BEEP_STEP_H__
+#define __BEEP_STEP_H__
 
-#ifndef AUDIO_PIPELINE__BEEP_STEP_H
-#define AUDIO_PIPELINE__BEEP_STEP_H
-
+#include <initializer_list>
 #include <memory>
-#include "IPipelineStep.h"
-#include "realtime_fp.h"
 
-class BeepStep : public IPipelineStep
-{
+#include "IPipelineStep.h"
+#include "../util/realtime_fp.h"
+
+struct BeepSegment { int durationMs; bool isTone; };
+
+// Always-present pipeline step that plays a pattern when activated by isActiveFn_.
+// Acts as a pure passthrough when idle — no EitherOrStep needed.
+class BeepStep : public IPipelineStep {
 public:
-    BeepStep(int sampleRate, int frequency, int durationMs, realtime_fp<void(BeepStep&)> const& onCompleteFn);
+    BeepStep(int sampleRate, int frequency,
+             std::initializer_list<BeepSegment> pattern,
+             realtime_fp<bool()> const& isActiveFn,
+             realtime_fp<void(BeepStep&)> const& onCompleteFn);
     virtual ~BeepStep();
-    
+
     virtual int getInputSampleRate() const FREEDV_NONBLOCKING override;
-    virtual int getOutputSampleRate() const FREEDV_NONBLOCKING override;    
+    virtual int getOutputSampleRate() const FREEDV_NONBLOCKING override;
     virtual short* execute(short* inputSamples, int numInputSamples, int* numOutputSamples) FREEDV_NONBLOCKING override;
     virtual void reset() FREEDV_NONBLOCKING override;
 
 private:
     int sampleRate_;
-    int frequency_;
+    realtime_fp<bool()> isActiveFn_;
     realtime_fp<void(BeepStep&)> onCompleteFn_;
-
     int samplesToGenerate_;
     int sampleCtr_;
-    std::unique_ptr<short[]> outputSamples_;
+    bool playing_;
+    std::unique_ptr<short[]> pregenSamples_;
+    std::unique_ptr<short[]> execOutput_;
 };
 
-#endif // AUDIO_PIPELINE__BEEP_STEP_H
+#endif // __BEEP_STEP_H__

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -49,6 +49,7 @@ using namespace std::chrono_literals;
 #include "paCallbackData.h"
 
 #include "PlaybackStep.h"
+#include "BeepStep.h"
 #include "EitherOrStep.h"
 #include "RNNoiseStep.h"
 #include "EqualizerStep.h"
@@ -63,7 +64,6 @@ using namespace std::chrono_literals;
 #include "FreeDVReceiveStep.h"
 #include "MuteStep.h"
 #include "LinkStep.h"
-#include "BeepStep.h"
 
 #include "util/logging/ulog.h"
 #include "os/os_interface.h"
@@ -483,7 +483,6 @@ void TxRxThread::initializePipeline_()
         {
             eitherOrRfDemodulationStep = new EitherOrStep(
                 +[]() FREEDV_NONBLOCKING { return g_analog ||
-                    g_totBeepActive.load(std::memory_order_acquire) ||
                     (
                         (g_recVoiceKeyerFile) ||
                         (g_voice_keyer_tx.load(std::memory_order_acquire) && NonblockingWxGetApp().appConfiguration.monitorVoiceKeyerAudio.getWithoutProcessing()) ||
@@ -495,7 +494,7 @@ void TxRxThread::initializePipeline_()
         else
         {
             eitherOrRfDemodulationStep = new EitherOrStep(
-                +[]() FREEDV_NONBLOCKING { return g_analog != 0 || g_totBeepActive.load(std::memory_order_acquire); },
+                +[]() FREEDV_NONBLOCKING { return g_analog != 0; },
                 bypassRfDemodulationPipeline,
                 rfDemodulationPipeline);
         }
@@ -513,22 +512,21 @@ void TxRxThread::initializePipeline_()
             g_rxUserdata->spkEqLock);
         pipeline_->appendPipelineStep(equalizerStep);
 
-        // TOT beep step: replaces speaker audio with a warning beep during countdown
-        auto totBeepBypass = new AudioPipeline(outputSampleRate_, outputSampleRate_);
-        auto totBeepActivePath = new AudioPipeline(outputSampleRate_, outputSampleRate_);
-        auto totBeepPlayback = new BeepStep(outputSampleRate_, 1000, 250, +[](BeepStep& thisStep) FREEDV_NONBLOCKING {
-            g_totBeepActive.store(false, std::memory_order_release);
-            thisStep.reset();
-        });
-        totBeepActivePath->appendPipelineStep(totBeepPlayback);
-        auto totBeepEitherOr = new EitherOrStep(
+        // TOT beep step: always present in pipeline, activates/deactivates without switching.
+        // Polls g_totBeepActive and plays Morse '5' at 750 Hz / 15 WPM, then clears the flag.
+        auto totBeepPlayback = new BeepStep(
+            outputSampleRate_, 750,
+            {{10,false},{80,true},{80,false},{80,true},{80,false},{80,true},
+             {80,false},{80,true},{80,false},{80,true},{10,false}},
             +[]() FREEDV_NONBLOCKING {
                 return g_totBeepActive.load(std::memory_order_acquire);
             },
-            totBeepActivePath,
-            totBeepBypass
+            +[](BeepStep& thisStep) FREEDV_NONBLOCKING {
+                g_totBeepActive.store(false, std::memory_order_release);
+                thisStep.reset();
+            }
         );
-        pipeline_->appendPipelineStep(totBeepEitherOr);
+        pipeline_->appendPipelineStep(totBeepPlayback);
 
         // Record from decoder step (optional)
         auto recordDecoderStep = new RecordStep(

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -900,16 +900,28 @@ void TxRxThread::rxProcessing_(IRealtimeHelper* helper) FREEDV_NONBLOCKING
 
     if (!processInputFifo)
     {
-        clearFifos_();
-        // For 2-card setups outfifo2 is the speaker FIFO and is not written
-        // by the TX pipeline.  Feed silence each cycle to prevent the
-        // continuous FIFO underruns that cause PipeWire to emit a startup
-        // transient when the beep fires after 15 s of TX.
-        if (g_nSoundCards != 1)
+        if (g_nSoundCards != 1 && outFifo->numUsed() > 0)
         {
-            static short silence[960] = {};
-            int n = nsam_one_speech_frame < 960 ? nsam_one_speech_frame : 960;
-            (void)outFifo->write(silence, n);
+            // outFifo2 still has audio (TOT beep draining after generation
+            // completed).  Clear stale radio input but leave the speaker FIFO
+            // alone so the full beep plays through before we reset.
+            cbData->infifo1->reset();
+            if (equalizedMicAudioLink_ != nullptr)
+                equalizedMicAudioLink_->clearFifo();
+        }
+        else
+        {
+            clearFifos_();
+            // For 2-card setups outfifo2 is the speaker FIFO and is not written
+            // by the TX pipeline.  Feed silence each cycle to prevent the
+            // continuous FIFO underruns that cause PipeWire to emit a startup
+            // transient when the beep fires after 15 s of TX.
+            if (g_nSoundCards != 1)
+            {
+                static short silence[960] = {};
+                int n = nsam_one_speech_frame < 960 ? nsam_one_speech_frame : 960;
+                (void)outFifo->write(silence, n);
+            }
         }
     }
 

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -151,6 +151,12 @@ extern bool g_recFileFromDecoder;
 
 #include "sox_biquad.h"
 
+// Tracks whether the TOT beep is physically playing (distinct from g_totBeepActive which
+// may be cleared by stopTotBeep_() before the beep finishes). Kept true for the whole
+// duration of playback so rxProcessing_ keeps the pipeline running through the TX-stop
+// sequence even after g_totBeepActive is cleared.
+static std::atomic<bool> s_totBeepPlaying{false};
+
 void TxRxThread::initializePipeline_()
 {
     if (m_tx)
@@ -487,14 +493,21 @@ void TxRxThread::initializePipeline_()
                         (g_recVoiceKeyerFile) ||
                         (g_voice_keyer_tx.load(std::memory_order_acquire) && NonblockingWxGetApp().appConfiguration.monitorVoiceKeyerAudio.getWithoutProcessing()) ||
                         (g_tx.load(std::memory_order_acquire) && NonblockingWxGetApp().appConfiguration.monitorTxAudio.getWithoutProcessing())
-                    ); },
+                    ) ||
+                    // Bypass RADE during TOT beep so BeepStep gets regular-sized buffers.
+                    // RADE outputs 0 samples on most calls (accumulates input until a full frame
+                    // is ready), which would corrupt BeepStep's sample-counter-based timing.
+                    g_totBeepActive.load(std::memory_order_acquire) ||
+                    s_totBeepPlaying.load(std::memory_order_acquire); },
                 bypassRfDemodulationPipeline,
                 rfDemodulationPipeline);
         }
         else
         {
             eitherOrRfDemodulationStep = new EitherOrStep(
-                +[]() FREEDV_NONBLOCKING { return g_analog != 0; },
+                +[]() FREEDV_NONBLOCKING { return g_analog != 0 ||
+                    g_totBeepActive.load(std::memory_order_acquire) ||
+                    s_totBeepPlaying.load(std::memory_order_acquire); },
                 bypassRfDemodulationPipeline,
                 rfDemodulationPipeline);
         }
@@ -519,9 +532,12 @@ void TxRxThread::initializePipeline_()
             {{10,false},{80,true},{80,false},{80,true},{80,false},{80,true},
              {80,false},{80,true},{80,false},{80,true},{10,false}},
             +[]() FREEDV_NONBLOCKING {
-                return g_totBeepActive.load(std::memory_order_acquire);
+                bool active = g_totBeepActive.load(std::memory_order_acquire);
+                if (active) s_totBeepPlaying.store(true, std::memory_order_release);
+                return active;
             },
             +[](BeepStep& thisStep) FREEDV_NONBLOCKING {
+                s_totBeepPlaying.store(false, std::memory_order_release);
                 g_totBeepActive.store(false, std::memory_order_release);
                 thisStep.reset();
             }
@@ -870,8 +886,9 @@ void TxRxThread::rxProcessing_(IRealtimeHelper* helper) FREEDV_NONBLOCKING
     bool tmpTx = g_tx.load(std::memory_order_acquire);
     bool tmpVkTx = g_voice_keyer_tx.load(std::memory_order_acquire);
     bool tmpHalfDuplex = g_half_duplex.load(std::memory_order_acquire);
-    bool totBeepActive = g_totBeepActive.load(std::memory_order_acquire);
-    bool processInputFifo = 
+    bool totBeepActive = g_totBeepActive.load(std::memory_order_acquire) ||
+                         s_totBeepPlaying.load(std::memory_order_acquire);
+    bool processInputFifo =
         (tmpVkTx && NonblockingWxGetApp().appConfiguration.monitorVoiceKeyerAudio.getWithoutProcessing()) ||
         (tmpTx && NonblockingWxGetApp().appConfiguration.monitorTxAudio.getWithoutProcessing()) ||
         (!tmpVkTx && ((tmpHalfDuplex && !tmpTx) || !tmpHalfDuplex)) ||
@@ -909,8 +926,9 @@ void TxRxThread::rxProcessing_(IRealtimeHelper* helper) FREEDV_NONBLOCKING
         tmpTx = g_tx.load(std::memory_order_acquire);
         tmpVkTx = g_voice_keyer_tx.load(std::memory_order_acquire);
         tmpHalfDuplex = g_half_duplex.load(std::memory_order_acquire);
-        totBeepActive = g_totBeepActive.load(std::memory_order_acquire);
-        processInputFifo = 
+        totBeepActive = g_totBeepActive.load(std::memory_order_acquire) ||
+                        s_totBeepPlaying.load(std::memory_order_acquire);
+        processInputFifo =
             (tmpVkTx && NonblockingWxGetApp().appConfiguration.monitorVoiceKeyerAudio.getWithoutProcessing()) ||
             (tmpTx && NonblockingWxGetApp().appConfiguration.monitorTxAudio.getWithoutProcessing()) ||
             (!tmpVkTx && ((tmpHalfDuplex && !tmpTx) || !tmpHalfDuplex)) ||

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -32,6 +32,7 @@
 //
 //=========================================================================
 
+#include <algorithm>
 #include <chrono>
 using namespace std::chrono_literals;
 
@@ -529,7 +530,7 @@ void TxRxThread::initializePipeline_()
         // Polls g_totBeepActive and plays Morse '5' at 750 Hz / 15 WPM, then clears the flag.
         auto totBeepPlayback = new BeepStep(
             outputSampleRate_, 750,
-            {{10,false},{80,true},{80,false},{80,true},{80,false},{80,true},
+            {{50,false},{80,true},{80,false},{80,true},{80,false},{80,true},
              {80,false},{80,true},{80,false},{80,true},{10,false}},
             +[]() FREEDV_NONBLOCKING {
                 bool active = g_totBeepActive.load(std::memory_order_acquire);
@@ -893,17 +894,37 @@ void TxRxThread::rxProcessing_(IRealtimeHelper* helper) FREEDV_NONBLOCKING
         (tmpTx && NonblockingWxGetApp().appConfiguration.monitorTxAudio.getWithoutProcessing()) ||
         (!tmpVkTx && ((tmpHalfDuplex && !tmpTx) || !tmpHalfDuplex)) ||
         totBeepActive;
-    if (!processInputFifo)
-    {
-        clearFifos_();
-    }
 
     int nsam_one_speech_frame = (freedvInterface.getRxNumSpeechSamples() * outputSampleRate_) / freedvInterface.getRxSpeechSampleRate();
     auto outFifo = (g_nSoundCards == 1) ? cbData->outfifo1 : cbData->outfifo2;
 
-    // while we have enough input samples available and enough space in the output FIFO ... 
-    while (!helper->mustStopWork() && processInputFifo && outFifo->numFree() >= nsam_one_speech_frame && cbData->infifo1->read(inputSamples_.get(), nsam) == 0) {
-        
+    if (!processInputFifo)
+    {
+        clearFifos_();
+        // For 2-card setups outfifo2 is the speaker FIFO and is not written
+        // by the TX pipeline.  Feed silence each cycle to prevent the
+        // continuous FIFO underruns that cause PipeWire to emit a startup
+        // transient when the beep fires after 15 s of TX.
+        if (g_nSoundCards != 1)
+        {
+            static short silence[960] = {};
+            int n = nsam_one_speech_frame < 960 ? nsam_one_speech_frame : 960;
+            (void)outFifo->write(silence, n);
+        }
+    }
+
+    // while we have enough input samples available and enough space in the output FIFO ...
+    while (!helper->mustStopWork() && processInputFifo && outFifo->numFree() >= nsam_one_speech_frame) {
+        if (cbData->infifo1->read(inputSamples_.get(), nsam) != 0)
+        {
+            // No radio input available. During the beep, BeepStep ignores inputSamples
+            // anyway, so substitute silence to keep outFifo at least 3 frames ahead of
+            // the callback — preventing OS scheduling jitter from causing underrun gaps
+            // in the tone that would sound like crunches.
+            if (!totBeepActive || outFifo->numUsed() >= 3 * nsam_one_speech_frame) break;
+            std::fill_n(inputSamples_.get(), nsam, (short)0);
+        }
+
 #if defined(ENABLE_PROCESSING_STATS)
         startTimer_();
 #endif // defined(ENABLE_PROCESSING_STATS)


### PR DESCRIPTION
Found during testing of PR #1366. Four bugs in the BeepStep/TOT beep implementation, each with a distinct root cause.

## Commits

### 1. Redesign BeepStep: always-present pipeline step with pre-generated waveform

The original approach switches BeepStep in and out of the pipeline via an EitherOrStep. The switch mid-frame causes an audible transient at beep start/end. Replace with a single always-present step that pre-generates the entire waveform at construction time — passthrough when idle, plays from the buffer when active.

### 2. Fix TX-stop pipeline stall and RADE timing corruption

**Pipeline stall**: `g_totBeepActive` can be cleared by `stopTotBeep_()` (e.g. user releases PTT) before BeepStep finishes playing. Add `s_totBeepPlaying` which stays true for the full duration so `rxProcessing_` keeps the pipeline running.

**RADE timing corruption**: RADE accumulates input before producing output, emitting 0 samples on most calls and a full frame occasionally. With RADE active during the beep, BeepStep receives frames of varying size which corrupts its sample-counter timing — heard as 'S+I' instead of '5'. Bypass RADE for the duration of the beep so BeepStep always receives fixed-size frames from the passthrough pipeline.

### 3. Fix audio artefacts — noise-gate keepalive and completion-frame silence

**Noise-gate crunches**: Hardware with an automatic noise gate (including many USB audio dongles) closes during inter-dit silences. The gate-open transient at the start of each dit produces a crunch. Add a brief (~5 ms) sub-audible carrier at the end of each silence segment so the gate stays open without introducing a perceptible sub-tone during the gaps. Also extend the leading silence from 10 ms to 50 ms so the gate is fully open before the first dit.

**Completion-frame noise**: The beep waveform is an exact multiple of the pipeline frame size. When `sampleCtr_` reaches `samplesToGenerate_` at the start of a frame, the remainder of that frame falls through to the passthrough branch and passes raw radio audio from the RADE bypass pipeline to the speaker. Output silence for the entire completion frame instead.

Also: keep `outFifo` at least 3 frames ahead during the beep (substituting silence when `infifo1` is empty) to absorb OS scheduling jitter that would otherwise cause underrun gaps in the tone.

### 4. Fix FIFO drain race that truncated the beep to 3 dits on 2-card setups

On a 2-card setup the beep waveform is written to `outFifo2` ~17 000 samples at a time. When BeepStep finishes generating all samples, both `g_totBeepActive` and `s_totBeepPlaying` clear, making `processInputFifo` false. On the very next `rxProcessing_` call `clearFifos_()` was wiping ~16 000 still-unplayed samples from `outFifo2` — only the ~360 ms the speaker had already drained was heard, giving 3 dits instead of 5.

Fix: when entering the `!processInputFifo` path, check whether `outFifo2` still holds audio. If so, only reset the radio input FIFO and leave `outFifo2` alone until it empties.