### PR TITLE
Fix spacebar PTT restarting TX immediately after TOT fires while key is held

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1277,6 +1277,8 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     Bind(wxEVT_TIMER, &MainFrame::OnTOTTimer, this, ID_TIMER_TOT);
     m_totWarningTimer.SetOwner(this, ID_TIMER_TOT_WARNING);
     Bind(wxEVT_TIMER, &MainFrame::OnTOTWarningTimer, this, ID_TIMER_TOT_WARNING);
+    m_pttKeyPollTimer.SetOwner(this, ID_TIMER_PTT_KEY_POLL);
+    Bind(wxEVT_TIMER, &MainFrame::OnPttKeyPollTimer, this, ID_TIMER_PTT_KEY_POLL);
 #endif
     
     // Create voice keyer popup menu.

--- a/src/main.h
+++ b/src/main.h
@@ -120,6 +120,7 @@ enum {
         ID_TIMER_UPD_FREQ,
         ID_TIMER_TOT,           // Time-Out Timer
         ID_TIMER_TOT_WARNING,   // Polls remaining TOT time to show warning
+        ID_TIMER_PTT_KEY_POLL,  // Polls physical PTT key state after a forced TX stop
      };
 
 #define EXCHANGE_DATA_IN    0
@@ -339,12 +340,25 @@ class MainFrame : public TopFrame
         // Time-Out Timer (TOT): stops TX after configured period
         wxTimer                 m_totTimer;
         wxTimer                 m_totWarningTimer;
+
+        // Polls the physical PTT key state (via wxGetKeyState) after a forced
+        // TX stop, so a held key can't immediately restart TX -- see
+        // m_pttKeyRequireRelease_ below.
+        wxTimer                 m_pttKeyPollTimer;
 #endif
 
         // TOT warning state
         std::chrono::time_point<std::chrono::high_resolution_clock> m_totTxStartTime;
         int                     m_totCurrentDurationMs{0};
         TotWarningDialog*       m_totWarningDialog_{nullptr};
+
+        // Set when TX is force-stopped (e.g. by the TOT) while the PTT key is
+        // still physically held down. Blocks the spacebar from restarting TX
+        // until wxGetKeyState() confirms a genuine release -- this can't be
+        // determined reliably from wxEVT_KEY_UP/DOWN alone, since holding a
+        // key down can generate real (non-auto-repeat-flagged) up/down event
+        // pairs at the OS key-repeat rate.
+        bool                    m_pttKeyRequireRelease_{false};
 
         // TOT beep state
         std::chrono::time_point<std::chrono::high_resolution_clock> m_totLastBeepTime_;
@@ -489,6 +503,7 @@ class MainFrame : public TopFrame
 
         void OnTOTTimer(wxTimerEvent& evt);
         void OnTOTWarningTimer(wxTimerEvent& evt);
+        void OnPttKeyPollTimer(wxTimerEvent& evt);
         void playTotBeep_();
         void stopTotBeep_();
         

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1085,7 +1085,10 @@ int MainApp::FilterEvent(wxEvent& event)
             bool totWarningActive = frame->m_totWarningDialog_ != nullptr && frame->m_totWarningDialog_->IsActive();
             bool tuneActive = frame->m_btnTogTune->GetValue();
 	    bool keyRepeated = static_cast<wxKeyEvent&>(event).IsAutoRepeat();
-            if (frame->m_RxRunning && !tuneActive && !keyRepeated && (mainWindowActive || totWarningActive || reporterActiveButNotUpdatingTextMessage) && 
+            // m_pttKeyRequireRelease_ blocks a key held through a forced TX stop
+            // (e.g. TOT) from immediately restarting TX -- see main.h.
+            if (frame->m_RxRunning && !tuneActive && !keyRepeated && !frame->m_pttKeyRequireRelease_ &&
+                (mainWindowActive || totWarningActive || reporterActiveButNotUpdatingTextMessage) &&
                 wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
 
                 // space bar controls tx/rx if keyer not running
@@ -1275,6 +1278,32 @@ void MainFrame::OnTOTTimer(wxTimerEvent&)
         m_btnTogPTT->SetValue(false);
         endingTx.store(true, std::memory_order_release);
         togglePTT();
+
+        // If the spacebar PTT key is still physically held down (e.g. something
+        // resting on the keyboard), holding it through the timeout must not be
+        // able to immediately re-key the rig -- that would defeat the whole
+        // point of the TOT. wxEVT_KEY_UP/DOWN aren't reliable for detecting
+        // "still held" here: on some platforms, a held key generates real
+        // key-up/key-down event pairs at the OS repeat rate rather than a
+        // single sustained key-down, so we poll the actual OS key state
+        // instead and keep the spacebar disabled until it genuinely goes up.
+        if (wxGetApp().appConfiguration.pttMomentaryMode &&
+            wxGetKeyState(static_cast<wxKeyCode>(wxGetApp().appConfiguration.pttKeyCode.get())))
+        {
+            log_info("TOT fired while PTT key still held -- blocking restart until key is released");
+            m_pttKeyRequireRelease_ = true;
+            m_pttKeyPollTimer.Start(30, wxTIMER_CONTINUOUS);
+        }
+    }
+}
+
+void MainFrame::OnPttKeyPollTimer(wxTimerEvent&)
+{
+    if (!wxGetKeyState(static_cast<wxKeyCode>(wxGetApp().appConfiguration.pttKeyCode.get())))
+    {
+        log_info("PTT key released -- spacebar PTT re-armed");
+        m_pttKeyRequireRelease_ = false;
+        m_pttKeyPollTimer.Stop();
     }
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1071,7 +1071,6 @@ void MainFrame::OnCheckSNRClick(wxCommandEvent&)
 }
 
 // check for space bar press (only when running)
