### PR TITLE
Stop missed momentary PTT release when TX is still starting

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -360,6 +360,15 @@ class MainFrame : public TopFrame
         // pairs at the OS key-repeat rate.
         bool                    m_pttKeyRequireRelease_{false};
 
+        // Set when the momentary PTT key is released while a TX start is
+        // still in progress (e.g. during the configured TX/RX delay in
+        // togglePTT()). A stop requested during that window can't be
+        // actioned immediately -- togglePTT()'s re-entrancy guard
+        // (txChangeoverOccurring_) would just no-op it -- so togglePTT()
+        // checks this once the start completes and immediately stops TX
+        // if it's set, instead of leaving the radio keyed indefinitely.
+        bool                    m_momentaryKeyReleasedDuringChangeover_{false};
+
         // TOT beep state
         std::chrono::time_point<std::chrono::high_resolution_clock> m_totLastBeepTime_;
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1135,10 +1135,21 @@ int MainApp::FilterEvent(wxEvent& event)
                 wxGetApp().appConfiguration.enableSpaceBarForPTT && !frame->isReceiveOnly() &&
                 wxGetApp().appConfiguration.pttMomentaryMode) {
 
-                if (frame->vk_state == VK_IDLE && g_tx.load(std::memory_order_acquire)) {
-                    frame->m_btnTogPTT->SetValue(false);
-                    frame->m_btnTogPTT->SetBackgroundColour(wxNullColour);
-                    frame->togglePTT();
+                if (frame->vk_state == VK_IDLE) {
+                    if (g_tx.load(std::memory_order_acquire)) {
+                        frame->m_btnTogPTT->SetValue(false);
+                        frame->m_btnTogPTT->SetBackgroundColour(wxNullColour);
+                        frame->togglePTT();
+                    } else if (frame->m_btnTogPTT->GetValue()) {
+                        // Key released before g_tx caught up -- likely still inside
+                        // togglePTT()'s TX/RX delay loop for the start that's in
+                        // progress. Calling togglePTT() here would no-op against its
+                        // re-entrancy guard, so remember the release and let
+                        // togglePTT() action it once the start finishes -- see
+                        // m_momentaryKeyReleasedDuringChangeover_ in main.h.
+                        log_info("PTT key released mid-changeover -- deferring momentary stop");
+                        frame->m_momentaryKeyReleasedDuringChangeover_ = true;
+                    }
                 }
                 return Event_Processed;
             }
@@ -1707,6 +1718,21 @@ void MainFrame::togglePTT(void) {
         txChangeoverOccurring_ = false;
         m_sliderMicSpkrLevel->Refresh(); // Redraw doesn't happen immediately otherwise in some environments
     });
+
+    if (newTx && m_momentaryKeyReleasedDuringChangeover_)
+    {
+        // The momentary PTT key was released while this start was still in
+        // progress (see the wxEVT_KEY_UP handler in FilterEvent). Queued
+        // after the CallAfter() above so it runs once txChangeoverOccurring_
+        // has cleared, rather than no-opping against it.
+        m_momentaryKeyReleasedDuringChangeover_ = false;
+        log_info("Momentary PTT key was released while TX was starting -- stopping now");
+        CallAfter([this]() {
+            m_btnTogPTT->SetValue(false);
+            m_btnTogPTT->SetBackgroundColour(wxNullColour);
+            togglePTT();
+        });
+    }
 }
 
 void MainFrame::OnTogBtnTune(wxCommandEvent&)


### PR DESCRIPTION
## Summary

`togglePTT()` keys the radio immediately on TX start, but doesn't set `g_tx` true until after the configured TX/RX delay (`txRxDelayMilliseconds`) completes -- it pumps the event loop via `Yield()` the whole time so the UI stays responsive during that wait.

If the momentary spacebar PTT key is tapped fast enough, the matching `KEY_UP` can be processed (re-entrantly, via that `Yield()`) before `g_tx` catches up. The momentary-stop check only acts when `g_tx` is true, so the release is silently dropped -- the radio is left keyed with no audio flowing and no further `KEY_UP` to catch it, until some later key event happens to land after `g_tx` finally goes true. In practice this shows up as momentary mode appearing to behave like latching mode for a quick tap (it takes a second tap to actually stop TX), while a slower press-and-hold-then-release works correctly.

Confirmed via diagnostic logging on Mageia 10 with `TxRxDelayMilliseconds=150`: a fast tap showed `g_tx` still `false` at the `KEY_UP` that should have stopped TX.

## Fix

When `KEY_UP` sees `g_tx` still false but the PTT button already shows pressed, record the release in a new flag (`m_momentaryKeyReleasedDuringChangeover_`) instead of dropping it. `togglePTT()` checks that flag right after its own re-entrancy guard (`txChangeoverOccurring_`) clears -- queued as a second `CallAfter`, after the existing one -- and immediately stops TX if the key was released mid-start.

## Test plan

- [x] Built and tested via `freedv-rade-update` against `pr:1393 @ 82b9971c` on Mageia 10
- [x] Fast tap with `TxRxDelayMilliseconds=150` (previously reproduced the bug): now stops correctly on first tap
- [x] Fast tap with `TxRxDelayMilliseconds=0`: still stops correctly (no regression)
- [x] Press-and-hold-then-release: still works correctly (no regression)
- [x] TOT timeout still stops TX correctly in both delay configurations

Implemented with the help of Claude Code.