### PR TITLE
Fix PTT button stuck red when mouse slides off before release

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -957,7 +957,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Right-justify SNR column in FreeDV Reporter to improve appearance. (PR #1387) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
-    * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366)
+    * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398) - thanks @barjac!
     * Load last-used config file on restarts. (PR #1365, #1371)
     * Add "Set tune output to minimum" to Tune button context menu for safety. (PR #1378) - thanks @barjac!
     * Move Tune button into Control widget for improved usability. (PR #1377) - thanks @barjac!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1259,6 +1259,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
    // m_btnTogPTT->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnPTT_UI), NULL, this);
     m_btnTogPTT->Bind(wxEVT_LEFT_DOWN, &MainFrame::OnTogBtnPTTMouseDown, this);
     m_btnTogPTT->Bind(wxEVT_LEFT_DCLICK, &MainFrame::OnTogBtnPTTMouseDown, this);
+    m_btnTogPTT->Bind(wxEVT_LEAVE_WINDOW, &MainFrame::OnTogBtnPTTMouseLeave, this);
 
     loadConfiguration_();
     

--- a/src/main.h
+++ b/src/main.h
@@ -426,6 +426,7 @@ class MainFrame : public TopFrame
         // NOTE: sets TX colour on press to avoid a GTK blue-flash during the TX delay.
         // Upstream may prefer a different approach (e.g. true press-to-start TX).
         void OnTogBtnPTTMouseDown( wxMouseEvent& event );
+        void OnTogBtnPTTMouseLeave( wxMouseEvent& event );
         void OnTogBtnVoiceKeyerClick (wxCommandEvent& event) override;
         void OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& event ) override;
         

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1151,6 +1151,21 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
 }
 
 //-------------------------------------------------------------------------
+// OnTogBtnPTTMouseLeave()
+// Reset premature TX colour if mouse leaves button before release and TX
+// has not actually started, preventing a stuck-red button.
+//-------------------------------------------------------------------------
+void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
+{
+    if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
+    {
+        m_btnTogPTT->SetBackgroundColour(wxNullColour);
+        m_btnTogPTT->Refresh();
+    }
+    event.Skip();
+}
+
+//-------------------------------------------------------------------------
 // OnTogBtnPTT ()
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTT (wxCommandEvent&)


### PR DESCRIPTION
## Summary

- When the user clicks the PTT button and slides the mouse off before releasing, the button was left stuck red even though TX never started
- This is a side effect of PR #1366's cosmetic fix which sets the button red on mouse-down (to avoid a GTK blue-flash during the TX delay)
- The TX command event only fires on release *within* the button, so sliding off means the button colour is never reset

## Fix

Add `OnTogBtnPTTMouseLeave()` bound to `wxEVT_LEAVE_WINDOW` on the PTT button. If the mouse leaves while TX has not actually started (`g_tx` false and button value false), the button colour is reset to `wxNullColour`, restoring the correct RX appearance.

No change to TX start behaviour — this is purely a colour reset guard.

## Test plan

- [ ] Click PTT and release normally — TX starts, button stays red ✓
- [ ] Click PTT, slide mouse off before releasing — button resets to normal colour, TX does not start ✓
- [ ] Click PTT, slide off, slide back on, release — TX starts normally ✓
- [ ] Hardware PTT / VOX / voice keyer unaffected ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)