### PR TITLE
Start TX on XMIT button press rather than release; fix related edge cases

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1039,6 +1039,10 @@ setDefaultMode:
     
     m_togBtnAnalog->Disable();
     m_btnTogPTT->Disable();
+    m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+    m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
     m_togBtnVoiceKeyer->Disable();
 
     // squelch settings

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2893,6 +2893,10 @@ void MainFrame::performFreeDVOff_()
 
         m_togBtnAnalog->Disable();
         m_btnTogPTT->Disable();
+        m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+        m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
         m_togBtnVoiceKeyer->Disable();
     
         m_rbRADE->Enable();
@@ -2924,6 +2928,10 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent&)
     m_togBtnAnalog->Enable(false);
     m_togBtnVoiceKeyer->Enable(false);
     m_btnTogPTT->Enable(false);
+    m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+    m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
         
     // we are attempting to start
 
@@ -2951,6 +2959,13 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent&)
                 m_togBtnAnalog->Enable(m_RxRunning);
                 m_togBtnVoiceKeyer->Enable(txEnabled);
                 m_btnTogPTT->Enable(txEnabled);
+                if (!txEnabled)
+                {
+                    m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+                    m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
+                }
                 optionsDlg->setSessionActive(m_RxRunning);
 
                 if (m_RxRunning)
@@ -2982,6 +2997,13 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent&)
                 m_togBtnAnalog->Enable(m_RxRunning);
                 m_togBtnVoiceKeyer->Enable(m_RxRunning);
                 m_btnTogPTT->Enable(m_RxRunning);
+                if (!m_RxRunning)
+                {
+                    m_btnTogPTT->SetBackgroundColour(wxNullColour);
+#if !defined(__APPLE__)
+                    m_btnTogPTT->SetForegroundColour(wxNullColour);
+#endif // !defined(__APPLE__)
+                }
                 optionsDlg->setSessionActive(m_RxRunning);
                 m_togBtnOnOff->SetValue(m_RxRunning);
                 m_togBtnOnOff->SetLabel(wxT("&Start Modem"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1255,7 +1255,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
 
     m_togBtnOnOff->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnOnOffUI), NULL, this);
     m_togBtnAnalog->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrame::OnTogBtnAnalogClickUI), NULL, this);
-    m_btnTogPTT->Bind(wxEVT_LEFT_UP, &MainFrame::OnTogBtnPTTMouseDown, this);
+    m_btnTogPTT->Bind(wxEVT_LEFT_DOWN, &MainFrame::OnTogBtnPTTMouseDown, this);
     m_btnTogPTT->Bind(wxEVT_LEFT_DCLICK, &MainFrame::OnTogBtnPTTMouseDown, this);
     m_btnTogPTT->Bind(wxEVT_LEAVE_WINDOW, &MainFrame::OnTogBtnPTTMouseLeave, this);
 

--- a/src/main.h
+++ b/src/main.h
@@ -369,6 +369,11 @@ class MainFrame : public TopFrame
         // if it's set, instead of leaving the radio keyed indefinitely.
         bool                    m_momentaryKeyReleasedDuringChangeover_{false};
 
+        // Set by OnTogBtnPTTMouseDown after it calls togglePTT() directly on
+        // LEFT_DOWN. Causes OnTogBtnPTT to discard the redundant click event
+        // that wxToggleButton fires on LEFT_UP and undo its auto-toggle.
+        bool                    m_suppressNextPTTClick_{false};
+
         // TOT beep state
         std::chrono::time_point<std::chrono::high_resolution_clock> m_totLastBeepTime_;
 
@@ -447,8 +452,8 @@ class MainFrame : public TopFrame
         void OnTogBtnPTT( wxCommandEvent& event ) override;
         void OnTogBtnPTTRightClick( wxContextMenuEvent& event ) override;
 
