### PR TITLE
Fix TLS connection failures in AppImage.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -971,7 +971,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Restore heard station list on launch. (PR #1358) - thanks @barjac!
     * Add momentary PTT option to FreeDV. (PR #1393)
     * Allow 8k sample rate for 'radio' devices. (PR #1416)
-    * FreeDV Reporter: Connect to server via TLS by default. (PR #1422)
+    * FreeDV Reporter: Connect to server via TLS by default. (PR #1422, #1427)
     * Block special characters in recording file name suffixes and default the voice keyer file selector to show .wav and .mp3. (PR #1424) - thanks @barjac!
 3. Build system:
     * Clear CMake deprecation warnings in FreeDV. (PR #1383, #1386)

--- a/appimage/AppRun.sh
+++ b/appimage/AppRun.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+echo "In AppImage AppRun"
+cd "$APPDIR"
+export SSL_CERT_FILE="$APPDIR/etc/ssl/certs/ca-certificates.crt"
+export SSL_CERT_DIR="$APPDIR/etc/ssl/certs"
+echo "#### after import"
+exec "$APPDIR/usr/bin/freedv" "$@"

--- a/appimage/FreeDV-FlexRadio.desktop
+++ b/appimage/FreeDV-FlexRadio.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Name=FreeDV-FlexRadio
-Exec=freedv-flex
-Icon=freedv256x256
-Type=Application
-Categories=Utility;

--- a/appimage/FreeDV-KA9Q.desktop
+++ b/appimage/FreeDV-KA9Q.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Name=FreeDV-KA9Q
-Exec=freedv-ka9q
-Icon=freedv256x256
-Type=Application
-Categories=Utility;

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -33,7 +33,13 @@ fi
   --executable "$APPEXEC" \
   --appdir "$APPDIR" \
   --icon-file ../contrib/freedv256x256.png \
+  --custom-apprun "AppRun.sh" \
   --desktop-file $DESKTOP_FILE
+
+# Manually copy over /etc/ssl to APPDIR. Needed for OpenSSL to behave properly on non-Ubuntu
+# distros.
+mkdir -p "$APPDIR/etc/ssl/certs"
+cp -aL /etc/ssl/certs/* "$APPDIR/etc/ssl/certs"
 
 # Create the output
 ./linuxdeploy-${MACH_ARCH}.AppImage \


### PR DESCRIPTION
Root certificate locations are distro-dependent. On Fedora, for instance, they're *not* in /etc/ssl (whereas that's the path on Ubuntu and macOS). This PR (along with the associated change at https://github.com/tmiw/freedv-backend/pull/19) includes a copy of these root certificates to eliminate the distro dependency.