### PR TITLE
FreeDV 700D/E/1600 Removal: Remove related GUI elements

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -280,30 +280,6 @@ jobs:
           .\TestFreeDVReporting.ps1 -RadioToComputerDevice "${{env.RADIO_TO_COMPUTER_DEVICE}}" -ComputerToRadioDevice "${{env.COMPUTER_TO_RADIO_DEVICE}}" -MicrophoneToComputerDevice "${{env.MICROPHONE_TO_COMPUTER_DEVICE}}" -ComputerToSpeakerDevice "${{env.COMPUTER_TO_SPEAKER_DEVICE}}"
       timeout-minutes: 10
 
-    - name: Test 700D
-      shell: pwsh
-      working-directory: ${{github.workspace}}\FreeDV-Install-Location\bin
-      if: ${{ !cancelled() }}
-      run: |
-          .\TestFreeDVFullDuplex.ps1 -RadioToComputerDevice "${{env.RADIO_TO_COMPUTER_DEVICE}}" -ComputerToRadioDevice "${{env.COMPUTER_TO_RADIO_DEVICE}}" -MicrophoneToComputerDevice "${{env.MICROPHONE_TO_COMPUTER_DEVICE}}" -ComputerToSpeakerDevice "${{env.COMPUTER_TO_SPEAKER_DEVICE}}" -ModeToTest 700D -NumberOfRuns 1
-      timeout-minutes: 10
-
-    - name: Test 700E
-      shell: pwsh
-      working-directory: ${{github.workspace}}\FreeDV-Install-Location\bin
-      if: ${{ !cancelled() }}
-      run: |
-          .\TestFreeDVFullDuplex.ps1 -RadioToComputerDevice "${{env.RADIO_TO_COMPUTER_DEVICE}}" -ComputerToRadioDevice "${{env.COMPUTER_TO_RADIO_DEVICE}}" -MicrophoneToComputerDevice "${{env.MICROPHONE_TO_COMPUTER_DEVICE}}" -ComputerToSpeakerDevice "${{env.COMPUTER_TO_SPEAKER_DEVICE}}" -ModeToTest 700E -NumberOfRuns 1
-      timeout-minutes: 10
-
-    - name: Test 1600
-      shell: pwsh
-      working-directory: ${{github.workspace}}\FreeDV-Install-Location\bin
-      if: ${{ !cancelled() }}
-      run: |
-          .\TestFreeDVFullDuplex.ps1 -RadioToComputerDevice "${{env.RADIO_TO_COMPUTER_DEVICE}}" -ComputerToRadioDevice "${{env.COMPUTER_TO_RADIO_DEVICE}}" -MicrophoneToComputerDevice "${{env.MICROPHONE_TO_COMPUTER_DEVICE}}" -ComputerToSpeakerDevice "${{env.COMPUTER_TO_SPEAKER_DEVICE}}" -ModeToTest 1600 -NumberOfRuns 1
-      timeout-minutes: 10
- 
     - name: Screenshot if failed
       if: failure()
       shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,10 +771,6 @@ set_tests_properties(rade_loss PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
 endif(NOT SANITIZERS_ENABLED)
 endif(NOT ENABLE_RTSAN)
 
-DefineAudioTest(700D)
-DefineAudioTest(700E)
-DefineAudioTest(1600)
-
 add_test(NAME rade_reporting_clean COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/test_rade_reporting.sh)
 if(NOT SANITIZERS_ENABLED)
 set_tests_properties(rade_reporting_clean PROPERTIES PASS_REGULAR_EXPRESSION "Reporting callsign ZZ0ZZZ @ SNR")

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -958,6 +958,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Hamlib: Set frequency again on mode changes. (PR #1395)
     * Consolidate EOO length calculation in freedv-backend to improve callsign decode reliability. (PR #1402)
     * Hamlib: Switch off memory channel before setting frequency/mode. (PR #1403) - thanks @barjac!
+    * Hamlib/OmniRig: Round received frequency to nearest 100 Hz. (PR #1373)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -953,6 +953,10 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Enhancements:
     * RADEV2: Standardize mode as USB. (PR #1397)
+2. Other:
+    * Remove legacy FreeDV modes (700D/700E/1600). (PR #1407)
+
+*Note: Legacy FreeDV modes (700D/700E/1600) have been removed due to low use. FreeDV 2.4.x is still available if one wishes to operate these modes.*
 
 ## V2.4.0 TBD 2026
 

--- a/src/config/FilterConfiguration.cpp
+++ b/src/config/FilterConfiguration.cpp
@@ -26,59 +26,20 @@ DEFINE_FILTER_CONFIG_NAMES(SpkOut);
 DEFINE_FILTER_CONFIG_NAMES_OLD(MicIn);
 DEFINE_FILTER_CONFIG_NAMES_OLD(SpkOut);
 
-static float GammaBetaSaveProcessor_(float val)
-{
-    return val * 100.0;
-}
-
-static float GammaBetaLoadProcessor_(float val)
-{
-    return val / 100.0;
-}
-
 FilterConfiguration::FilterConfiguration()
-    : codec2LPCPostFilterEnable("/Filter/codec2LPCPostFilterEnable", true)
-    , codec2LPCPostFilterBassBoost("/Filter/codec2LPCPostFilterBassBoost", true)
-    , codec2LPCPostFilterGamma("/Filter/codec2LPCPostFilter/Gamma", CODEC2_LPC_PF_GAMMA*100)
-    , codec2LPCPostFilterBeta("/Filter/codec2LPCPostFilter/Beta", CODEC2_LPC_PF_BETA*100)
-    , noiseReductionEnable("/Filter/speexpp_enable", true)
+    : noiseReductionEnable("/Filter/speexpp_enable", true)
     , agcEnabled("/Filter/agcEnable", true)
     , bwExpandEnabled("/Filter/bwExpandEnable", true)
-    , enable700CEqualizer("/Filter/700C_EQ", true)
 {
-    codec2LPCPostFilterGamma.setSaveProcessor(GammaBetaSaveProcessor_);
-    codec2LPCPostFilterBeta.setSaveProcessor(GammaBetaSaveProcessor_);
-    codec2LPCPostFilterGamma.setLoadProcessor(GammaBetaLoadProcessor_);
-    codec2LPCPostFilterBeta.setLoadProcessor(GammaBetaLoadProcessor_);
+    // empty
 }
 
 void FilterConfiguration::load(wxConfigBase* config)
-{
-    // Migration: these values were using incorrect data types, so we have to
-    // move to new names in order to prevent Windows errors (for example:)
-    //
-    // 14:03:28: Registry value "HKCU\Software\freedv\Filter\codec2LPCPostFilterGamma" is not text (but of type DWORD)
-    // 14:03:28: Registry value "HKCU\Software\freedv\Filter\codec2LPCPostFilterBeta" is not text (but of type DWORD)
-    auto oldPostFilterGamma = (float)config->Read(
-        wxT("/Filter/codec2LPCPostFilterGamma"), 
-        CODEC2_LPC_PF_GAMMA*100);
-    codec2LPCPostFilterGamma.setDefaultVal(oldPostFilterGamma);
-    
-    auto oldPostFilterBeta = (float)config->Read(
-        wxT("/Filter/codec2LPCPostFilterBeta"), 
-        CODEC2_LPC_PF_BETA*100);
-    codec2LPCPostFilterBeta.setDefaultVal(oldPostFilterBeta);
-    
+{    
     micInChannel.load(config);
     spkOutChannel.load(config);
     
-    load_(config, codec2LPCPostFilterEnable);
-    load_(config, codec2LPCPostFilterBassBoost);
-    load_(config, codec2LPCPostFilterGamma);
-    load_(config, codec2LPCPostFilterBeta);
-    
     load_(config, noiseReductionEnable);
-    load_(config, enable700CEqualizer);
     load_(config, agcEnabled);
     load_(config, bwExpandEnabled);
 }
@@ -88,13 +49,7 @@ void FilterConfiguration::save(wxConfigBase* config)
     micInChannel.save(config);
     spkOutChannel.save(config);
     
-    save_(config, codec2LPCPostFilterEnable);
-    save_(config, codec2LPCPostFilterBassBoost);
-    save_(config, codec2LPCPostFilterGamma);
-    save_(config, codec2LPCPostFilterBeta);
-    
     save_(config, noiseReductionEnable);
-    save_(config, enable700CEqualizer);
     save_(config, agcEnabled);
     save_(config, bwExpandEnabled);
 }

--- a/src/config/FilterConfiguration.h
+++ b/src/config/FilterConfiguration.h
@@ -83,15 +83,9 @@ public:
     FilterChannel<MicIn> micInChannel;
     FilterChannel<SpkOut> spkOutChannel;
     
-    ConfigurationDataElement<bool> codec2LPCPostFilterEnable;
-    ConfigurationDataElement<bool> codec2LPCPostFilterBassBoost;
-    ConfigurationDataElement<float> codec2LPCPostFilterGamma;
-    ConfigurationDataElement<float> codec2LPCPostFilterBeta;
-    
     ConfigurationDataElement<bool> noiseReductionEnable;
     ConfigurationDataElement<bool> agcEnabled;
     ConfigurationDataElement<bool> bwExpandEnabled;
-    ConfigurationDataElement<bool> enable700CEqualizer;
     
     virtual void load(wxConfigBase* config) override;
     virtual void save(wxConfigBase* config) override;

--- a/src/config/FreeDVConfiguration.cpp
+++ b/src/config/FreeDVConfiguration.cpp
@@ -79,9 +79,6 @@ FreeDVConfiguration::FreeDVConfiguration()
     , quickRecordRawPath("/QuickRecord/SavePath", _(""))
     , quickRecordDecodedPath("/QuickRecord/SaveDecodedPath", _(""))
         
-    , freedv700Clip("/FreeDV700/txClip", true)
-    , freedv700TxBPF("/FreeDV700/txBPF", true)
-        
     , noiseSNR("/Noise/noise_snr", 2)
         
     , debugConsoleEnabled("/Debug/console", false)
@@ -196,9 +193,6 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     
     load_(config, halfDuplexMode);
     
-    load_(config, freedv700Clip);
-    load_(config, freedv700TxBPF);
-    
     load_(config, noiseSNR);
     
     load_(config, debugConsoleEnabled);
@@ -286,9 +280,6 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     
     save_(config, quickRecordRawPath);
     save_(config, quickRecordDecodedPath);
-    
-    save_(config, freedv700Clip);
-    save_(config, freedv700TxBPF);
     
     save_(config, noiseSNR);
     

--- a/src/config/FreeDVConfiguration.cpp
+++ b/src/config/FreeDVConfiguration.cpp
@@ -55,10 +55,6 @@ FreeDVConfiguration::FreeDVConfiguration()
     /* Current tab view */
     , currentNotebookTab("/MainFrame/rxNbookCtrl", 0)
         
-    /* Squelch configuration */
-    , squelchActive("/Audio/SquelchActive", 1)
-    , squelchLevel("/Audio/SquelchLevel", (int)(SQ_DEFAULT_SNR*2))
-        
     /* Misc. audio settings */
     , fifoSizeMs("/Audio/fifoSize_ms", (int)FIFO_SIZE)
     , transmitLevel("/Audio/transmitLevel", 0)
@@ -79,8 +75,6 @@ FreeDVConfiguration::FreeDVConfiguration()
     , voiceKeyerRepeats("/VoiceKeyer/Repeats", 5)
         
     , halfDuplexMode("/Rig/HalfDuplex", true)
-    , multipleReceiveEnabled("/Rig/MultipleRx", true)
-    , multipleReceiveOnSingleThread("/Rig/SingleRxThread", true)
         
     , quickRecordRawPath("/QuickRecord/SavePath", _(""))
     , quickRecordDecodedPath("/QuickRecord/SaveDecodedPath", _(""))
@@ -100,8 +94,6 @@ FreeDVConfiguration::FreeDVConfiguration()
     , waterfallColor("/Waterfall/Color", 0)
     , statsResetTimeSecs("/Stats/ResetTime", 10)
         
-    , currentFreeDVMode("/Audio/mode", FREEDV_MODE_RADE)
-        
     , currentSpectrumAveraging("/Plot/Spectrum/CurrentAveraging", 0)
     
     , experimentalFeatures("/ExperimentalFeatures", false)
@@ -117,7 +109,6 @@ FreeDVConfiguration::FreeDVConfiguration()
     , reportingUserMsgColWidth("/Windows/FreeDVReporter/reportingUserMsgColWidth", 130)
         
     , showDecodeStats("/Debug/showDecodeStats", false)
-    , enableLegacyModes("/Modem/enableLegacyModes", false)
 {
     // empty
 }
@@ -151,9 +142,6 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     load_(config, reporterWindowCurrentSortDirection);
     
     load_(config, currentNotebookTab);
-    
-    load_(config, squelchActive);
-    load_(config, squelchLevel);
     
     load_(config, fifoSizeMs);
     load_(config, transmitLevel);
@@ -207,8 +195,6 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     load_(config, voiceKeyerRepeats);
     
     load_(config, halfDuplexMode);
-    load_(config, multipleReceiveEnabled);
-    load_(config, multipleReceiveOnSingleThread);
     
     load_(config, freedv700Clip);
     load_(config, freedv700TxBPF);
@@ -225,7 +211,6 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     load_(config, waterfallColor);
     
     load_(config, statsResetTimeSecs);
-    load_(config, currentFreeDVMode);
     
     load_(config, currentSpectrumAveraging);
     
@@ -247,7 +232,6 @@ void FreeDVConfiguration::load(wxConfigBase* config)
     load_(config, reportingUserMsgColWidth);
     
     load_(config, showDecodeStats);
-    load_(config, enableLegacyModes);
 
     load_(config, txAttenByBand);
     load_(config, tuneAttenByBand);
@@ -283,9 +267,6 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     
     save_(config, currentNotebookTab);
     
-    save_(config, squelchActive);
-    save_(config, squelchLevel);
-    
     save_(config, fifoSizeMs);
     save_(config, transmitLevel);
     save_(config, tuneLevel);
@@ -302,8 +283,6 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     save_(config, voiceKeyerRepeats);
     
     save_(config, halfDuplexMode);
-    save_(config, multipleReceiveEnabled);
-    save_(config, multipleReceiveOnSingleThread);
     
     save_(config, quickRecordRawPath);
     save_(config, quickRecordDecodedPath);
@@ -323,7 +302,6 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     save_(config, waterfallColor);
     
     save_(config, statsResetTimeSecs);
-    save_(config, currentFreeDVMode);
     
     save_(config, currentSpectrumAveraging);
     
@@ -340,7 +318,6 @@ void FreeDVConfiguration::save(wxConfigBase* config)
     save_(config, reportingUserMsgColWidth);
     
     save_(config, showDecodeStats);
-    save_(config, enableLegacyModes);
 
     save_(config, txAttenByBand);
     save_(config, tuneAttenByBand);

--- a/src/config/FreeDVConfiguration.h
+++ b/src/config/FreeDVConfiguration.h
@@ -87,9 +87,6 @@ public:
     ConfigurationDataElement<wxString> quickRecordRawPath;
     ConfigurationDataElement<wxString> quickRecordDecodedPath;
     
-    ConfigurationDataElement<bool> freedv700Clip;
-    ConfigurationDataElement<bool> freedv700TxBPF;
-    
     ConfigurationDataElement<int> noiseSNR;
     
     ConfigurationDataElement<bool> debugConsoleEnabled; // note: Windows only

--- a/src/config/FreeDVConfiguration.h
+++ b/src/config/FreeDVConfiguration.h
@@ -65,9 +65,6 @@ public:
     
     ConfigurationDataElement<long> currentNotebookTab;
     
-    ConfigurationDataElement<long> squelchActive;
-    ConfigurationDataElement<long> squelchLevel;
-    
     ConfigurationDataElement<int> fifoSizeMs;
     ConfigurationDataElement<int> transmitLevel;
     ConfigurationDataElement<int> tuneLevel;
@@ -86,8 +83,6 @@ public:
     ConfigurationDataElement<int> voiceKeyerRepeats;
     
     ConfigurationDataElement<bool> halfDuplexMode;
-    ConfigurationDataElement<bool> multipleReceiveEnabled;
-    ConfigurationDataElement<bool> multipleReceiveOnSingleThread;
     
     ConfigurationDataElement<wxString> quickRecordRawPath;
     ConfigurationDataElement<wxString> quickRecordDecodedPath;
@@ -106,9 +101,7 @@ public:
     
     ConfigurationDataElement<int> waterfallColor;
     ConfigurationDataElement<unsigned int> statsResetTimeSecs;
-    
-    ConfigurationDataElement<int> currentFreeDVMode;
-    
+        
     ConfigurationDataElement<int> currentSpectrumAveraging;
     
     ConfigurationDataElement<bool> experimentalFeatures;
@@ -124,8 +117,6 @@ public:
     ConfigurationDataElement<int> reportingUserMsgColWidth;
     
     ConfigurationDataElement<bool> showDecodeStats;
-    
-    ConfigurationDataElement<bool> enableLegacyModes;
     
     virtual void load(wxConfigBase* config) override;
     virtual void save(wxConfigBase* config) override;

--- a/src/config/ReportingConfiguration.cpp
+++ b/src/config/ReportingConfiguration.cpp
@@ -30,9 +30,7 @@
 #include "ReportingConfiguration.h"
 
 ReportingConfiguration::ReportingConfiguration()
-    : reportingFreeTextString("/Data/CallSign", _(""))
-        
-    , reportingEnabled("/Reporting/Enable", false)
+    : reportingEnabled("/Reporting/Enable", false)
     , reportingCallsign("/Reporting/Callsign", _(""))
     , reportingGridSquare("/Reporting/GridSquare", _(""))
         
@@ -181,8 +179,6 @@ void ReportingConfiguration::load(wxConfigBase* config)
     reportingEnabled.setDefaultVal(oldPskEnable);
     reportingCallsign.setDefaultVal(oldPskCallsign);
     reportingGridSquare.setDefaultVal(oldGridSquare);
-    
-    load_(config, reportingFreeTextString);
  
     load_(config, reportingEnabled);
     load_(config, reportingCallsign);
@@ -275,9 +271,7 @@ void ReportingConfiguration::load(wxConfigBase* config)
 }
 
 void ReportingConfiguration::save(wxConfigBase* config)
-{
-    save_(config, reportingFreeTextString);
- 
+{ 
     save_(config, reportingEnabled);
     save_(config, reportingCallsign);
     save_(config, reportingGridSquare);

--- a/src/config/ReportingConfiguration.h
+++ b/src/config/ReportingConfiguration.h
@@ -31,9 +31,6 @@ public:
     ReportingConfiguration();
     virtual ~ReportingConfiguration() = default;
     
-    // Old format reporting (FEC-free text field)
-    ConfigurationDataElement<wxString> reportingFreeTextString;
-    
     ConfigurationDataElement<bool> reportingEnabled;
     ConfigurationDataElement<wxString> reportingCallsign;
     ConfigurationDataElement<wxString> reportingGridSquare;

--- a/src/gui/dialogs/dlg_filter.cpp
+++ b/src/gui/dialogs/dlg_filter.cpp
@@ -81,29 +81,6 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
     wxBoxSizer* bSizer30;
     bSizer30 = new wxBoxSizer(wxVERTICAL);
 
-    // LPC Post Filter --------------------------------------------------------
-    wxStaticBox* lpcPostFilterBox = new wxStaticBox(this, wxID_ANY, _("FreeDV 1600 LPC Post Filter"));
-    wxStaticBoxSizer* lpcpfs = new wxStaticBoxSizer(lpcPostFilterBox, wxHORIZONTAL);
-
-    wxBoxSizer* left = new wxBoxSizer(wxVERTICAL);
-
-    m_codec2LPCPostFilterEnable = new wxCheckBox(lpcPostFilterBox, wxID_ANY, _("Enable"), wxDefaultPosition,wxDefaultSize, wxCHK_2STATE);
-    left->Add(m_codec2LPCPostFilterEnable, 0, wxALL, 5);
-
-    m_codec2LPCPostFilterBassBoost = new wxCheckBox(lpcPostFilterBox, wxID_ANY, _("0-1 kHz 3dB Boost"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    left->Add(m_codec2LPCPostFilterBassBoost, 0, wxALL, 5);
-    lpcpfs->Add(left, 0, wxALL | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_CENTRE_VERTICAL, 5);
-
-    wxBoxSizer* sizerBetaGamma = new wxBoxSizer(wxVERTICAL);
-    newLPCPFControl(&m_codec2LPCPostFilterBeta, &m_staticTextBeta, lpcPostFilterBox, sizerBetaGamma, "Beta");
-    newLPCPFControl(&m_codec2LPCPostFilterGamma, &m_staticTextGamma, lpcPostFilterBox, sizerBetaGamma, "Gamma");
-    lpcpfs->Add(sizerBetaGamma, 1, wxALL | wxEXPAND, 5);
-    
-    m_LPCPostFilterDefault = new wxButton(lpcPostFilterBox, wxID_ANY, wxT("Default"));
-    lpcpfs->Add(m_LPCPostFilterDefault, 0, wxALL | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_CENTRE_VERTICAL, 5);
-
-    bSizer30->Add(lpcpfs, 0, wxALL | wxEXPAND, 5);
-
     // RNNoise pre-processor --------------------------------------------------
 
     wxStaticBoxSizer* sbSizer_rnnoise;
@@ -118,10 +95,6 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
     sbSizer_rnnoise->Add(m_ckboxAgcEnabled, 0, wxALL | wxALIGN_LEFT, 5);
     m_ckboxAgcEnabled->SetToolTip(_("Automatic gain control for microphone"));
     
-    m_ckbox700C_EQ = new wxCheckBox(sb_rnnoise, wxID_ANY, _("700D/700E Auto EQ"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    sbSizer_rnnoise->Add(m_ckbox700C_EQ, 0, wxALL | wxALIGN_LEFT, 5);
-    m_ckbox700C_EQ->SetToolTip(_("Automatic equalisation for FreeDV 700D/700E Codec input audio"));
-
     bSizer30->Add(sbSizer_rnnoise, 0, wxALL | wxEXPAND, 5);   
 
     // Speaker audio post-processing
@@ -263,14 +236,9 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
 
     this->Connect(wxEVT_INIT_DIALOG, wxInitDialogEventHandler(FilterDlg::OnInitDialog));
 
-    m_codec2LPCPostFilterEnable->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnEnable), NULL, this);
-    m_codec2LPCPostFilterBassBoost->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnBassBoost), NULL, this);
-    m_LPCPostFilterDefault->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FilterDlg::OnLPCPostFilterDefault), NULL, this);
-
     m_ckboxNoiseReduction->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnNoiseReductionEnable), NULL, this);
     m_ckboxAgcEnabled->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnAgcEnable), NULL, this);
     m_ckboxBwExpandEnabled->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnBwExpandEnable), NULL, this);
