### PR TITLE
Hamlib: Switch off memory channel before setting frequency/mode

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -957,6 +957,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Right-justify SNR column in FreeDV Reporter to improve appearance. (PR #1387) - thanks @barjac!
     * Hamlib: Set frequency again on mode changes. (PR #1395)
     * Consolidate EOO length calculation in freedv-backend to improve callsign decode reliability. (PR #1402)
+    * Hamlib: Switch off memory channel before setting frequency/mode. (PR #1403) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398) - thanks @barjac!

--- a/src/rig_control/HamlibRigController.cpp
+++ b/src/rig_control/HamlibRigController.cpp
@@ -638,7 +638,7 @@ void HamlibRigController::setFrequencyImpl_(uint64_t frequencyHz)
         }
     }
 
-    vfo_t currVfo = getCurrentVfo_(); 
+    vfo_t currVfo = getWritableVfo_();
     setFrequencyHelper_(currVfo, frequencyHz);
 
     if (pttSet_)
@@ -722,7 +722,7 @@ void HamlibRigController::setModeImpl_(IRigFrequencyController::Mode mode)
         }
     }
 
-    vfo_t currVfo = getCurrentVfo_(); 
+    vfo_t currVfo = getWritableVfo_();
     setModeHelper_(currVfo, hamlibMode);
 
     if (pttSet_)
@@ -887,6 +887,33 @@ vfo_t HamlibRigController::getCurrentVfo_()
         }
     }
     
+    return vfo;
+}
+
+vfo_t HamlibRigController::getWritableVfo_()
+{
+    vfo_t vfo = getCurrentVfo_();
+
+    if (vfo == RIG_VFO_MEM)
+    {
+        // Hamlib can't set frequency/mode directly on a memory channel --
+        // switch to VFO A first so the subsequent set_freq/set_mode call
+        // succeeds instead of failing with "Invalid parameter".
+        auto tmpRig = rig_.load(std::memory_order_acquire);
+        if (tmpRig != nullptr)
+        {
+            int result = rig_set_vfo(tmpRig, RIG_VFO_A);
+            if (result == RIG_OK)
+            {
+                vfo = RIG_VFO_A;
+            }
+            else
+            {
+                log_debug("rig_set_vfo: error = %s ", rigerror(result));
+            }
+        }
+    }
+
     return vfo;
 }
 

--- a/src/rig_control/HamlibRigController.h
+++ b/src/rig_control/HamlibRigController.h
@@ -111,6 +111,7 @@ private:
     const int MAX_GET_FREQUENCY_ERR_COUNT = 1;
     
     vfo_t getCurrentVfo_();
+    vfo_t getWritableVfo_();
     void setFrequencyHelper_(vfo_t currVfo, uint64_t frequencyHz);
     void setModeHelper_(vfo_t currVfo, rmode_t mode);
     


### PR DESCRIPTION
## Summary
- `rig_set_freq`/`rig_set_mode` fail with "Invalid parameter" when the rig's current VFO is MEM, since most CAT protocols can't set an arbitrary frequency/mode while a memory channel is selected.
- This breaks FreeDV pushing its saved frequency/mode whenever the rig is left parked on a memory channel — at startup, on double-click QSY from FreeDV Reporter, and when accepting an incoming QSY request.
- Adds `getWritableVfo_()`, which switches to VFO A first if the current VFO is MEM, and uses it in the two write paths (`setFrequencyImpl_`, `setModeImpl_`). Read-only paths (periodic polling, disconnect-time restore) are unchanged since querying works fine on any VFO.
- If `rig_set_vfo(RIG_VFO_A)` fails (rig doesn't support VFO switching), it falls back to the original VFO with a debug log — no worse than current behaviour for those rigs.

## Test plan
- [x] Verified on TS450S: frequency/mode pushes from a memory-channel start now succeed instead of failing.
- [x] Verified double-click QSY from FreeDV Reporter while radio is on a memory channel.

Thanks Claude