-        // NOTE: sets TX colour on press to avoid a GTK blue-flash during the TX delay.
-        // Upstream may prefer a different approach (e.g. true press-to-start TX).
+        // Starts/stops TX immediately on LEFT_DOWN; consumes the event to prevent a
+        // redundant wxEVT_COMMAND_TOGGLEBUTTON_CLICKED from firing on LEFT_UP.
         void OnTogBtnPTTMouseDown( wxMouseEvent& event );
         void OnTogBtnPTTMouseLeave( wxMouseEvent& event );
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1149,7 +1149,7 @@ int MainApp::FilterEvent(wxEvent& event)
                 if (frame->vk_state == VK_IDLE) {
                     if (g_tx.load(std::memory_order_acquire)) {
                         frame->m_btnTogPTT->SetValue(false);
-                        frame->m_btnTogPTT->SetBackgroundColour(wxNullColour);
+                        frame->m_btnTogPTT->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
                         frame->togglePTT();
                     } else if (frame->m_btnTogPTT->GetValue()) {
                         // Key released before g_tx caught up -- likely still inside
@@ -1246,9 +1246,9 @@ void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire)
         && !txChangeoverOccurring_)
     {
-        m_btnTogPTT->SetBackgroundColour(wxNullColour);
+        m_btnTogPTT->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 #if !defined(__APPLE__)
-        m_btnTogPTT->SetForegroundColour(wxNullColour);
+        m_btnTogPTT->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
 #endif // !defined(__APPLE__)
         m_btnTogPTT->Refresh();
     }