-    m_ckbox700C_EQ->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::On700C_EQ), NULL, this);
 
     int events[] = {
         wxEVT_SCROLL_TOP, wxEVT_SCROLL_BOTTOM, wxEVT_SCROLL_LINEUP, wxEVT_SCROLL_LINEDOWN, wxEVT_SCROLL_PAGEUP, 
@@ -295,10 +263,7 @@ FilterDlg::FilterDlg(wxWindow* parent, bool running, bool *newMicInFilter, bool 
         m_SpkOutMid.sliderFreq->Connect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidFreqScroll), NULL, this);
         m_SpkOutMid.sliderGain->Connect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidGainScroll), NULL, this);
         m_SpkOutMid.sliderQ->Connect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidQScroll), NULL, this);
-        m_SpkOutVol.sliderGain->Connect(event, wxScrollEventHandler(FilterDlg::OnSpkOutVolGainScroll), NULL, this);
-        
-        m_codec2LPCPostFilterBeta->Connect(event, wxScrollEventHandler(FilterDlg::OnBetaScroll), NULL, this);
-        m_codec2LPCPostFilterGamma->Connect(event, wxScrollEventHandler(FilterDlg::OnGammaScroll), NULL, this);
+        m_SpkOutVol.sliderGain->Connect(event, wxScrollEventHandler(FilterDlg::OnSpkOutVolGainScroll), NULL, this);        
     }
     
     m_MicInEnable->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnMicInEnable), NULL, this);
@@ -323,10 +288,6 @@ FilterDlg::~FilterDlg()
     // Disconnect Events
     this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(FilterDlg::OnClose), NULL, this);
     this->Disconnect(wxEVT_INIT_DIALOG, wxInitDialogEventHandler(FilterDlg::OnInitDialog));
-
-    m_codec2LPCPostFilterEnable->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnEnable), NULL, this);
-    m_codec2LPCPostFilterBassBoost->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnBassBoost), NULL, this);
-    m_LPCPostFilterDefault->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FilterDlg::OnLPCPostFilterDefault), NULL, this);
 
     m_ckboxNoiseReduction->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnNoiseReductionEnable), NULL, this);
     m_ckboxAgcEnabled->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnAgcEnable), NULL, this);
@@ -355,10 +316,7 @@ FilterDlg::~FilterDlg()
         m_SpkOutMid.sliderFreq->Disconnect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidFreqScroll), NULL, this);
         m_SpkOutMid.sliderGain->Disconnect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidGainScroll), NULL, this);
         m_SpkOutMid.sliderQ->Disconnect(event, wxScrollEventHandler(FilterDlg::OnSpkOutMidQScroll), NULL, this);
