### PR TITLE
Pin PTT button text colour explicitly instead of relying on GTK theme

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -960,7 +960,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Hamlib: Switch off memory channel before setting frequency/mode. (PR #1403) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
-    * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398) - thanks @barjac!
+    * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!
     * Load last-used config file on restarts. (PR #1365, #1371)
     * Add "Set tune output to minimum" to Tune button context menu for safety. (PR #1378) - thanks @barjac!
     * Move Tune button into Control widget for improved usability. (PR #1377) - thanks @barjac!

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1145,6 +1145,7 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
     {
         m_btnTogPTT->SetBackgroundColour(*wxRED);
+        m_btnTogPTT->SetForegroundColour(*wxBLACK);
         m_btnTogPTT->Refresh();
     }
     event.Skip();
@@ -1160,6 +1161,7 @@ void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
     {
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
+        m_btnTogPTT->SetForegroundColour(wxNullColour);
         m_btnTogPTT->Refresh();
     }
     event.Skip();
@@ -1309,8 +1311,12 @@ void MainFrame::togglePTT(void) {
     if (wasInTx)
     {
         // Amber during TX->RX drain: distinct from TX (red) and RX (default),
-        // black text readable throughout.
+        // black text readable throughout. Foreground is pinned explicitly
+        // (not just left to the GTK theme) since some themes/window states
+        // - e.g. backdrop while the TOT warning dialog has focus - would
+        // otherwise dim or recolour the default text away from black.
         m_btnTogPTT->SetBackgroundColour(wxColour(255, 165, 0));
+        m_btnTogPTT->SetForegroundColour(*wxBLACK);
         m_btnTogPTT->SetLabel("TX Ending");
         m_btnTogPTT->Refresh();
 
@@ -1592,6 +1598,7 @@ void MainFrame::togglePTT(void) {
     m_btnTogPTT->SetValue(newTx);
     m_btnTogPTT->SetLabel(_("&PTT"));
     m_btnTogPTT->SetBackgroundColour(m_btnTogPTT->GetValue() ? *wxRED : wxNullColour);
+    m_btnTogPTT->SetForegroundColour(m_btnTogPTT->GetValue() ? *wxBLACK : wxNullColour);
     
     // The Report Frequency drop-down should not be modifiable during TX.
     // Additionally, tuning during normal TX is verboten.

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -309,8 +309,9 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         // to Mic In
 
         if (vk_event == VK_SPACE_BAR) {
-            m_btnTogPTT->SetValue(false); 
+            m_btnTogPTT->SetValue(false);
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
+            m_btnTogPTT->SetForegroundColour(wxNullColour);
             endingTx.store(true, std::memory_order_release);
             togglePTT();
             m_togBtnVoiceKeyer->SetValue(false);
@@ -321,8 +322,9 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         }
 
         if (vk_event == VK_PLAY_FINISHED) {
-            m_btnTogPTT->SetValue(false); 
+            m_btnTogPTT->SetValue(false);
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
+            m_btnTogPTT->SetForegroundColour(wxNullColour);
             endingTx.store(true, std::memory_order_release);
             CallAfter([&]() { togglePTT(); });
             vk_repeat_counter++;
@@ -404,8 +406,9 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
     default:
         // catch anything we missed
 
-        m_btnTogPTT->SetValue(false); 
+        m_btnTogPTT->SetValue(false);
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
+        m_btnTogPTT->SetForegroundColour(wxNullColour);
         endingTx.store(true, std::memory_order_release);
         togglePTT();
         m_togBtnVoiceKeyer->SetValue(false);


### PR DESCRIPTION
## Summary
- `m_btnTogPTT` only ever had `SetBackgroundColour()` called on it (red for TX, amber for the TX->RX drain, null for idle); the text colour was always left to the active GTK theme to decide.
- On wxGTK < 3.3 (e.g. Mageia 9), the main frame losing window activation while the TOT warning dialog has focus puts the button into GTK's "backdrop" state, dimming the intended black text to grey. On other themes the default foreground can resolve to white, making it unreadable against the red/amber background in all states.
- Explicitly pin `SetForegroundColour(*wxBLACK)` alongside every place the background is set to red/amber, and reset it back to `wxNullColour` (theme default) alongside every place the background is reset to idle, mirroring the existing background-colour pattern.

## Test plan
- [x] Built and verified locally
- [x] Tested on Mageia 9 (wxGTK < 3.3) — confirms PTT button text stays readable through the TOT warning dialog and during the TX/amber/idle states

🤖 Generated with [Claude Code](https://claude.com/claude-code)