-static bool IsPttKeyDown_ = false;
 
 int MainApp::FilterEvent(wxEvent& event)
 {
@@ -1085,7 +1084,8 @@ int MainApp::FilterEvent(wxEvent& event)
                 !frame->m_reporterDialog->isTextMessageFieldInFocus();
             bool totWarningActive = frame->m_totWarningDialog_ != nullptr && frame->m_totWarningDialog_->IsActive();
             bool tuneActive = frame->m_btnTogTune->GetValue();
-            if (frame->m_RxRunning && !tuneActive && !IsPttKeyDown_ && (mainWindowActive || totWarningActive || reporterActiveButNotUpdatingTextMessage) && 
+	    bool keyRepeated = static_cast<wxKeyEvent&>(event).IsAutoRepeat();
+            if (frame->m_RxRunning && !tuneActive && !keyRepeated && (mainWindowActive || totWarningActive || reporterActiveButNotUpdatingTextMessage) && 
                 wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly()) {
 
                 // space bar controls tx/rx if keyer not running
@@ -1093,7 +1093,6 @@ int MainApp::FilterEvent(wxEvent& event)
                     if (wxGetApp().appConfiguration.pttMomentaryMode) {
                         // Momentary mode: start TX only on the initial key press (not repeated events).
                         if (!g_tx.load(std::memory_order_acquire)) {
-                            IsPttKeyDown_ = true;
                             frame->m_btnTogPTT->SetValue(true);
                             frame->m_btnTogPTT->SetBackgroundColour(*wxRED);
                             frame->togglePTT();
@@ -1130,7 +1129,6 @@ int MainApp::FilterEvent(wxEvent& event)
                 wxGetApp().appConfiguration.pttMomentaryMode) {
 
                 if (frame->vk_state == VK_IDLE && g_tx.load(std::memory_order_acquire)) {
-                    IsPttKeyDown_ = false;
                     frame->m_btnTogPTT->SetValue(false);
                     frame->m_btnTogPTT->SetBackgroundColour(wxNullColour);
                     frame->togglePTT();


### PR DESCRIPTION
Built on top of #1393 at commit 3585eca0 (current tip, including the unrelated colour fixes from #1405).

## Bug

In momentary PTT mode, if the spacebar PTT key is still physically held down when the Time-Out Timer (TOT) fires (e.g. something resting on the keyboard), TX restarts immediately afterward instead of staying off — defeating the safety purpose of the TOT.

## Root cause

`OnTOTTimer` force-stops TX without regard to whether the spacebar key is still physically held. On Linux/GTK, a key held under sustained pressure can generate real `KEY_UP`/`KEY_DOWN` event pairs at the OS repeat rate rather than one sustained `KEY_DOWN`, and `wxKeyEvent::IsAutoRepeat()` is unreliable at the point `wxApp::FilterEvent` intercepts them. The next repeat-driven `KEY_DOWN` then sees the key as "freshly pressed" and immediately re-keys TX.

This PR contains two commits:

1. **Revert of `add9e6e4`** ("Try different way of filtering out duplicate PTT keypresses"). That commit was itself a second attempt at fixing this same pre-existing bug, but it compounded the problem — TX would interrupt the TOT warning countdown after a couple of seconds and restart immediately (confirmed via direct testing, see #1393 comment thread).
2. **The actual fix**: instead of inferring "still held" from the key event stream, poll `wxGetKeyState()` (a direct OS query) after a TOT-forced stop, and latch out spacebar restart until it confirms a genuine key release.

The fix only engages from inside `OnTOTTimer`'s forced-stop path, so normal momentary-PTT hold/release behavior (no timeout reached) is unaffected.

Tested locally via repeated TOT-timeout-while-held scenarios, as well as normal (non-TOT) momentary PTT use, with no regressions observed.

Above analysis and fix by Claude Code.