-        m_SpkOutVol.sliderGain->Disconnect(event, wxScrollEventHandler(FilterDlg::OnSpkOutVolGainScroll), NULL, this);
-        
-        m_codec2LPCPostFilterBeta->Disconnect(event, wxScrollEventHandler(FilterDlg::OnBetaScroll), NULL, this);
-        m_codec2LPCPostFilterGamma->Disconnect(event, wxScrollEventHandler(FilterDlg::OnGammaScroll), NULL, this);
+        m_SpkOutVol.sliderGain->Disconnect(event, wxScrollEventHandler(FilterDlg::OnSpkOutVolGainScroll), NULL, this);        
     }
     
     m_MicInEnable->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(FilterDlg::OnMicInEnable), NULL, this);
@@ -368,31 +326,6 @@ FilterDlg::~FilterDlg()
     m_SpkOutDefault->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FilterDlg::OnSpkOutDefault), NULL, this);
 
     m_sdbSizer5OK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FilterDlg::OnOK), NULL, this);
-}
-
-void FilterDlg::newLPCPFControl(wxSlider **slider, wxStaticText **stValue, wxWindow* parent, wxSizer *s, wxString const& controlName)
-{
-    wxBoxSizer *bs = new wxBoxSizer(wxHORIZONTAL);
-
-    wxStaticText* st = new wxStaticText(parent, wxID_ANY, controlName, wxDefaultPosition, wxSize(70,-1), wxALIGN_RIGHT);
-    bs->Add(st, 0, wxALIGN_CENTER_VERTICAL|wxALL, 2);
-
-    *slider = new wxSlider(parent, wxID_ANY, 0, 0, SLIDER_MAX_BETA_GAMMA, wxDefaultPosition); 
-    (*slider)->SetMinSize(wxSize(SLIDER_LENGTH,wxDefaultCoord));
-
-    bs->Add(*slider, 1, wxALL|wxEXPAND, 2);
-
-    *stValue = new wxStaticText(parent, wxID_ANY, wxT("0.0"), wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
-    bs->Add(*stValue, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxALL, 2);
-
-    s->Add(bs, 0, wxALL | wxEXPAND, 0);
-
-#if wxUSE_ACCESSIBILITY
-    auto lpcAccessible = new LabelOverrideAccessible([stValue]() {
-        return (*stValue)->GetLabel();
-    });
-    (*slider)->SetAccessible(lpcAccessible);
-#endif // wxUSE_ACCESSIBILITY
 }
 
 void FilterDlg::newEQControl(wxWindow* parent, wxSlider** slider, wxStaticText** value, wxSizer *sizer, wxString const& controlName, int max)
@@ -484,13 +417,6 @@ void FilterDlg::ExchangeData(int inout)
 {
     if(inout == EXCHANGE_DATA_IN)
     {
-        // LPC Post filter
-
-        m_codec2LPCPostFilterEnable->SetValue(wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterEnable);
-        m_codec2LPCPostFilterBassBoost->SetValue(wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBassBoost);
-        m_beta = wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBeta; setBeta();
-        m_gamma = wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterGamma; setGamma();
-
         // RNNoise Pre-Processor
 
         m_ckboxNoiseReduction->SetValue(wxGetApp().appConfiguration.filterConfiguration.noiseReductionEnable);
@@ -500,9 +426,6 @@ void FilterDlg::ExchangeData(int inout)
         
         // BW Expand
         m_ckboxBwExpandEnabled->SetValue(wxGetApp().appConfiguration.filterConfiguration.bwExpandEnabled);
-
-        // Codec 2 700C EQ
-        m_ckbox700C_EQ->SetValue(wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer);
 
         // Mic In Equaliser
 
@@ -576,13 +499,6 @@ void FilterDlg::ExchangeData(int inout)
     }
     if(inout == EXCHANGE_DATA_OUT)
     {
-        // LPC Post filter
-
-        wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterEnable     = m_codec2LPCPostFilterEnable->GetValue();
-        wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBassBoost  = m_codec2LPCPostFilterBassBoost->GetValue();
-        wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBeta       = m_beta;
-        wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterGamma      = m_gamma;
-
         // RNNoise Pre-Processor
         wxGetApp().appConfiguration.filterConfiguration.noiseReductionEnable = m_ckboxNoiseReduction->GetValue();
         
@@ -591,9 +507,6 @@ void FilterDlg::ExchangeData(int inout)
         
         // BW Expand
         wxGetApp().appConfiguration.filterConfiguration.bwExpandEnabled = m_ckboxBwExpandEnabled->GetValue();
-
-        // Codec 2 700C EQ
-        wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer = m_ckbox700C_EQ->GetValue();
 
         // Mic In Equaliser
 
@@ -638,16 +551,6 @@ float FilterDlg::limit(float value, float min, float max) {
 //-------------------------------------------------------------------------
 // OnDefault()
 //-------------------------------------------------------------------------
-
-void FilterDlg::OnLPCPostFilterDefault(wxCommandEvent&)
-{
-    m_beta = CODEC2_LPC_PF_BETA; setBeta();
-    m_gamma = CODEC2_LPC_PF_GAMMA; setGamma();
-    m_codec2LPCPostFilterEnable->SetValue(true);
-    m_codec2LPCPostFilterBassBoost->SetValue(true);
-    ExchangeData(EXCHANGE_DATA_OUT);
-}
-
 void FilterDlg::OnMicInDefault(wxCommandEvent&)
 {
     m_MicInBass.freqHz = 100.0;
@@ -719,50 +622,12 @@ void FilterDlg::OnInitDialog(wxInitDialogEvent&)
     ExchangeData(EXCHANGE_DATA_IN);
 }
 
-void FilterDlg::setBeta(void) {
-    wxString buf = wxNumberFormatter::ToString(m_beta, 2);
-    m_staticTextBeta->SetLabel(buf);
-    int slider = (int)(m_beta*SLIDER_MAX_BETA_GAMMA + 0.5);
-    m_codec2LPCPostFilterBeta->SetValue(slider);
-}
-
-void FilterDlg::setCodec2(void) {
-    if (m_running) {
-        freedvInterface.setLpcPostFilter(
-                                       m_codec2LPCPostFilterEnable->GetValue(),
-                                       m_codec2LPCPostFilterBassBoost->GetValue(),
-                                       m_beta, m_gamma);
-    }
-    ExchangeData(EXCHANGE_DATA_OUT);
-}
-
-void FilterDlg::setGamma(void) {
-    wxString buf = wxNumberFormatter::ToString(m_gamma, 2);
-    m_staticTextGamma->SetLabel(buf);
-    int slider = (int)(m_gamma*SLIDER_MAX_BETA_GAMMA + 0.5);
-    m_codec2LPCPostFilterGamma->SetValue(slider);
-}
-
 void FilterDlg::OnEnable(wxScrollEvent&) {
-    setCodec2();
     updateControlState();
 }
 
 void FilterDlg::OnBassBoost(wxScrollEvent&) {
-    setCodec2();
     updateControlState();
-}
-
-void FilterDlg::OnBetaScroll(wxScrollEvent&) {
-    m_beta = (float)m_codec2LPCPostFilterBeta->GetValue()/SLIDER_MAX_BETA_GAMMA;
-    setBeta();
-    setCodec2();
-}
-
-void FilterDlg::OnGammaScroll(wxScrollEvent&) {
-    m_gamma = (float)m_codec2LPCPostFilterGamma->GetValue()/SLIDER_MAX_BETA_GAMMA;
-    setGamma();
-    setCodec2();
 }
 
 void FilterDlg::OnNoiseReductionEnable(wxScrollEvent&) {
@@ -780,14 +645,6 @@ void FilterDlg::OnAgcEnable(wxScrollEvent&) {
 void FilterDlg::OnBwExpandEnable(wxScrollEvent&) {
     wxGetApp().appConfiguration.filterConfiguration.bwExpandEnabled = m_ckboxBwExpandEnabled->GetValue();
     g_bwExpandEnabled.store(wxGetApp().appConfiguration.filterConfiguration.bwExpandEnabled, std::memory_order_release); // forces immediate change at pipeline level
-    ExchangeData(EXCHANGE_DATA_OUT);
-}
-
-void FilterDlg::On700C_EQ(wxScrollEvent&) {
-    wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer = m_ckbox700C_EQ->GetValue();
-    if (m_running) {
-        freedvInterface.setEq(wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer);
-    }
     ExchangeData(EXCHANGE_DATA_OUT);
 }
 
@@ -822,11 +679,6 @@ void FilterDlg::updateControlState()
     m_SpkOutVol.sliderGain->Enable(true);
     
     m_SpkOutDefault->Enable(wxGetApp().appConfiguration.filterConfiguration.spkOutChannel.eqEnable);
-    
-    m_codec2LPCPostFilterBeta->Enable(m_codec2LPCPostFilterEnable->GetValue());
-    m_codec2LPCPostFilterBassBoost->Enable(m_codec2LPCPostFilterEnable->GetValue());
-    m_codec2LPCPostFilterGamma->Enable(m_codec2LPCPostFilterEnable->GetValue());
-    m_LPCPostFilterDefault->Enable(m_codec2LPCPostFilterEnable->GetValue());
 }
 
 void FilterDlg::OnMicInEnable(wxScrollEvent&) {

--- a/src/gui/dialogs/dlg_filter.h
+++ b/src/gui/dialogs/dlg_filter.h
@@ -76,17 +76,13 @@ class FilterDlg : public wxDialog
         void    OnOK(wxCommandEvent& event);
         void    OnClose(wxCloseEvent& event);
         void    OnInitDialog(wxInitDialogEvent& event);
-        void    OnLPCPostFilterDefault(wxCommandEvent& event);
 
-        void    OnBetaScroll(wxScrollEvent& event);
-        void    OnGammaScroll(wxScrollEvent& event);
         void    OnEnable(wxScrollEvent& event);
         void    OnBassBoost(wxScrollEvent& event);
 
         void    OnNoiseReductionEnable(wxScrollEvent& event);
         void    OnAgcEnable(wxScrollEvent& event);
         void    OnBwExpandEnable(wxScrollEvent& event);
-        void    On700C_EQ(wxScrollEvent& event);
 
         void    OnMicInBassFreqScroll(wxScrollEvent&) { sliderToFreq(&m_MicInBass, true); }
         void    OnMicInBassGainScroll(wxScrollEvent&) { sliderToGain(&m_MicInBass, true); }
@@ -113,19 +109,13 @@ class FilterDlg : public wxDialog
         void    OnSpkOutDefault(wxCommandEvent& event);
 
         wxStaticText* m_staticText8;
-        wxCheckBox*   m_codec2LPCPostFilterEnable;
         wxStaticText* m_staticText9;
-        wxCheckBox*   m_codec2LPCPostFilterBassBoost;
         wxStaticText* m_staticText91;
-        wxSlider*     m_codec2LPCPostFilterBeta;
         wxStaticText* m_staticTextBeta;
         wxStaticText* m_staticText911;
-        wxSlider*     m_codec2LPCPostFilterGamma;
         wxStaticText* m_staticTextGamma;
-        wxButton*     m_LPCPostFilterDefault;
 
         wxCheckBox*   m_ckboxNoiseReduction;
-        wxCheckBox*   m_ckbox700C_EQ;
         wxCheckBox*   m_ckboxAgcEnabled;
         wxCheckBox*   m_ckboxBwExpandEnabled;
         
@@ -144,16 +134,9 @@ class FilterDlg : public wxDialog
 
      private:
         bool          m_running;
-        float         m_beta;
-        float         m_gamma;
-
-        void          setBeta(void);  // sets slider and static text from m_beta
-        void          setGamma(void); // sets slider and static text from m_gamma
-        void          setCodec2(void);
  
         void          newEQControl(wxWindow* parent, wxSlider** slider, wxStaticText** value, wxSizer *sizer, wxString const& controlName, int max);
         EQ            newEQ(wxWindow* parent, wxSizer *bs, wxString const& eqName, float maxFreqHz, bool enableQ, bool enableFreq, int maxSliderBass);
-        void          newLPCPFControl(wxSlider **slider, wxStaticText **stValue, wxWindow* parent, wxSizer *sbs, wxString const& controlName);
         wxNotebook    *m_auiNotebook;
         void          setFreq(EQ *eq);
         void          setGain(EQ *eq);

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -132,21 +132,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     // Reporting tab
     wxBoxSizer* sizerReporting = new wxBoxSizer(wxVERTICAL);
-    
-    //------------------------------
-    // Txt Msg Text Box
-    //------------------------------
-
-    wxStaticBoxSizer* sbSizer_callSign;
-    wxStaticBox *sb_textMsg = new wxStaticBox(m_reportingTab, wxID_ANY, _("Txt Msg"));
-    sbSizer_callSign = new wxStaticBoxSizer(sb_textMsg, wxVERTICAL);
-
-    m_txtCtrlCallSign = new wxTextCtrl(sb_textMsg, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
-    m_txtCtrlCallSign->SetToolTip(_("Text message that you can send along with your voice. Note that this does not have error correction and thus is not guaranteed to arrive at the receiving station."));
-    sbSizer_callSign->Add(m_txtCtrlCallSign, 0, wxALL | wxEXPAND, 5);
-
-    sizerReporting->Add(sbSizer_callSign,0, wxALL | wxEXPAND, 5);
- 
+     
     //----------------------------------------------------------
     // Reporting Options 
     //----------------------------------------------------------
@@ -786,7 +772,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     // Tab ordering for accessibility
     //-------------------
 #if 0
-    m_txtCtrlCallSign->MoveBeforeInTabOrder(m_ckboxReportingEnable);
     m_ckboxReportingEnable->MoveBeforeInTabOrder(m_txt_callsign);
     m_txt_callsign->MoveBeforeInTabOrder(m_txt_grid_square);
     
@@ -974,8 +959,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
             m_freqList->Append(item);
         }
         
-        m_txtCtrlCallSign->SetValue(wxGetApp().appConfiguration.reportingConfiguration.reportingFreeTextString);
-
         m_ckboxEnableSpacebarForPTT->SetValue(wxGetApp().appConfiguration.enableSpaceBarForPTT);
         m_selectedPTTKeyCode = wxGetApp().appConfiguration.pttKeyCode;
         m_capturingPTTKey = false;
@@ -1174,8 +1157,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqModeChanges = m_ckboxEnableFreqModeChanges->GetValue();
         wxGetApp().appConfiguration.rigControlConfiguration.hamlibEnableFreqChangesOnly = m_ckboxEnableFreqChangesOnly->GetValue();
         
-        wxGetApp().appConfiguration.reportingConfiguration.reportingFreeTextString = m_txtCtrlCallSign->GetValue();
-
         wxGetApp().appConfiguration.halfDuplexMode = m_ckHalfDuplex->GetValue();
         
         /* Plot settings */
@@ -1484,7 +1465,6 @@ void OptionsDlg::updateReportingState()
 
         if (m_ckboxReportingEnable->GetValue())
         {
-            m_txtCtrlCallSign->Enable(false);
             m_txt_callsign->Enable(true);
             m_txt_grid_square->Enable(true);
             m_ckboxManualFrequencyReporting->Enable(true);
@@ -1520,7 +1500,6 @@ void OptionsDlg::updateReportingState()
         }
         else
         {
-            m_txtCtrlCallSign->Enable(true);
             m_txt_callsign->Enable(false);
             m_txt_grid_square->Enable(false);
             m_ckboxPskReporterEnable->Enable(false);
@@ -1540,7 +1519,6 @@ void OptionsDlg::updateReportingState()
     {
         // Txt Msg/Reporter options cannot be modified during a session.
         m_ckboxReportingEnable->Enable(false);
-        m_txtCtrlCallSign->Enable(false);
         m_txt_callsign->Enable(false);
         m_txt_grid_square->Enable(false);
         m_ckboxManualFrequencyReporting->Enable(false);

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -571,22 +571,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     // Modem tab
     wxBoxSizer* sizerModem = new wxBoxSizer(wxVERTICAL);
-    
-    //------------------------------
-    // FreeDV 700 Options
-    //------------------------------
-
-    wxStaticBoxSizer* sbSizer_freedv700;
-    wxStaticBox *sb_freedv700 = new wxStaticBox(m_modemTab, wxID_ANY, _("Modem Options"));
-    sbSizer_freedv700 = new wxStaticBoxSizer(sb_freedv700, wxHORIZONTAL);
-
-    m_ckboxFreeDV700txClip = new wxCheckBox(sb_freedv700, wxID_ANY, _("Clipping"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    sbSizer_freedv700->Add(m_ckboxFreeDV700txClip, 0, wxALL | wxALIGN_LEFT, 5);
-
-    m_ckboxFreeDV700txBPF = new wxCheckBox(sb_freedv700, wxID_ANY, _("TX Band Pass Filter"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    sbSizer_freedv700->Add(m_ckboxFreeDV700txBPF, 0, wxALL | wxALIGN_LEFT, 5);
-
-    sizerModem->Add(sbSizer_freedv700, 0, wxALL|wxEXPAND, 5);
 
     //------------------------------
     // Half/Full duplex selection
@@ -819,8 +803,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     m_buttonChooseVoiceKeyerWaveFilePath->MoveBeforeInTabOrder(m_txtCtrlVoiceKeyerRxPause);
     m_txtCtrlVoiceKeyerRxPause->MoveBeforeInTabOrder(m_txtCtrlVoiceKeyerRepeats);
     
-    m_ckboxFreeDV700txClip->MoveBeforeInTabOrder(m_ckboxFreeDV700txBPF);
-    m_ckboxFreeDV700txBPF->MoveBeforeInTabOrder(m_ckHalfDuplex);
     m_ckboxSingleRxThread->MoveBeforeInTabOrder(m_statsResetTime);
     
     m_ckboxTestFrame->MoveBeforeInTabOrder(m_ckboxChannelNoise);
@@ -870,8 +852,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
 
     m_ckboxTestFrame->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnTestFrame), NULL, this);
     m_ckboxChannelNoise->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnChannelNoise), NULL, this);
-
-    m_ckboxFreeDV700txClip->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnFreeDV700txClip), NULL, this);
 
 #ifdef __WXMSW__
     m_ckboxDebugConsole->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnDebugConsole), NULL, this);
@@ -930,7 +910,6 @@ OptionsDlg::~OptionsDlg()
     m_ckboxTestFrame->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnTestFrame), NULL, this);
     m_ckboxChannelNoise->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnChannelNoise), NULL, this);
 
