### PR TITLE
Consolidate EOO length calculation in freedv-backend.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -956,6 +956,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Revert to libsamplerate library to fix remaining audio quality issues. (PR #1379)
     * Right-justify SNR column in FreeDV Reporter to improve appearance. (PR #1387) - thanks @barjac!
     * Hamlib: Set frequency again on mode changes. (PR #1395)
+    * Consolidate EOO length calculation in freedv-backend to improve callsign decode reliability. (PR #1402)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398) - thanks @barjac!

--- a/cmake/BuildFreeDVBackend.cmake
+++ b/cmake/BuildFreeDVBackend.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     freedv_backend
     GIT_REPOSITORY https://github.com/tmiw/freedv-backend
-    GIT_TAG ms-eoo-refactor-end-silence
+    GIT_TAG main
 )
 
 FetchContent_MakeAvailable(freedv_backend)

--- a/cmake/BuildFreeDVBackend.cmake
+++ b/cmake/BuildFreeDVBackend.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     freedv_backend
     GIT_REPOSITORY https://github.com/tmiw/freedv-backend
-    GIT_TAG main
+    GIT_TAG ms-eoo-refactor-end-silence
 )
 
 FetchContent_MakeAvailable(freedv_backend)

--- a/src/config/RigControlConfiguration.cpp
+++ b/src/config/RigControlConfiguration.cpp
@@ -52,7 +52,6 @@ RigControlConfiguration::RigControlConfiguration()
     , serialPTTInputPolarityCTS("/Rig/CTSPolarity", false)
         
     , leftChannelVoxTone("/Rig/leftChannelVoxTone",  false)
-    , rigResponseTimeMicroseconds("/Rig/rigResponseTimeMicroseconds", 0)
     , totTimerEnabled("/Rig/TotTimerEnabled", true)
     , totTimerSecs("/Rig/TotTimerSecs", 180)
 {
@@ -98,7 +97,6 @@ void RigControlConfiguration::load(wxConfigBase* config)
     
     load_(config, leftChannelVoxTone);
 
-    load_(config, rigResponseTimeMicroseconds);
     load_(config, totTimerEnabled);
     load_(config, totTimerSecs);
 }
@@ -136,7 +134,6 @@ void RigControlConfiguration::save(wxConfigBase* config)
     
     save_(config, leftChannelVoxTone);
 
-    save_(config, rigResponseTimeMicroseconds);
     save_(config, totTimerEnabled);
     save_(config, totTimerSecs);
 }

--- a/src/config/RigControlConfiguration.h
+++ b/src/config/RigControlConfiguration.h
@@ -62,13 +62,6 @@ public:
     
     ConfigurationDataElement<bool> leftChannelVoxTone;
 
-    // Not directly modifiable by the user -- this is a cached version
-    // so that the first TX after a restart of FreeDV will wait the same
-    // amount of time as during the previous run (ensuring that only the
-    // absolute first TX or the first TX after a CAT/PTT config change
-    // will have zero wait).
-    ConfigurationDataElement<int> rigResponseTimeMicroseconds;
-
     // Time-Out Timer (TOT): limits how long FreeDV can stay in transmit.
     ConfigurationDataElement<bool> totTimerEnabled;
     ConfigurationDataElement<int>  totTimerSecs;

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -558,12 +558,10 @@ int FreeDVInterface::getTxNNomModemSamples() const FREEDV_NONBLOCKING
 {
     if (txMode_ >= FREEDV_MODE_RADE)
     {
-        const int NUM_SAMPLES_SILENCE = 60 * RADE_MODEM_SAMPLE_RATE / 1000;
-
         // Verified that rade_api.c from librade has no unbounded operations
         // as of 2025-10-03.
         FREEDV_BEGIN_VERIFIED_SAFE
-        return std::max(rade_n_tx_out(rade_), rade_n_tx_eoo_out(rade_) + NUM_SAMPLES_SILENCE);
+        return std::max(rade_n_tx_out(rade_), radeTxStep_->eooLengthInSamples());
         FREEDV_END_VERIFIED_SAFE
     }
 

--- a/src/gui/dialogs/dlg_easy_setup.cpp
+++ b/src/gui/dialogs/dlg_easy_setup.cpp
@@ -596,9 +596,6 @@ void EasySetupDialog::ExchangePttDeviceData(int inout)
     }
     else if (inout == EXCHANGE_DATA_OUT)
     {
-        // Reset PTT delay data as it may be different with this new configuration
-        wxGetApp().appConfiguration.rigControlConfiguration.rigResponseTimeMicroseconds = 0;
-
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibUseForPTT = m_ckUseHamlibPTT->GetValue();
         
         wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTT = m_ckUseSerialPTT->GetValue();

--- a/src/gui/dialogs/dlg_ptt.cpp
+++ b/src/gui/dialogs/dlg_ptt.cpp
@@ -639,9 +639,6 @@ void ComPortsDlg::ExchangeData(int inout)
     }
 
     if (inout == EXCHANGE_DATA_OUT) {
-        // Reset PTT delay as it may be different with the new configuration
-        wxGetApp().appConfiguration.rigControlConfiguration.rigResponseTimeMicroseconds = 0;
-
         wxGetApp().appConfiguration.rigControlConfiguration.leftChannelVoxTone = m_ckLeftChannelVoxTone->GetValue();
 
         /* Hamlib settings. */

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1407,37 +1407,15 @@ void MainFrame::togglePTT(void) {
         {
             latency = outDevice->getLatencyInMicroseconds();
         }
-        auto pttResponseTime = 0;
 
-        // Also take into account any latency between the computer and radio.
-        // The only way to do this is by tracking how long it takes to respond
-        // to PTT requests (and that's not necessarily great, either). Normally
-        // this component should be a small part of the overall latency, but it
-        // could be larger when dealing with SDR radios that are on the network.
-        //
-        // Note: This may not provide accurate results until after going from 
-        // TX->RX the first time, but one missed report during a session shouldn't 
-        // be a huge deal.
-        auto pttController = wxGetApp().rigPttController;
-        if (pttController)
-        {
-            // We only need to worry about the time getting to the radio,
-            // not the time to get from the radio to us.
-            pttResponseTime = std::max(
-                pttController->getRigResponseTimeMicroseconds() / 2,
-                wxGetApp().appConfiguration.rigControlConfiguration.rigResponseTimeMicroseconds.get());
-            wxGetApp().appConfiguration.rigControlConfiguration.rigResponseTimeMicroseconds = pttResponseTime;
-        }
-
-        auto totalPauseTime = latency + pttResponseTime;
         log_info(
-            "Pausing for a minimum of %d us (%d us latency + %d us PTT response time) before TX->RX to allow remaining audio to go out", 
-            totalPauseTime, latency, pttResponseTime);
+            "Pausing for a minimum of %d us before TX->RX to allow remaining audio to go out", 
+            latency);
         before = highResClock.now();
         while(true)
         {
             auto diff = highResClock.now() - before;
-            if (diff >= std::chrono::microseconds(totalPauseTime))
+            if (diff >= std::chrono::microseconds(latency))
             {
                 break;
             }


### PR DESCRIPTION
Update freedv-gui to use experimentally determined EOO length in freedv-backend and remove flaky Hamlib response time calculation. (Hopefully) resolves #1399 and improves callsign decode/reporting reliability.