@@ -1735,11 +1735,11 @@ void MainFrame::togglePTT(void) {
     // using the voice keyer).
     m_btnTogPTT->SetValue(newTx);
     m_btnTogPTT->SetLabel(_("&XMIT"));
-    m_btnTogPTT->SetBackgroundColour(m_btnTogPTT->GetValue() ? *wxRED : wxNullColour);
+    m_btnTogPTT->SetBackgroundColour(m_btnTogPTT->GetValue() ? *wxRED : wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 #if !defined(__APPLE__)
-    // macOS limitations prevent the foreground color of toggle buttons from being 
+    // macOS limitations prevent the foreground color of toggle buttons from being
     // reliably set, so don't mess with it in the first place.
-    m_btnTogPTT->SetForegroundColour(m_btnTogPTT->GetValue() ? *wxBLACK : wxNullColour);
+    m_btnTogPTT->SetForegroundColour(m_btnTogPTT->GetValue() ? *wxBLACK : wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
 #endif // !defined(__APPLE__)
     
     // The Report Frequency drop-down should not be modifiable during TX.
@@ -1779,7 +1779,7 @@ void MainFrame::togglePTT(void) {
         log_info("Momentary PTT key was released while TX was starting -- stopping now");
         CallAfter([this]() {
             m_btnTogPTT->SetValue(false);
-            m_btnTogPTT->SetBackgroundColour(wxNullColour);
+            m_btnTogPTT->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
             togglePTT();
         });
     }

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1211,12 +1211,15 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
         m_btnTogPTT->Refresh();
     }
 
-    // Pre-set the button value to the intended post-toggle state. This means
-    // that when OnTogBtnPTT fires on LEFT_UP and suppresses the click, it can
-    // simply invert GetValue() to undo the widget's auto-toggle -- regardless
-    // of where togglePTT() is in its TX delay at that moment.
+    // Pre-set the button value to the intended post-toggle state so it gives
+    // immediate visual feedback before togglePTT() finishes its delay.
     m_btnTogPTT->SetValue(!m_btnTogPTT->GetValue());
-    m_suppressNextPTTClick_ = true;
+
+    // In latching mode the click event on LEFT_UP would double-toggle, so
+    // suppress it. In momentary mode we leave it unsuppressed: the click on
+    // release is what stops TX (mirroring the spacebar momentary behaviour).
+    if (!wxGetApp().appConfiguration.pttMomentaryMode)
+        m_suppressNextPTTClick_ = true;
 
     if (vk_state == VK_TX)
         VoiceKeyerProcessEvent(VK_SPACE_BAR);
@@ -1232,9 +1235,14 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
 // g_tx and GetValue() have been updated by togglePTT(). The
 // txChangeoverOccurring_ guard prevents this firing while togglePTT() is
 // running (it would see g_tx/GetValue() still false and wrongly reset colour).
+// Always clears m_suppressNextPTTClick_: if the mouse leaves before release,
+// wxToggleButton will not fire TOGGLEBUTTON_CLICKED on LEFT_UP, so the flag
+// would otherwise stay set and silently consume the next click or spacebar.
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
 {
+    m_suppressNextPTTClick_ = false;
+
     if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire)
         && !txChangeoverOccurring_)
     {
@@ -1265,6 +1273,15 @@ void MainFrame::OnTogBtnPTT (wxCommandEvent&)
     {
         // Disable TX via VK code to prevent state inconsistencies.
         VoiceKeyerProcessEvent(VK_SPACE_BAR);
+    }
+    else if (wxGetApp().appConfiguration.pttMomentaryMode && txChangeoverOccurring_)
+    {
+        // Mouse released while TX start is still in progress; togglePTT() would
+        // no-op against its re-entrancy guard, so defer the stop exactly as the
+        // keyboard momentary handler does for mid-changeover key releases.
+        log_info("PTT mouse released mid-changeover -- deferring momentary stop");
+        m_momentaryKeyReleasedDuringChangeover_ = true;
+        m_btnTogPTT->SetValue(true); // click auto-toggled to false; restore to match pre-set
     }
     else
     {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1201,6 +1201,10 @@ void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
 {
     if (txChangeoverOccurring_) { event.Skip(); return; }
 
+    // Clear any stale suppress flag (e.g. set by OnTOTTimer) so a fresh press
+    // always starts a clean cycle rather than having its release silently eaten.
+    m_suppressNextPTTClick_ = false;
+
     // Pre-empt GTK's blue active-state for the RX->TX direction.
     if (!g_tx.load(std::memory_order_acquire))
     {
@@ -1357,6 +1361,15 @@ void MainFrame::OnTOTTimer(wxTimerEvent&)
             m_pttKeyRequireRelease_ = true;
             m_pttKeyPollTimer.Start(30, wxTIMER_CONTINUOUS);
         }
+
+        // Suppress any pending XMIT mouse button release in momentary mode.
+        // Unlike the keyboard (which needs polling), the click event simply
+        // won't fire if the mouse is released outside the button, and
+        // OnTogBtnPTTMouseDown clears this flag on any fresh press -- so
+        // setting it unconditionally here is safe even if no mouse press is
+        // currently in progress.
+        if (wxGetApp().appConfiguration.pttMomentaryMode)
+            m_suppressNextPTTClick_ = true;
     }
 }
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1192,43 +1192,54 @@ void MainFrame::OnTogBtnPTTRightClick( wxContextMenuEvent& )
 
 //-------------------------------------------------------------------------
 // OnTogBtnPTTMouseDown()
-// Set TX colour immediately on mouse press when going RX->TX, avoiding a GTK
-// blue-flash during the TX delay before togglePTT() sets it on release.
-// Only fires when the pipeline is genuinely in RX (g_tx false); during the
-// TX->RX drain g_tx is still true, so clicks there are correctly ignored.
-// NOTE for upstream: this is a simple cosmetic fix. A fuller alternative would
-// be to start TX here on press and suppress the togglePTT() call on release.
+// Start/stop TX immediately on LEFT_DOWN rather than waiting for release.
+// Pre-sets the button value and sets m_suppressNextPTTClick_ so that the
+// redundant wxEVT_COMMAND_TOGGLEBUTTON_CLICKED that wxToggleButton fires on
+// LEFT_UP is discarded by OnTogBtnPTT without double-toggling.
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTTMouseDown(wxMouseEvent& event)
 {
-    if (txChangeoverOccurring_) return;
+    if (txChangeoverOccurring_) { event.Skip(); return; }
 
-    if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
+    // Pre-empt GTK's blue active-state for the RX->TX direction.
+    if (!g_tx.load(std::memory_order_acquire))
     {
         m_btnTogPTT->SetBackgroundColour(*wxRED);
 #if !defined(__APPLE__)
-        // macOS limitations prevent the foreground color of toggle buttons from being 
-        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(*wxBLACK);
 #endif // !defined(__APPLE__)
         m_btnTogPTT->Refresh();
     }
+
+    // Pre-set the button value to the intended post-toggle state. This means
+    // that when OnTogBtnPTT fires on LEFT_UP and suppresses the click, it can
+    // simply invert GetValue() to undo the widget's auto-toggle -- regardless
+    // of where togglePTT() is in its TX delay at that moment.
+    m_btnTogPTT->SetValue(!m_btnTogPTT->GetValue());
+    m_suppressNextPTTClick_ = true;
+
+    if (vk_state == VK_TX)
+        VoiceKeyerProcessEvent(VK_SPACE_BAR);
+    else
+        togglePTT();
+
     event.Skip();
 }
 
 //-------------------------------------------------------------------------
 // OnTogBtnPTTMouseLeave()
-// Reset premature TX colour if mouse leaves button before release and TX
-// has not actually started, preventing a stuck-red button.
+// Reset pre-empt colour if mouse leaves during the TX start delay before
+// g_tx and GetValue() have been updated by togglePTT(). The
+// txChangeoverOccurring_ guard prevents this firing while togglePTT() is
+// running (it would see g_tx/GetValue() still false and wrongly reset colour).
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
 {
-    if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire))
+    if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire)
+        && !txChangeoverOccurring_)
     {
         m_btnTogPTT->SetBackgroundColour(wxNullColour);
 #if !defined(__APPLE__)
-        // macOS limitations prevent the foreground color of toggle buttons from being 
-        // reliably set, so don't mess with it in the first place.
         m_btnTogPTT->SetForegroundColour(wxNullColour);
 #endif // !defined(__APPLE__)
         m_btnTogPTT->Refresh();
@@ -1241,12 +1252,21 @@ void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTT (wxCommandEvent&)
 {
+    // OnTogBtnPTTMouseDown already called togglePTT() on LEFT_DOWN; discard
+    // this redundant click event and undo the widget's auto-toggle.
+    if (m_suppressNextPTTClick_)
+    {
+        m_suppressNextPTTClick_ = false;
+        m_btnTogPTT->SetValue(!m_btnTogPTT->GetValue());
+        return;
+    }
+
     if (vk_state == VK_TX)
     {
         // Disable TX via VK code to prevent state inconsistencies.
         VoiceKeyerProcessEvent(VK_SPACE_BAR);
     }
-    else 
+    else
     {
         togglePTT();
     }

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1247,8 +1247,8 @@ void MainFrame::OnTogBtnPTTMouseLeave(wxMouseEvent& event)
 {
     m_suppressNextPTTClick_ = false;
 
-    if (!m_btnTogPTT->GetValue() && !g_tx.load(std::memory_order_acquire)
-        && !txChangeoverOccurring_)
+    if (m_btnTogPTT->IsEnabled() && !m_btnTogPTT->GetValue()
+        && !g_tx.load(std::memory_order_acquire) && !txChangeoverOccurring_)
     {
         m_btnTogPTT->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
 #if !defined(__APPLE__)


### PR DESCRIPTION
Tested on Linux (wxGTK 3.3, Mageia 10). This applies to PR #1393 @ de8f7e4
**Repro for the original issue:** latching mode, press and hold XMIT — TX does not start until release.

I have tested this in every possible scenario that I can think of and I cannot now break it. The TX now fires on button down simultaneously with the RED button colour change and no flicker. 

## Changes

- Rebind XMIT button to `wxEVT_LEFT_DOWN` (reverts 767a7979); call `togglePTT()` directly on press. In latching mode a `m_suppressNextPTTClick_` flag discards the redundant `TOGGLEBUTTON_CLICKED` that fires on release, with the button value pre-set before the call so the suppress handler can undo the widget's auto-toggle safely at any point in the TX delay.
- Momentary mode is not suppressed — the release click stops TX as expected. Mid-changeover mouse release deferred via `m_momentaryKeyReleasedDuringChangeover_`, mirroring the existing keyboard path.
- `OnTogBtnPTTMouseLeave` clears suppress unconditionally: `TOGGLEBUTTON_CLICKED` never fires if the mouse leaves before release, so without this the flag would persist and silently eat a later spacebar or click event.
- Replace `wxNullColour` resets on the XMIT button with `wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE/BTNTEXT)`. Calling `SetBackgroundColour(wxNullColour)` removes the GTK CSS provider installed by the red TX colour, leaving the widget in a different state from buttons that were never styled — causing a blue hover tint after the first TX cycle. Keeping an explicit provider prevents this.
- In `OnTOTTimer`, set `m_suppressNextPTTClick_` in momentary mode to prevent the held mouse button restarting TX after TOT expiry, mirroring the existing `m_pttKeyRequireRelease_` keyboard guard. `OnTogBtnPTTMouseDown` clears any stale suppress at entry so this cannot eat a later intentional click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)