-    m_ckboxFreeDV700txClip->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxScrollEventHandler(OptionsDlg::OnFreeDV700txClip), NULL, this);
     m_buttonChooseVoiceKeyerWaveFilePath->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(OptionsDlg::OnChooseVoiceKeyerWaveFilePath), NULL, this);
     m_buttonChooseQuickRecordRawPath->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(OptionsDlg::OnChooseQuickRecordPath), NULL, this);
     m_buttonChooseQuickRecordDecodedPath->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(OptionsDlg::OnChooseQuickRecordPath), NULL, this);
@@ -1053,9 +1032,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_showDecodeStats->SetValue(wxGetApp().appConfiguration.showDecodeStats);
         
         m_experimentalFeatures->SetValue(wxGetApp().appConfiguration.experimentalFeatures);
-       
-        m_ckboxFreeDV700txClip->SetValue(wxGetApp().appConfiguration.freedv700Clip);
-        m_ckboxFreeDV700txBPF->SetValue(wxGetApp().appConfiguration.freedv700TxBPF);
         
 #ifdef __WXMSW__
         m_ckboxDebugConsole->SetValue(wxGetApp().appConfiguration.debugConsoleEnabled);
@@ -1256,8 +1232,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         g_freedv_verbose = m_ckboxFreeDVAPIVerbose->GetValue();
 
         wxGetApp().appConfiguration.showDecodeStats = m_showDecodeStats->GetValue();
-        wxGetApp().appConfiguration.freedv700Clip = m_ckboxFreeDV700txClip->GetValue();
-        wxGetApp().appConfiguration.freedv700TxBPF = m_ckboxFreeDV700txBPF->GetValue();
         
 #ifdef __WXMSW__
         wxGetApp().appConfiguration.debugConsoleEnabled = m_ckboxDebugConsole->GetValue();
@@ -1472,10 +1446,6 @@ void OptionsDlg::OnChooseCsvLogFilePath(wxCommandEvent&) {
     }
 
     m_txtCtrlCsvLogFilePath->SetValue(fileDialog.GetPath());
-}
-
-void OptionsDlg::OnFreeDV700txClip(wxScrollEvent&) {
-    wxGetApp().appConfiguration.freedv700Clip = m_ckboxFreeDV700txClip->GetValue();
 }
 
 void OptionsDlg::OnDebugConsole(wxScrollEvent&) {

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -586,9 +586,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     m_ckboxFreeDV700txBPF = new wxCheckBox(sb_freedv700, wxID_ANY, _("TX Band Pass Filter"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
     sbSizer_freedv700->Add(m_ckboxFreeDV700txBPF, 0, wxALL | wxALIGN_LEFT, 5);
 
-    m_ckboxEnableLegacyModes = new wxCheckBox(sb_freedv700, wxID_ANY, _("Enable Legacy Modes"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-    sbSizer_freedv700->Add(m_ckboxEnableLegacyModes, 0, wxALL | wxALIGN_LEFT, 5);
-    
     sizerModem->Add(sbSizer_freedv700, 0, wxALL|wxEXPAND, 5);
 
     //------------------------------
@@ -602,24 +599,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     sbSizer_duplex->Add(m_ckHalfDuplex, 0, wxALL | wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 
     sizerModem->Add(sbSizer_duplex,0, wxALL | wxEXPAND, 5);
-
-    //------------------------------
-    // Multiple RX selection
-    //------------------------------
-    wxStaticBox *sb_multirx = new wxStaticBox(m_modemTab, wxID_ANY, _("Multiple RX Operation"));
-    wxStaticBoxSizer* sbSizer_multirx = new wxStaticBoxSizer(sb_multirx, wxVERTICAL);
-
-    wxBoxSizer* sbSizer_simultaneousDecode = new wxBoxSizer(wxHORIZONTAL);
-    m_ckboxMultipleRx = new wxCheckBox(sb_multirx, wxID_ANY, _("Simultaneously Decode All HF Modes"), wxDefaultPosition, wxSize(-1,-1), 0);
-    sbSizer_simultaneousDecode->Add(m_ckboxMultipleRx, 0, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
-    sbSizer_multirx->Add(sbSizer_simultaneousDecode, 0, wxALIGN_LEFT, 0);
-    
-    wxBoxSizer* sbSizer_singleThread = new wxBoxSizer(wxHORIZONTAL);
-    m_ckboxSingleRxThread = new wxCheckBox(sb_multirx, wxID_ANY, _("Use single thread for multiple RX operation"), wxDefaultPosition, wxSize(-1,-1), 0);
-    sbSizer_singleThread->Add(m_ckboxSingleRxThread, 0, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
-    sbSizer_multirx->Add(sbSizer_singleThread, 0, wxALIGN_LEFT, 0);
-    
-    sizerModem->Add(sbSizer_multirx,0, wxALL|wxEXPAND, 5);
     
     wxStaticBox *sb_modemstats = new wxStaticBox(m_modemTab, wxID_ANY, _("Modem Statistics"));
     wxStaticBoxSizer* sbSizer_modemstats = new wxStaticBoxSizer(sb_modemstats, wxVERTICAL);
@@ -842,8 +821,6 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     
     m_ckboxFreeDV700txClip->MoveBeforeInTabOrder(m_ckboxFreeDV700txBPF);
     m_ckboxFreeDV700txBPF->MoveBeforeInTabOrder(m_ckHalfDuplex);
-    m_ckHalfDuplex->MoveBeforeInTabOrder(m_ckboxMultipleRx);
-    m_ckboxMultipleRx->MoveBeforeInTabOrder(m_ckboxSingleRxThread);
     m_ckboxSingleRxThread->MoveBeforeInTabOrder(m_statsResetTime);
     
     m_ckboxTestFrame->MoveBeforeInTabOrder(m_ckboxChannelNoise);
@@ -914,9 +891,7 @@ OptionsDlg::OptionsDlg(wxWindow* parent, wxWindowID id, const wxString& title, c
     m_ckboxUDPReportingEnable->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnReportingEnable), NULL, this);
     m_ckboxUDPBroadcastEnable->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnReportingEnable), NULL, this);
     m_ckboxTone->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnToneStateEnable), NULL, this);
-    
-    m_ckboxMultipleRx->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnMultipleRxEnable), NULL, this);
-    
+        
     m_ckboxEnableFreqModeChanges->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
     m_ckboxEnableFreqChangesOnly->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
     m_ckboxNoFreqModeChanges->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
@@ -972,9 +947,7 @@ OptionsDlg::~OptionsDlg()
     m_ckboxUDPReportingEnable->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnReportingEnable), NULL, this);
     m_ckboxUDPBroadcastEnable->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnReportingEnable), NULL, this);
     m_ckboxTone->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnToneStateEnable), NULL, this);
