### PR TITLE
Upgrade Hamlib to 4.7.2.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -968,6 +968,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Restore heard station list on launch. (PR #1358) - thanks @barjac!
 3. Build system:
     * Clear CMake deprecation warnings in FreeDV. (PR #1383, #1386)
+    * Upgrade Hamlib to 4.7.2. (PR #1413)
 4. Other:
     * FlexRadio/KA9Q integrations moved to freedv-integrations repo. (PR #1368)
 

--- a/build_osx.sh
+++ b/build_osx.sh
@@ -34,7 +34,7 @@ if [ $BUILD_DEPS == 1 ]; then
     if [ ! -d hamlib-code ]; then
         git clone https://github.com/Hamlib/Hamlib.git hamlib-code
     fi
-    cd hamlib-code && git checkout 4.7.1 && git pull
+    cd hamlib-code && git checkout 4.7.2 && git pull
     ./bootstrap 
     if [ $UNIV_BUILD == 1 ]; then
         CFLAGS="-g -O3 -mmacosx-version-min=11.0 -arch x86_64 -arch arm64" CXXFLAGS="-g -O3 -mmacosx-version-min=11.0 -arch x86_64 -arch arm64" ./configure --enable-shared --prefix $HAMLIBDIR --without-libusb

--- a/cmake/BuildHamlib.cmake
+++ b/cmake/BuildHamlib.cmake
@@ -16,7 +16,7 @@ endif(MINGW AND CMAKE_CROSSCOMPILING)
 
 include(ExternalProject)
 ExternalProject_Add(build_hamlib
-    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.7.1.zip
+    URL https://github.com/Hamlib/Hamlib/archive/refs/tags/4.7.2.zip
     BUILD_IN_SOURCE 1
     INSTALL_DIR external/dist
     PATCH_COMMAND ${HAMLIB_PATCH_CMD}


### PR DESCRIPTION
Upgrades Hamlib to 4.7.2 (recently released a few days ago). Only applies to AppImages and Windows/macOS builds.