### PR TITLE
Fix corruption of string config arrays containing commas

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -960,6 +960,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Hamlib: Switch off memory channel before setting frequency/mode. (PR #1403) - thanks @barjac!
     * Hamlib/OmniRig: Round received frequency to nearest 100 Hz. (PR #1373)
     * Tighten remaining audio settings to improve audio drops. (PR #1412)
+    * Fix corruption of string config arrays containing commas. (PR #1417) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/config/WxWidgetsConfigStore.cpp
+++ b/src/config/WxWidgetsConfigStore.cpp
@@ -183,32 +183,55 @@ std::vector<int> WxWidgetsConfigStore::generateNumArrayFromString_(wxString cons
 wxString WxWidgetsConfigStore::generateStringFromArray_(std::vector<wxString> const& vec)
 {
     wxString rv = "";
-    
+
     int count = vec.size();
     for (auto& item : vec)
     {
-        rv += item;
+        wxString escaped = item;
+        escaped.Replace("\\", "\\\\");
+        escaped.Replace(",", "\\,");
+        rv += escaped;
         count--;
-        
+
         if (count > 0)
         {
             rv += ",";
         }
     }
-    
+
     return rv;
 }
 
 std::vector<wxString> WxWidgetsConfigStore::generateStrArrayFromString_(wxString const& str)
 {
     std::vector<wxString> rv;
-    
-    wxStringTokenizer tokenizer(str, ",");
-    while ( tokenizer.HasMoreTokens() )
+    if (str.IsEmpty()) return rv;
+
+    wxString current;
+    for (size_t i = 0; i < str.Length(); i++)
     {
-        wxString token = tokenizer.GetNextToken();
-        rv.push_back(token);
+        wxChar ch = str[i];
+        if (ch == '\\' && i + 1 < str.Length())
+        {
+            wxChar next = str[i + 1];
+            if (next == ',' || next == '\\')
+            {
+                current += next;
+                i++;
+                continue;
+            }
+        }
+        if (ch == ',')
+        {
+            rv.push_back(current);
+            current.Clear();
+        }
+        else
+        {
+            current += ch;
+        }
     }
-    
+    rv.push_back(current);
+
     return rv;
 }


### PR DESCRIPTION
`WxWidgetsConfigStore` stores `std::vector<wxString>` config fields as comma-joined strings. Commas inside the string values (e.g. a FreeDV Reporter status message such as "CQ, listening") were not escaped, so on the next load the value was split into multiple elements.

Fix: backslash-escape commas and backslashes on save; unescape on load. Existing saved values without commas round-trip unchanged.

Affected fields: `freedvReporterRecentStatusTexts`, `freedvReporterColumnFilterValues`, `reportingFrequencyList` (frequencies never contain commas so no change in practice).