-    
-    m_ckboxMultipleRx->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(OptionsDlg::OnMultipleRxEnable), NULL, this);
-    
+        
     m_ckboxEnableFreqModeChanges->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
     m_ckboxEnableFreqChangesOnly->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
     m_ckboxNoFreqModeChanges->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(OptionsDlg::OnFreqModeChangeEnable), NULL, this);
@@ -1057,9 +1030,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         m_txtCtrlQuickRecordDecodedPath->SetValue(wxGetApp().appConfiguration.quickRecordDecodedPath);
         
         m_ckHalfDuplex->SetValue(wxGetApp().appConfiguration.halfDuplexMode);
-
-        m_ckboxMultipleRx->SetValue(wxGetApp().appConfiguration.multipleReceiveEnabled);
-        m_ckboxSingleRxThread->SetValue(wxGetApp().appConfiguration.multipleReceiveOnSingleThread);
         
         m_ckboxTestFrame->SetValue(wxGetApp().m_testFrames);
 
@@ -1086,7 +1056,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
        
         m_ckboxFreeDV700txClip->SetValue(wxGetApp().appConfiguration.freedv700Clip);
         m_ckboxFreeDV700txBPF->SetValue(wxGetApp().appConfiguration.freedv700TxBPF);
-        m_ckboxEnableLegacyModes->SetValue(wxGetApp().appConfiguration.enableLegacyModes);
         
 #ifdef __WXMSW__
         m_ckboxDebugConsole->SetValue(wxGetApp().appConfiguration.debugConsoleEnabled);
@@ -1175,7 +1144,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         updateChannelNoiseState();
         updateAttnCarrierState();
         updateToneState();
-        updateMultipleRxState();
         updateRigControlState();
 
         wxCommandEvent tmpEvent;
@@ -1233,8 +1201,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.reportingConfiguration.reportingFreeTextString = m_txtCtrlCallSign->GetValue();
 
         wxGetApp().appConfiguration.halfDuplexMode = m_ckHalfDuplex->GetValue();
-        wxGetApp().appConfiguration.multipleReceiveEnabled = m_ckboxMultipleRx->GetValue();
-        wxGetApp().appConfiguration.multipleReceiveOnSingleThread = m_ckboxSingleRxThread->GetValue();
         
         /* Plot settings */
         wxGetApp().appConfiguration.currentSpectrumAveraging = m_cbxNumSpectrumAveraging->GetSelection();
@@ -1292,7 +1258,6 @@ void OptionsDlg::ExchangeData(int inout, bool storePersistent)
         wxGetApp().appConfiguration.showDecodeStats = m_showDecodeStats->GetValue();
         wxGetApp().appConfiguration.freedv700Clip = m_ckboxFreeDV700txClip->GetValue();
         wxGetApp().appConfiguration.freedv700TxBPF = m_ckboxFreeDV700txBPF->GetValue();
-        wxGetApp().appConfiguration.enableLegacyModes = m_ckboxEnableLegacyModes->GetValue();
         
 #ifdef __WXMSW__
         wxGetApp().appConfiguration.debugConsoleEnabled = m_ckboxDebugConsole->GetValue();
@@ -1642,21 +1607,6 @@ void OptionsDlg::updateToneState()
     m_txtToneAmplitude->Enable(m_ckboxTone->GetValue());
 }
 
-void OptionsDlg::updateMultipleRxState()
-{
-    if (!sessionActive_)
-    {
-        m_ckboxMultipleRx->Enable(true);
-        m_ckboxSingleRxThread->Enable(m_ckboxMultipleRx->GetValue());
-    }
-    else
-    {
-        // Multi-RX settings cannot be updated during a session.
-        m_ckboxMultipleRx->Enable(false);
-        m_ckboxSingleRxThread->Enable(false);
-    }
-}
-
 void OptionsDlg::updateRigControlState()
 {
     if (!sessionActive_)
@@ -1688,11 +1638,6 @@ void OptionsDlg::OnReportingEnable(wxCommandEvent&)
 void OptionsDlg::OnToneStateEnable(wxCommandEvent&)
 {
     updateToneState();
-}
-
-void OptionsDlg::OnMultipleRxEnable(wxCommandEvent&)
-{
-    updateMultipleRxState();
 }
 
 void OptionsDlg::OnFreqModeChangeEnable(wxCommandEvent&)

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -63,7 +63,6 @@ class OptionsDlg : public wxDialog
  
         void    OnTestFrame(wxScrollEvent& event);
         void    OnChannelNoise(wxScrollEvent& event);
-        void    OnFreeDV700txClip(wxScrollEvent& event);
         void    OnDebugConsole(wxScrollEvent& event);
 
         void    OnFifoReset(wxCommandEvent& event);
@@ -149,9 +148,6 @@ class OptionsDlg : public wxDialog
         wxCheckBox   *m_ckboxTone;
         wxTextCtrl   *m_txtToneFreqHz;
         wxTextCtrl   *m_txtToneAmplitude;
-
-        wxCheckBox   *m_ckboxFreeDV700txClip;
-        wxCheckBox   *m_ckboxFreeDV700txBPF;
 
         wxRadioButton *m_rb_textEncoding1;
         wxRadioButton *m_rb_textEncoding2;

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -78,8 +78,6 @@ class OptionsDlg : public wxDialog
         void    enterPTTCaptureMode_();
         void    exitPTTCaptureMode_(bool accept, int keyCode = 0);
 
-        wxTextCtrl   *m_txtCtrlCallSign; // TODO: this should be renamed to tx_txtmsg, and rename all related incl persis strge
-
         wxCheckBox* m_ckHalfDuplex;
 
         wxNotebook  *m_notebook;

--- a/src/gui/dialogs/dlg_options.h
+++ b/src/gui/dialogs/dlg_options.h
@@ -70,7 +70,6 @@ class OptionsDlg : public wxDialog
         
         void    OnReportingEnable(wxCommandEvent& event);
         void    OnToneStateEnable(wxCommandEvent& event);
-        void    OnMultipleRxEnable(wxCommandEvent& event);
         void    OnFreqModeChangeEnable(wxCommandEvent& event);
         void    OnEnableSpacebarForPTT(wxCommandEvent& event);
         void    OnSetPTTKey(wxCommandEvent& event);
@@ -153,7 +152,6 @@ class OptionsDlg : public wxDialog
 
         wxCheckBox   *m_ckboxFreeDV700txClip;
         wxCheckBox   *m_ckboxFreeDV700txBPF;
-        wxCheckBox   *m_ckboxEnableLegacyModes;
 
         wxRadioButton *m_rb_textEncoding1;
         wxRadioButton *m_rb_textEncoding2;
@@ -202,8 +200,6 @@ class OptionsDlg : public wxDialog
 
         wxCheckBox   *m_ckboxDebugConsole;
 
-        wxCheckBox*  m_ckboxMultipleRx;
-        wxCheckBox*  m_ckboxSingleRxThread;
         wxTextCtrl*  m_statsResetTime;
         
         wxCheckBox*  m_ckbox_use_utc_time;
@@ -234,7 +230,6 @@ class OptionsDlg : public wxDialog
          void updateChannelNoiseState();
          void updateAttnCarrierState();
          void updateToneState();
-         void updateMultipleRxState();
          void updateRigControlState();
          
          bool sessionActive_;

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -57,9 +57,8 @@ extern int g_analog;
 #define USER_MESSAGE_COL (8)
 #define LAST_TX_DATE_COL (9)
 #define LAST_RX_CALLSIGN_COL (10)
-#define LAST_RX_MODE_COL (11)
-#define SNR_COL (12)
-#define LAST_UPDATE_DATE_COL (13)
+#define SNR_COL (11)
+#define LAST_UPDATE_DATE_COL (12)
 #define RIGHTMOST_COL (LAST_UPDATE_DATE_COL + 1)
 
 #define UNKNOWN_SNR_VAL (-99)
@@ -140,10 +139,6 @@ void FreeDVReporterDialog::createColumn_(int col, bool visible)
         case LAST_RX_CALLSIGN_COL:
             colName = wxT("RX Call");
             minWidth = 65;
-            break;
-        case LAST_RX_MODE_COL:
-            colName = wxT("Mode");
-            minWidth = 60;
             break;
         case SNR_COL:
             colName = wxT("SNR");
@@ -271,12 +266,6 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
         {
             log_info("Creating col %d", col);
             auto visible = (bool)wxGetApp().appConfiguration.reportingConfiguration.freedvReporterColumnVisibility->at(col);
-
-            // Hide RX Mode column if legacy modes aren't enabled
-            if (col == LAST_RX_MODE_COL)
-            {
-                visible &= wxGetApp().appConfiguration.enableLegacyModes;
-            }
             createColumn_(col, visible);
         }
     }
@@ -412,7 +401,6 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
         {USER_MESSAGE_COL, _("User Message")},
         {LAST_TX_DATE_COL, _("Last TX Date")},
         {LAST_RX_CALLSIGN_COL, _("Last RX Callsign")},
-        {LAST_RX_MODE_COL, _("Last RX Mode")},
         {SNR_COL, _("SNR")},
         {LAST_UPDATE_DATE_COL, _("Last Update")},
     };
@@ -422,11 +410,6 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
         auto menuItem = showMenu_->Append(wxID_HIGHEST + 100 + item.first, item.second, wxEmptyString, wxITEM_CHECK);
         menuItem->Check(wxGetApp().appConfiguration.reportingConfiguration.freedvReporterColumnVisibility->at(item.first));
         this->Connect(wxID_HIGHEST + 100 + item.first, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(FreeDVReporterDialog::OnShowColumn));
-
-        if (item.first == LAST_RX_MODE_COL && !wxGetApp().appConfiguration.enableLegacyModes)
-        {
-            menuItem->Enable(false);
-        }
     }
 
     std::vector<int> idleLongerThanMinutes { 30, 60, 90, 120 };
@@ -776,12 +759,6 @@ void FreeDVReporterDialog::refreshLayout()
         item->SetAlignment(wxALIGN_RIGHT);
         renderer->SetAlignment(wxALIGN_RIGHT | wxALIGN_CENTRE_VERTICAL);
     }
-    
-    // Hide/show legacy columns
-    item = getColumnForModelColId_(LAST_RX_MODE_COL);
-    item->SetHidden(!wxGetApp().appConfiguration.enableLegacyModes || !wxGetApp().appConfiguration.reportingConfiguration.freedvReporterColumnVisibility->at(LAST_RX_MODE_COL));
-    auto menuItem = showMenu_->FindChildItem(wxID_HIGHEST + 100 + LAST_RX_MODE_COL);
-    menuItem->Enable(wxGetApp().appConfiguration.enableLegacyModes);
 
     // Update filter status in window
     updateFilterStatus_();
@@ -2569,7 +2546,6 @@ wxString FreeDVReporterDialog::FreeDVReporterDataModel::getColumnDisplayValue_(R
         case USER_MESSAGE_COL:   return data->userMessage;
         case LAST_TX_DATE_COL:   return data->lastTx;
         case LAST_RX_CALLSIGN_COL: return data->lastRxCallsign;
-        case LAST_RX_MODE_COL:   return data->lastRxMode;
         case SNR_COL:            return data->snr;
         case LAST_UPDATE_DATE_COL: return data->lastUpdate;
         default:                 return "";
@@ -2934,9 +2910,6 @@ int FreeDVReporterDialog::FreeDVReporterDataModel::Compare (const wxDataViewItem
         case LAST_RX_CALLSIGN_COL:
             result = leftData->lastRxCallsign.CmpNoCase(rightData->lastRxCallsign);
             break;
-        case LAST_RX_MODE_COL:
-            result = leftData->lastRxMode.CmpNoCase(rightData->lastRxMode);
-            break;
         case SNR_COL:
             result = leftData->snrVal - rightData->snrVal;
             break;
@@ -3136,9 +3109,6 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::GetValue (wxVariant &variant
                 break;
             case LAST_RX_CALLSIGN_COL:
                 variant = wxVariant(row->lastRxCallsign);
-                break;
-            case LAST_RX_MODE_COL:
-                variant = wxVariant(row->lastRxMode);
                 break;
             case SNR_COL:
                 variant = wxVariant(row->snr);
@@ -3694,8 +3664,7 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onReceiveUpdateFn_(std::stri
 
             auto sortingColumn = parent_->m_listSpots->GetSortingColumn();
             bool isChanged = 
-                (sortingColumn == parent_->getColumnForModelColId_(LAST_RX_CALLSIGN_COL) && iter->second->lastRxCallsign != receivedCallsignWx) ||
-                (sortingColumn == parent_->getColumnForModelColId_(LAST_RX_MODE_COL) && iter->second->lastRxMode != rxModeWx);
+                (sortingColumn == parent_->getColumnForModelColId_(LAST_RX_CALLSIGN_COL) && iter->second->lastRxCallsign != receivedCallsignWx);
             bool isDataChanged =
                 iter->second->lastRxCallsign != receivedCallsignWx ||
                 iter->second->lastRxMode != rxModeWx;
@@ -3709,7 +3678,6 @@ void FreeDVReporterDialog::FreeDVReporterDataModel::onReceiveUpdateFn_(std::stri
                 // Frequency change--blank out SNR too.
                 isChanged |=
                     (sortingColumn == parent_->getColumnForModelColId_(LAST_RX_CALLSIGN_COL) && iter->second->lastRxCallsign != parent_->UNKNOWN_STR) ||
-                    (sortingColumn == parent_->getColumnForModelColId_(LAST_RX_MODE_COL) && iter->second->lastRxMode != parent_->UNKNOWN_STR) ||
                     (sortingColumn == parent_->getColumnForModelColId_(SNR_COL) && iter->second->snr != parent_->UNKNOWN_STR) ||
                     iter->second->lastRxDate.IsValid();
                 isDataChanged |=

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1853,58 +1853,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         }
         g_prev_State.store(state, std::memory_order_release);
 
-        // send Callsign ----------------------------------------------------
-
-        char callsign[MAX_CALLSIGN];
-        memset(callsign, 0, MAX_CALLSIGN);
-    
-        if (!wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled)
-        {
-            strncpy(callsign, (const char*) wxGetApp().appConfiguration.reportingConfiguration.reportingFreeTextString->mb_str(wxConvUTF8), MAX_CALLSIGN - 2);
-            if (strlen(callsign) < MAX_CALLSIGN - 1)
-            {
-                strncat(callsign, "\r", 2);
-            }     
-     
-            // buffer 1 txt message to ensure tx data fifo doesn't "run dry"
-            char* sendBuffer = &callsign[0];
-            auto txDataFifo = g_txDataInFifo.load(std::memory_order_acquire);
-            if ((unsigned)txDataFifo->numUsed() < strlen(sendBuffer)) {
-                unsigned int  i;
-
-                // write chars to tx data fifo
-                for(i = 0; i < strlen(sendBuffer); i++) {
-                    short ashort = (unsigned char)sendBuffer[i];
-                    txDataFifo->write(&ashort, 1);
-                }
-            }
-
-            // See if any Callsign info received --------------------------------
-
-            short ashort;
-            while (codec2_fifo_read(g_rxDataOutFifo, &ashort, 1) == 0) {
-                unsigned char incomingChar = (unsigned char)ashort;
-        
-                // Pre-1.5.1 behavior, where text is handled as-is.
-                if (incomingChar == '\r' || incomingChar == '\n' || incomingChar == 0 || ((m_pcallsign - m_callsign) > MAX_CALLSIGN-1))
-                {                        
-                    // CR completes line. Fill in remaining positions with zeroes.
-                    if ((m_pcallsign - m_callsign) <= MAX_CALLSIGN-1)
-                    {
-                        memset(m_pcallsign, 0, MAX_CALLSIGN - (m_pcallsign - m_callsign));
-                    }
-            
-                    // Reset to the beginning.
-                    m_pcallsign = m_callsign;
-                }
-                else
-                {
-                    *m_pcallsign++ = incomingChar;
-                }
-                m_txtCtrlCallSign->SetValue(m_callsign);
-            }
-        }
-
         // We should only report to reporters when all of the following are true:
         // a) The callsign encoder indicates a valid callsign has been received.
         // b) We detect a valid format callsign in the text (see https://en.wikipedia.org/wiki/Amateur_radio_call_signs).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,8 +116,6 @@ int g_tuneLevel = 0;
 std::atomic<float> g_tuneLevelScale;
 
 // GUI controls that affect rx and tx processes
-int   g_SquelchActive;
-float g_SquelchLevel;
 int   g_analog;
 std::atomic<bool>   g_tx;
 float g_snr;
@@ -325,38 +323,6 @@ void MainApp::UnitTest_()
     
     // Wait 100ms for FreeDV to come to foreground
     std::this_thread::sleep_for(100ms);
-
-    // Select FreeDV mode.
-    wxRadioButton* modeBtn = nullptr;
-    if (utFreeDVMode == "RADEV1")
-    {
-        modeBtn = frame->m_rbRADE;
-    }
-    else if (utFreeDVMode == "700D")
-    {
-        modeBtn = frame->m_rb700d;
-    }
-    else if (utFreeDVMode == "700E")
-    {
-        modeBtn = frame->m_rb700e;
-    }
-    else if (utFreeDVMode == "1600")
-    {
-        modeBtn = frame->m_rb1600;
-    }
-    
-    if (modeBtn != nullptr)
-    {
-        log_info("Firing mode change");
-        /*sim.MouseMove(modeBtn->GetScreenPosition());
-        sim.MouseClick();*/
-        CallAfter([this, modeBtn]() {
-            modeBtn->SetValue(true);
-            wxCommandEvent* modeEvent = new wxCommandEvent(wxEVT_RADIOBUTTON, modeBtn->GetId());
-            modeEvent->SetEventObject(modeBtn);
-            QueueEvent(modeEvent);
-        });
-    }
     
     // Fire event to start FreeDV
     log_info("Firing start");
@@ -856,10 +822,6 @@ void MainFrame::loadConfiguration_()
     if (y < 0 || y > 2048) y = 20;
     if (w < 0 || w > 2048) w = 800;
     if (h < 0 || h > 2048) h = 780;
-
-    g_SquelchActive = wxGetApp().appConfiguration.squelchActive;
-    g_SquelchLevel = wxGetApp().appConfiguration.squelchLevel;
-    g_SquelchLevel /= 2.0;
     
     Move(x, y);
     wxSize size = GetMinSize();
@@ -987,65 +949,19 @@ void MainFrame::loadConfiguration_()
         m_cboReportFrequency->SetValue(sVal);
     }
 
-    int defaultMode = wxGetApp().appConfiguration.currentFreeDVMode.getDefaultVal();
-    int mode = wxGetApp().appConfiguration.currentFreeDVMode;
-setDefaultMode:
-    if (mode == 0)
-    {
-        m_rb1600->SetValue(1);
-    }
-    else if (mode == 4)
-    {
-        m_rb700d->SetValue(1);
-    }
-    else if (mode == 5)
-    {
-        m_rb700e->SetValue(1);
-    }
-    else if (mode == FREEDV_MODE_RADE)
-    {
-        m_rbRADE->SetValue(1);
-    }
-    else
-    {
-        // Default to RADE otherwise
-        mode = defaultMode;
-        goto setDefaultMode;
-    }
-    
-    // Disable controls not supported by RADE.
-    bool isEnabled = wxGetApp().appConfiguration.enableLegacyModes && mode != FREEDV_MODE_RADE;
-    squelchBox->Show(wxGetApp().appConfiguration.enableLegacyModes);
-    m_sliderSQ->Enable(isEnabled);
-    m_ckboxSQ->Enable(isEnabled);
-    m_textSQ->Enable(isEnabled);
-    m_btnCenterRx->Enable(isEnabled);
-    m_btnCenterRx->Show(wxGetApp().appConfiguration.enableLegacyModes);
-    m_BtnReSync->Enable(isEnabled);
-    m_BtnReSync->Show(wxGetApp().appConfiguration.enableLegacyModes);
-
-    if (!isEnabled)
-    {
-        m_textBits->SetLabel("Bits: unk");
-        m_textErrors->SetLabel("Errs: unk");
-        m_textBER->SetLabel("BER: unk");
-        m_textFreqOffset->SetLabel("FrqOff: unk");
-        m_textSyncMetric->SetLabel("Sync: unk");
-        m_textCodec2Var->SetLabel("Var: unk");
-        m_textClockOffset->SetLabel("ClkOff: unk");
-    }
+    m_textBits->SetLabel("Bits: unk");
+    m_textErrors->SetLabel("Errs: unk");
+    m_textBER->SetLabel("BER: unk");
+    m_textFreqOffset->SetLabel("FrqOff: unk");
+    m_textSyncMetric->SetLabel("Sync: unk");
+    m_textCodec2Var->SetLabel("Var: unk");
+    m_textClockOffset->SetLabel("ClkOff: unk");
     
     pConfig->SetPath(wxT("/"));
     
     m_togBtnAnalog->Disable();
     m_btnTogPTT->Disable();
     m_togBtnVoiceKeyer->Disable();
-
-    // squelch settings
-    m_sliderSQ->SetValue((int)((g_SquelchLevel+5.0)*2.0));
-    wxString sqsnr_string = wxNumberFormatter::ToString(g_SquelchLevel, 1) + "dB";
-    m_textSQ->SetLabel(sqsnr_string);
-    m_ckboxSQ->SetValue(g_SquelchActive);
 
     // SNR settings
 
@@ -1132,8 +1048,6 @@ setDefaultMode:
     }
     
     statsBox->Show(wxGetApp().appConfiguration.showDecodeStats);
-    modeBox->Show(wxGetApp().appConfiguration.enableLegacyModes);
-    m_BtnReSync->Show(wxGetApp().appConfiguration.enableLegacyModes);
 
     // Initialize FreeDV Reporter as required
     CallAfter(&MainFrame::initializeFreeDVReporter_);
@@ -1567,23 +1481,8 @@ void MainFrame::exportConfiguration_(wxConfigBase* config)
         wxGetApp().appConfiguration.tabLayout = ((TabFreeAuiNotebook*)m_auiNbookCtrl)->SavePerspective();
     }
     
-    wxGetApp().appConfiguration.squelchActive = g_SquelchActive;
-    wxGetApp().appConfiguration.squelchLevel = (int)(g_SquelchLevel*2.0);
-
     wxGetApp().appConfiguration.transmitLevel = g_txLevel;
     autoSaveCurrentBandLevels_(false);
-
-    int mode = FREEDV_MODE_RADE;
-    if (m_rb1600->GetValue())
-        mode = 0;
-    if (m_rb700d->GetValue())
-        mode = 4;
-    if (m_rb700e->GetValue())
-        mode = 5;
-    if (m_rbRADE->GetValue())
-        mode = FREEDV_MODE_RADE;
-    
-    wxGetApp().appConfiguration.currentFreeDVMode = mode;
     wxGetApp().appConfiguration.save(config);
 }
 
@@ -2398,57 +2297,6 @@ void MainFrame::OnExit(wxCommandEvent&)
     }
 }
 
-void MainFrame::OnChangeTxMode( wxCommandEvent& event )
-{
-    auto eventObject = (wxRadioButton*)event.GetEventObject();
-    auto newMode = g_mode;
-    if (eventObject == m_rb1600 || (eventObject == nullptr && m_rb1600->GetValue())) 
-    {
-        newMode = FREEDV_MODE_1600;
-    }
-    else if (eventObject == m_rbRADE || (eventObject == nullptr && m_rbRADE->GetValue())) 
-    {
-        newMode = FREEDV_MODE_RADE;
-    }
-    else if (eventObject == m_rb700d || (eventObject == nullptr && m_rb700d->GetValue())) 
-    {
-        newMode = FREEDV_MODE_700D;
-    }
-    else if (eventObject == m_rb700e || (eventObject == nullptr && m_rb700e->GetValue())) 
-    {
-        newMode = FREEDV_MODE_700E;
-    }
-
-    if (newMode != g_mode)
-    {
-        g_mode = newMode; 
-        if (freedvInterface.isRunning())
-        {
-            // Need to change the TX interface live.
-            freedvInterface.changeTxMode(g_mode);
-        }
-    
-        // Force recreation of EQ filters.
-        m_newMicInFilter = true;
-        m_newSpkOutFilter = true;
-    
-        // Report TX change to registered reporters
-        auto txStatus = g_tx.load(std::memory_order_acquire);
-        for (auto& obj : wxGetApp().m_reporters)
-        {
-            obj->transmit(freedvInterface.getCurrentTxModeStr(), txStatus);
-        }
-    
-        // Disable controls not supported by RADE
-        bool isEnabled = g_mode != FREEDV_MODE_RADE;
-        m_sliderSQ->Enable(isEnabled);
-        m_ckboxSQ->Enable(isEnabled);
-        m_textSQ->Enable(isEnabled);
-        m_btnCenterRx->Enable(isEnabled);
-        m_BtnReSync->Enable(isEnabled);
-    }
-}
-
 void MainFrame::performFreeDVOn_()
 {
     log_debug("Start .....");
@@ -2498,55 +2346,15 @@ void MainFrame::performFreeDVOn_()
         m_textSync->Enable();
         m_textCurrentDecodeMode->Enable();
         
-        // determine what mode we are using
-        wxCommandEvent tmpEvent;
-        OnChangeTxMode(tmpEvent);
-
-        if (!wxGetApp().appConfiguration.enableLegacyModes || !wxGetApp().appConfiguration.multipleReceiveEnabled || m_rbRADE->GetValue())
-        {
-            m_rb1600->Disable();
-            m_rbRADE->Disable();
-            m_rb700d->Disable();
-            m_rb700e->Disable();
-            
-            if (!wxGetApp().appConfiguration.enableLegacyModes)
-            {
-                // If legacy modes are not enabled, RADE is the only option.
-                g_mode = FREEDV_MODE_RADE;
-            }
-            freedvInterface.addRxMode(g_mode);
-        }
-        else
-        {
-            m_rbRADE->Disable();
-                    
-            int rxModes[] = {
-                FREEDV_MODE_1600,
-                FREEDV_MODE_700E,
-                FREEDV_MODE_700D,
-            };
-
-            for (auto& mode : rxModes)
-            {
-                freedvInterface.addRxMode(mode);
-            }
-        
-            // If we're receive-only, it doesn't make sense to be able to change TX mode.
-            if (g_nSoundCards <= 1)
-            {
-                m_rb1600->Disable();
-                m_rbRADE->Disable();
-                m_rb700d->Disable();
-                m_rb700e->Disable();
-            }
-        }
+        g_mode = FREEDV_MODE_RADE;
+        freedvInterface.addRxMode(g_mode);
         
         // Default voice keyer sample rate to 8K. The exact voice keyer
         // sample rate will be determined when the .wav file is loaded.
         g_sfTxFs = FS;
     
         wxGetApp().m_prevMode = g_mode;
-        freedvInterface.start(g_mode, wxGetApp().appConfiguration.fifoSizeMs, !wxGetApp().appConfiguration.multipleReceiveEnabled || wxGetApp().appConfiguration.multipleReceiveOnSingleThread, wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled);
+        freedvInterface.start(g_mode, wxGetApp().appConfiguration.fifoSizeMs, true, wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled);
 
         // Codec 2 VQ Equaliser
         freedvInterface.setEq(wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer);
@@ -2894,11 +2702,6 @@ void MainFrame::performFreeDVOff_()
         m_togBtnAnalog->Disable();
         m_btnTogPTT->Disable();
         m_togBtnVoiceKeyer->Disable();
-    
-        m_rbRADE->Enable();
-        m_rb1600->Enable();
-        m_rb700d->Enable();
-        m_rb700e->Enable();
         
         m_logQSO->Enable(m_lastReportedCallsignListView->GetItemCount() > 0);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2066,11 +2066,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             m_newMicInFilter = m_newSpkOutFilter = false;
         }
         g_mutexProtectingCallbackData.Unlock();
-    
-        // set some run time options (if applicable)
-        freedvInterface.setRunTimeOptions(
-            (int)wxGetApp().appConfiguration.freedv700Clip,
-            (int)wxGetApp().appConfiguration.freedv700TxBPF);
 
         // Test Frame Bit Error Updates ------------------------------------
 
@@ -2356,9 +2351,6 @@ void MainFrame::performFreeDVOn_()
         wxGetApp().m_prevMode = g_mode;
         freedvInterface.start(g_mode, wxGetApp().appConfiguration.fifoSizeMs, true, wxGetApp().appConfiguration.reportingConfiguration.reportingEnabled);
 
-        // Codec 2 VQ Equaliser
-        freedvInterface.setEq(wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer);
-
         // Codec2 verbosity setting
         freedvInterface.setVerbose(g_freedv_verbose);
 
@@ -2391,13 +2383,6 @@ void MainFrame::performFreeDVOn_()
             g_error_hist[i] = 0;
             g_error_histn[i] = 0;
         }
-
-        // init Codec 2 LPC Post Filter (FreeDV 1600)
-        freedvInterface.setLpcPostFilter(
-                                       wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterEnable,
-                                       wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBassBoost,
-                                       wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterBeta,
-                                       wxGetApp().appConfiguration.filterConfiguration.codec2LPCPostFilterGamma);
 
         log_debug("freedv_get_n_speech_samples(tx): %d", freedvInterface.getTxNumSpeechSamples());
         log_debug("freedv_get_speech_sample_rate(tx): %d", freedvInterface.getTxSpeechSampleRate());

--- a/src/main.h
+++ b/src/main.h
@@ -414,8 +414,6 @@ class MainFrame : public TopFrame
         void OnHelpCheckUpdatesUI( wxUpdateUIEvent& event ) override;
         void OnHelpAbout( wxCommandEvent& event ) override;
         void OnHelpManual( wxCommandEvent& event ) override;
-        void OnCmdSliderScroll( wxScrollEvent& event ) override;
-        void OnCheckSQClick( wxCommandEvent& event ) override;
         void OnCheckSNRClick( wxCommandEvent& event ) override;
 
         // Toggle Buttons
@@ -455,8 +453,6 @@ class MainFrame : public TopFrame
 #endif
 
         int VoiceKeyerStartTx(void);
-
-        void OnChangeTxMode( wxCommandEvent& event ) override;
         
         void applyTxLevel();
         void OnTxLevelDecrBig( wxCommandEvent& event ) override;

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -32,8 +32,6 @@
 
 extern int g_mode;
 
-extern int   g_SquelchActive;
-extern float g_SquelchLevel;
 extern int   g_analog;
 extern std::atomic<bool>   g_tx;
 extern std::atomic<int>   g_State, g_prev_State;
@@ -238,19 +236,6 @@ void MainFrame::OnToolsOptions(wxCommandEvent& event)
         
         // Show/hide stats box
         statsBox->Show(wxGetApp().appConfiguration.showDecodeStats);
-        
-        // Show/hide legacy modes
-        modeBox->Show(wxGetApp().appConfiguration.enableLegacyModes);
-        
-        bool isEnabled = wxGetApp().appConfiguration.enableLegacyModes && !m_rbRADE->GetValue();
-        squelchBox->Show(wxGetApp().appConfiguration.enableLegacyModes);
-        m_sliderSQ->Enable(isEnabled);
-        m_ckboxSQ->Enable(isEnabled);
-        m_textSQ->Enable(isEnabled);
-        m_btnCenterRx->Enable(isEnabled);
-        m_btnCenterRx->Show(wxGetApp().appConfiguration.enableLegacyModes);
-        m_BtnReSync->Enable(isEnabled);
-        m_BtnReSync->Show(wxGetApp().appConfiguration.enableLegacyModes);
 
         // XXX - with really short windows, wxWidgets sometimes doesn't size
         // the components properly until the user resizes the window (even if only
@@ -787,18 +772,6 @@ void MainFrame::OnPaint(wxPaintEvent& WXUNUSED(event))
 }
 
 //-------------------------------------------------------------------------
-// OnCmdSliderScroll()
-//-------------------------------------------------------------------------
-void MainFrame::OnCmdSliderScroll(wxScrollEvent& event)
-{
-    g_SquelchLevel = (float)m_sliderSQ->GetValue()/2.0 - 5.0;
-    wxString sqsnr_string = wxNumberFormatter::ToString(g_SquelchLevel, 1) + "dB"; // 0.5 dB steps
-    m_textSQ->SetLabel(sqsnr_string);
-
-    event.Skip();
-}
-
-//-------------------------------------------------------------------------
 // bandNameForFilter() - maps FilterFrequency enum to config key string
 //-------------------------------------------------------------------------
 static wxString bandNameForFilter(FilterFrequency band)
@@ -1033,21 +1006,6 @@ void MainFrame::OnChangeMicSpkrLevel( wxScrollEvent& )
     
     wxString fmtString = wxString::Format(MIC_SPKR_LEVEL_FORMAT_STR, wxNumberFormatter::ToString((double)sliderLevel, 1), DECIBEL_STR);
     m_txtMicSpkrLevelNum->SetLabel(fmtString);
-}
-
-//-------------------------------------------------------------------------
-// OnCheckSQClick()
-//-------------------------------------------------------------------------
-void MainFrame::OnCheckSQClick(wxCommandEvent&)
-{
-    if(!g_SquelchActive)
-    {
-        g_SquelchActive = true;
-    }
-    else
-    {
-        g_SquelchActive = false;
-    }
 }
 
 void MainFrame::setsnrBeta(bool snrSlow)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -491,12 +491,23 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
                 break;
         }
 
+        // Round to the nearest 100 Hz.
+        uint64_t wholeFreq = freq / 100;
+        uint64_t remainder = freq % 100;
+
+        if (remainder >= 50)
+        {
+            wholeFreq++;
+        }
+
+        auto newFreq = wholeFreq * 100;
+
         // Widest 60 meter allocation is 5.250-5.450 MHz per https://en.wikipedia.org/wiki/60-meter_band.
-        bool is60MeterBand = freq >= 5250000 && freq <= 5450000;
+        bool is60MeterBand = newFreq >= 5250000 && newFreq <= 5450000;
 
         // Update color based on the mode and current frequency.
-        bool isUsbFreq = freq >= 10000000 || is60MeterBand;
-        bool isLsbFreq = freq < 10000000 && !is60MeterBand;
+        bool isUsbFreq = newFreq >= 10000000 || is60MeterBand;
+        bool isLsbFreq = newFreq < 10000000 && !is60MeterBand;
 
         bool isMatchingMode = 
             (isUsbFreq && (mode == IRigFrequencyController::USB || mode == IRigFrequencyController::DIGU)) ||
@@ -520,11 +531,11 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
             wxString freqString;            
             if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequencyAsKhz)
             {
-                freqString = wxNumberFormatter::ToString(freq / 1000.0, 1);
+                freqString = wxNumberFormatter::ToString(newFreq / 1000.0, 1);
             }
             else
             {
-                freqString = wxNumberFormatter::ToString(freq / 1000.0 / 1000.0, 4);
+                freqString = wxNumberFormatter::ToString(newFreq / 1000.0 / 1000.0, 4);
             }
             
             // Set internal reporting frequency to ensure we don't immediately request
@@ -533,8 +544,8 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
             // by m_cboReportFrequency's change handler, so we should fire off reporting
             // here.
             auto oldFreq = wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency;
-            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = freq;
-            if (oldFreq != freq)
+            wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency = newFreq;
+            if (oldFreq != newFreq)
             {
                 for (auto& ptr : wxGetApp().m_reporters)
                 {
@@ -547,7 +558,7 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
         m_txtModeStatus->Refresh();
 
         // Auto-save outgoing band levels, then load the new band's levels
-        auto newBandEnum = FreeDVReporterDialog::getFilterForFrequency_(freq);
+        auto newBandEnum = FreeDVReporterDialog::getFilterForFrequency_(newFreq);
         if (newBandEnum != BAND_OTHER && newBandEnum != lastBand_)
         {
             autoSaveCurrentBandLevels_();
@@ -1145,7 +1156,11 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
     {
         m_btnTogPTT->SetBackgroundColour(*wxRED);
+#if !defined(__APPLE__)
+        // macOS limitations prevent the foreground color of toggle buttons from being 
+        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(*wxBLACK);
+#endif // !defined(__APPLE__)
         m_btnTogPTT->Refresh();
     }
     event.Skip();
@@ -1161,7 +1176,11 @@ void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
     {
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+        // macOS limitations prevent the foreground color of toggle buttons from being 
+        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
         m_btnTogPTT->Refresh();
     }
     event.Skip();
@@ -1316,7 +1335,11 @@ void MainFrame::togglePTT(void) {
         // - e.g. backdrop while the TOT warning dialog has focus - would
         // otherwise dim or recolour the default text away from black.
         m_btnTogPTT->SetBackgroundColour(wxColour(255, 165, 0));
+#if !defined(__APPLE__)
+        // macOS limitations prevent the foreground color of toggle buttons from being 
+        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(*wxBLACK);
+#endif // !defined(__APPLE__)
         m_btnTogPTT->SetLabel("TX Ending");
         m_btnTogPTT->Refresh();
 
@@ -1598,7 +1621,11 @@ void MainFrame::togglePTT(void) {
     m_btnTogPTT->SetValue(newTx);
     m_btnTogPTT->SetLabel(_("&PTT"));
     m_btnTogPTT->SetBackgroundColour(m_btnTogPTT->GetValue() ? *wxRED : wxNullColour);
+#if !defined(__APPLE__)
+    // macOS limitations prevent the foreground color of toggle buttons from being 
+    // reliably set, so don't mess with it in the first place.
     m_btnTogPTT->SetForegroundColour(m_btnTogPTT->GetValue() ? *wxBLACK : wxNullColour);
+#endif // !defined(__APPLE__)
     
     // The Report Frequency drop-down should not be modifiable during TX.
     // Additionally, tuning during normal TX is verboten.

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1851,8 +1851,6 @@ void MainFrame::resetStats_()
             g_error_hist[i] = 0;
             g_error_histn[i] = 0;
         }
-        // resets variance stats every time it is called
-        freedvInterface.setEq(wxGetApp().appConfiguration.filterConfiguration.enable700CEqualizer);
     }
 }
 

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -913,9 +913,6 @@ void TxRxThread::rxProcessing_(IRealtimeHelper* helper) FREEDV_NONBLOCKING
 #if defined(ENABLE_PROCESSING_STATS)
         startTimer_();
 #endif // defined(ENABLE_PROCESSING_STATS)
-        
-        // send latest squelch level to FreeDV API, as it handles squelch internally
-        freedvInterface.setSquelch(g_SquelchActive, g_SquelchLevel);
 
         auto outputSamples = pipeline_->execute(inputSamples_.get(), nsam, &nout);
         

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -520,9 +520,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     sbSizer3_33->Add(m_textCurrentDecodeMode, 0, wxALIGN_CENTER_HORIZONTAL, 1);
     m_textCurrentDecodeMode->Disable();
     
-    m_BtnReSync = new wxButton(syncBox, wxID_ANY, _("ReS&ync"), wxDefaultPosition, wxDefaultSize, 0);
-    sbSizer3_33->Add(m_BtnReSync, 0, wxALL | wxALIGN_CENTRE, 5);
-    
     m_btnCenterRx = new wxButton(syncBox, wxID_ANY, _("C&enter RX"), wxDefaultPosition, wxDefaultSize, 0);
     sbSizer3_33->Add(m_btnCenterRx, 0, wxALL | wxALIGN_CENTRE, 5);
     
@@ -671,41 +668,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     //=====================================================
     rightSizer = new wxWrapSizer(wxVERTICAL, wxREMOVE_LEADING_SPACES);
 
-    //=====================================================
-    // Squelch Slider Control
-    //=====================================================
-    wxStaticBoxSizer* sbSizer3;
-    squelchBox = new wxStaticBox(m_panel, wxID_ANY, _("S&quelch"), wxDefaultPosition, wxSize(100,-1));
-    sbSizer3 = new wxStaticBoxSizer(squelchBox, wxVERTICAL);
-
-    m_sliderSQ = new wxSlider(squelchBox, wxID_ANY, 0, 0, 40, wxDefaultPosition, wxDefaultSize, wxSL_AUTOTICKS);
-    m_sliderSQ->SetMinSize(wxSize(135,-1));
-
-    // Add accessibility class so that the values are read back correctly.
-#if wxUSE_ACCESSIBILITY
-    auto squelchSliderAccessibility = new LabelOverrideAccessible([&]() {
-        return m_textSQ->GetLabel();
-    });
-    m_sliderSQ->SetAccessible(squelchSliderAccessibility);
-#endif // wxUSE_ACCESSIBILITY
-
-    sbSizer3->Add(m_sliderSQ, 1, wxALIGN_CENTER_HORIZONTAL, 0);
-
-    //------------------------------
-    // Squelch Level static text box
-    //------------------------------
-    m_textSQ = new wxStaticText(squelchBox, wxID_ANY, wxT(""), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
-    m_textSQ->SetMinSize(wxSize(100,-1));
-    sbSizer3->Add(m_textSQ, 0, wxALIGN_CENTER_HORIZONTAL, 0);
-
-    //------------------------------
-    // Squelch Toggle Checkbox
-    //------------------------------
-    m_ckboxSQ = new wxCheckBox(squelchBox, wxID_ANY, _("Enable"), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
-
-    sbSizer3->Add(m_ckboxSQ, 0, wxALIGN_CENTER_HORIZONTAL, 0);
-    rightSizer->Add(sbSizer3, 0, wxALL | wxEXPAND, 2);
-
     // Transmit Level slider
     m_txLevelBox = new wxStaticBox(m_panel, wxID_ANY, _("TX &Attenuation"), wxDefaultPosition, wxSize(100,-1));
     wxBoxSizer* txLevelSizer = new wxStaticBoxSizer(m_txLevelBox, wxVERTICAL);
@@ -779,23 +741,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     
     /* new --- */
 
-    //------------------------------
-    // Mode box
-    //------------------------------
-    modeBox = new wxStaticBox(m_panel, wxID_ANY, _("&Mode"), wxDefaultPosition, wxSize(100,-1));
-    sbSizer_mode = new wxStaticBoxSizer(modeBox, wxVERTICAL);
-
-    m_rbRADE = new wxRadioButton( modeBox, wxID_ANY, wxT("RADEV1"), wxDefaultPosition, wxDefaultSize,  wxRB_GROUP);
-    sbSizer_mode->Add(m_rbRADE, 0, wxALIGN_LEFT|wxALL, 1); 
-    m_rb700d = new wxRadioButton( modeBox, wxID_ANY, wxT("700D"), wxDefaultPosition, wxDefaultSize,  0);
-    sbSizer_mode->Add(m_rb700d, 0, wxALIGN_LEFT|wxALL, 1);
-    m_rb700e = new wxRadioButton( modeBox, wxID_ANY, wxT("700E"), wxDefaultPosition, wxDefaultSize,  0);
-    sbSizer_mode->Add(m_rb700e, 0, wxALIGN_LEFT|wxALL, 1);
-    m_rb1600 = new wxRadioButton( modeBox, wxID_ANY, wxT("1600"), wxDefaultPosition, wxDefaultSize, 0);
-    sbSizer_mode->Add(m_rb1600, 0, wxALIGN_LEFT|wxALL, 1);
-
-    rightSizer->Add(sbSizer_mode,0, wxALL | wxEXPAND, 2);
-
     //=====================================================
     // Control Toggles box
     //=====================================================
@@ -856,10 +801,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     // Tab ordering for accessibility
     //-------------------
     m_auiNbookCtrl->MoveBeforeInTabOrder(m_BtnCallSignReset);
-    m_sliderSQ->MoveBeforeInTabOrder(m_ckboxSQ);
-    m_rbRADE->MoveBeforeInTabOrder(m_rb700d);
-    m_rb700d->MoveBeforeInTabOrder(m_rb700e);
-    m_rb700e->MoveBeforeInTabOrder(m_rb1600);
     
     m_togBtnOnOff->MoveBeforeInTabOrder(m_togBtnAnalog);
     m_togBtnAnalog->MoveBeforeInTabOrder(m_btnTogTune);
@@ -904,17 +845,8 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     this->Connect(m_menuItemAbout->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnHelpAbout));
     this->Connect(m_menuItemHelpManual->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnHelpManual));
     this->Connect(m_menuItemHelpGetAssistance->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnHelp));
-    m_sliderSQ->Connect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_LINEUP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_PAGEUP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Connect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_ckboxSQ->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(TopFrame::OnCheckSQClick), NULL, this);
-
+    
+    
     m_ckboxSNR->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(TopFrame::OnCheckSNRClick), NULL, this);
 
     m_audioRecord->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnRecord), NULL, this);
@@ -930,13 +862,8 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     m_BtnCallSignReset->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnCallSignReset), NULL, this);
     m_BtnBerReset->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnBerReset), NULL, this);
-    m_BtnReSync->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnReSync), NULL, this);
     m_btnCenterRx->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnCenterRx), NULL, this);
-   
-    m_rbRADE->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this); 
-    m_rb1600->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb700d->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb700e->Connect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
+
         
     m_btnTxLevelMM->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecrBig), NULL, this);
     m_btnTxLevelM->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecr), NULL, this);
@@ -1034,17 +961,6 @@ TopFrame::~TopFrame()
     this->Disconnect(ID_ABOUT, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnHelpAbout));
     this->Disconnect(wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(TopFrame::OnHelpManual));
     
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_TOP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_BOTTOM, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_LINEUP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_PAGEUP, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_sliderSQ->Disconnect(wxEVT_SCROLL_CHANGED, wxScrollEventHandler(TopFrame::OnCmdSliderScroll), NULL, this);
-    m_ckboxSQ->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(TopFrame::OnCheckSQClick), NULL, this);
-
     m_togBtnOnOff->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnOnOff), NULL, this);
     m_togBtnAnalog->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnAnalogClick), NULL, this);
     m_togBtnVoiceKeyer->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
@@ -1057,11 +973,6 @@ TopFrame::~TopFrame()
     m_audioRecord->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnRecord), NULL, this);
     
     m_logQSO->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnLogQSO), NULL, this);
-
-    m_rbRADE->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb1600->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb700d->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
-    m_rb700e->Disconnect(wxEVT_RADIOBUTTON, wxCommandEventHandler(TopFrame::OnChangeTxMode), NULL, this);
         
     m_btnTxLevelMM->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecrBig), NULL, this);
     m_btnTxLevelM->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecr), NULL, this);

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -112,9 +112,6 @@ class TopFrame : public wxFrame
         wxSlider* m_sliderMicSpkrLevel;
         wxStaticText* m_txtMicSpkrLevelNum;
         
-        wxSlider* m_sliderSQ;        
-        wxCheckBox* m_ckboxSQ;
-        wxStaticText* m_textSQ;
         wxStatusBar* m_statusBar1;
 
         wxStaticBox* statsBox;
@@ -130,17 +127,11 @@ class TopFrame : public wxFrame
         wxStaticText  *m_textCodec2Var;
 
         wxStaticText  *m_textSync;
-        wxButton      *m_BtnReSync;
         wxButton      *m_btnCenterRx;
         
         wxToggleButton      *m_audioRecord;
         
         wxButton*     m_logQSO;
-
-        wxRadioButton *m_rbRADE;
-        wxRadioButton *m_rb700d;
-        wxRadioButton *m_rb700e;
-        wxRadioButton *m_rb1600;
 
         wxSizer* rightSizer;
 
@@ -189,12 +180,8 @@ class TopFrame : public wxFrame
         virtual void OnHelpCheckUpdatesUI( wxUpdateUIEvent& event ) { event.Skip(); }
         virtual void OnHelpAbout( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnHelpManual( wxCommandEvent& event ) { event.Skip(); }
-        virtual void OnCmdSliderScroll( wxScrollEvent& event ) { event.Skip(); }
-        virtual void OnCheckSQClick( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnCheckSNRClick( wxCommandEvent& event ) { event.Skip(); }
 
-        virtual void OnTogBtnLoopRx( wxCommandEvent& event ) { event.Skip(); }
-        virtual void OnTogBtnLoopTx( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnOnOff( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnAnalogClick( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnVoiceKeyerClick( wxCommandEvent& event ) { event.Skip(); }
@@ -263,7 +250,6 @@ class TopFrame : public wxFrame
         wxAuiNotebook* m_auiNbookCtrl;
         wxComboBox*   m_cboReportFrequency;
         wxStaticBox*  m_freqBox;
-        wxStaticBox*  squelchBox;
         wxStaticBox*  m_txLevelBox;
         wxStaticBox* micSpeakerBox;
 

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -311,7 +311,11 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         if (vk_event == VK_SPACE_BAR) {
             m_btnTogPTT->SetValue(false);
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+            // macOS limitations prevent the foreground color of toggle buttons from being 
+            // reliably set, so don't mess with it in the first place.
             m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
             endingTx.store(true, std::memory_order_release);
             togglePTT();
             m_togBtnVoiceKeyer->SetValue(false);
@@ -324,7 +328,11 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
         if (vk_event == VK_PLAY_FINISHED) {
             m_btnTogPTT->SetValue(false);
             m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+            // macOS limitations prevent the foreground color of toggle buttons from being 
+            // reliably set, so don't mess with it in the first place.
             m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
             endingTx.store(true, std::memory_order_release);
             CallAfter([&]() { togglePTT(); });
             vk_repeat_counter++;
@@ -408,7 +416,11 @@ void MainFrame::VoiceKeyerProcessEvent(int vk_event) {
 
         m_btnTogPTT->SetValue(false);
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+        // macOS limitations prevent the foreground color of toggle buttons from being 
+        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
         endingTx.store(true, std::memory_order_release);
         togglePTT();
         m_togBtnVoiceKeyer->SetValue(false);


### PR DESCRIPTION
First in a series of PRs for #1391. This removes the GUI elements and persistent configuration related to the legacy FreeDV modes:

* Main window:
    * Mode selection (700D/E/1600/RADEV1)
    * Squelch
* FreeDV Reporter: "Last RX Mode" column and related handling
* Tools->Options:
    *  "Multiple RX" and related handling
    * "Enable Legacy Modes" 
    * TX BPF and clipping (only applied to 700*)
    * Reporting free-form text field (not supported in RADE)
* Tools->Filter:
    * 700C EQ
    * LPC Post Filtering (1600)
    
"Center RX" on the main window is also made unconditionally visible since it technically works for RADE now. 

Note: existing configuration files aren't touched; the removed config options will still be in there (but won't be exported to new files).