### PR TITLE
Only preserve previously selected tab on TX if it's in the same group as 'From Mic'.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -962,6 +962,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Tighten remaining audio settings to improve audio drops. (PR #1412)
     * Fix corruption of string config arrays containing commas. (PR #1417) - thanks @barjac!
     * Suppress button flicker in Linux light themes. (PR #1419, PR #1421) - thanks @barjac!
+    * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1270,6 +1270,16 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     m_reporterDialog = nullptr;
     m_filterDialog = nullptr;
 
+    // Initialize panel pointers to null before creation since "page changed" 
+    // events fire as we're adding these (and we compare against these pointers
+    // inside the handler).
+    m_panelSpectrum = nullptr;
+    m_panelWaterfall = nullptr;
+    m_panelSpeechIn = nullptr;
+    m_panelSpeechOut = nullptr;
+    m_panelDemodIn = nullptr;
+    m_panelSNR = nullptr;
+
     m_zoom              = 1.;
     suppressFreqModeUpdates_ = false;
     lastBand_ = BAND_OTHER;

--- a/src/main.h
+++ b/src/main.h
@@ -505,7 +505,7 @@ class MainFrame : public TopFrame
 
         void OnSystemColorChanged(wxSysColourChangedEvent& event) override;
         
-        void OnNotebookPageChanging(wxAuiNotebookEvent& event) override;
+        void OnNotebookPageChanged(wxAuiNotebookEvent& event) override;
         
         void OnChooseAlternateVoiceKeyerFile( wxCommandEvent& event );
         void OnRecordNewVoiceKeyerFile( wxCommandEvent& event );

--- a/src/main.h
+++ b/src/main.h
@@ -505,8 +505,6 @@ class MainFrame : public TopFrame
 
         void OnSystemColorChanged(wxSysColourChangedEvent& event) override;
         
-        void OnNotebookPageChanged(wxAuiNotebookEvent& event) override;
-        
         void OnChooseAlternateVoiceKeyerFile( wxCommandEvent& event );
         void OnRecordNewVoiceKeyerFile( wxCommandEvent& event );
 

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1584,7 +1584,24 @@ void MainFrame::togglePTT(void) {
         }
         
         // rx-> tx transition, swap to Mic In page to monitor speech
-        wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
+        // Note: we should only save the previous page if the current selection is something on
+        // the same tab group as "Frm Mic".
+        bool setCurrentNotebookTab = true;
+#if wxCHECK_VERSION(3,1,4)
+        wxAuiTabCtrl* fromMicTabControl = nullptr;
+        int fromMicTabIndex = 0;
+        if (m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex))
+        {
+            if (m_auiNbookCtrl->GetActiveTabCtrl() != fromMicTabControl)
+            {
+                setCurrentNotebookTab = false;
+            }
+        }
+#endif // wxCHECK_VERSION(3,1,4)
+        if (setCurrentNotebookTab)
+        {
+            wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
+        }
         
         // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
         // the current page ourselves is a better bet.

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1584,21 +1584,7 @@ void MainFrame::togglePTT(void) {
         }
         
         // rx-> tx transition, swap to Mic In page to monitor speech
-        // Note: we should only save the previous page if the current selection is something on
-        // the same tab group as "Frm Mic".
-        bool setCurrentNotebookTab = true;
-#if wxCHECK_VERSION(3,1,4)
-        wxAuiTabCtrl* fromMicTabControl = nullptr;
-        int fromMicTabIndex = 0;
-        if (m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex))
-        {
-            if (m_auiNbookCtrl->GetActiveTabCtrl() != fromMicTabControl)
-            {
-                setCurrentNotebookTab = false;
-            }
-        }
-#endif // wxCHECK_VERSION(3,1,4)
-        if (setCurrentNotebookTab)
+        if (wxGetApp().appConfiguration.currentNotebookTab >= 0)
         {
             wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
         }
@@ -2147,29 +2133,29 @@ void MainFrame::OnSystemColorChanged(wxSysColourChangedEvent& event)
     TopFrame::OnSystemColorChanged(event);
 }
 
-void MainFrame::OnNotebookPageChanging(wxAuiNotebookEvent& event)
+void MainFrame::OnNotebookPageChanged(wxAuiNotebookEvent& event)
 {
-#if 0
-    if (m_rbRADE->GetValue())
+    // Note: we should only save the previous page if the current selection is something on
+    // the same tab group as "Frm Mic".
+    bool setCurrentNotebookTab = true;
+#if wxCHECK_VERSION(3,1,4)
+    wxAuiTabCtrl* fromMicTabControl = nullptr;
+    int fromMicTabIndex = 0;
+    if (m_panelSpeechIn != nullptr && m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex))
     {
-        auto newSelection = event.GetSelection();
-        auto page = m_auiNbookCtrl->GetPage(newSelection);
-        
-        // Prevent selection of tabs not yet supported by RADE.
-        if (page == m_panelScatter || 
-            page == m_panelTimeOffset || 
-            page == m_panelFreqOffset || 
-            page == m_panelTestFrameErrors ||
-            page == m_panelTestFrameErrorsHist)
+        if (m_auiNbookCtrl->GetActiveTabCtrl() != fromMicTabControl)
         {
-            log_info("Veto attempt at viewing tab %d not supported by RADE", newSelection);
-            event.Veto();
-            return;
+            setCurrentNotebookTab = false;
         }
     }
-#endif
-    
-    TopFrame::OnNotebookPageChanging(event);
+#endif // wxCHECK_VERSION(3,1,4)
+    if (setCurrentNotebookTab)
+    {
+        wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
+    }
+
+    // Allow regular processing to occur.
+    event.Skip();
 }
 
 void MainFrame::OnCenterRx(wxCommandEvent&)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1584,11 +1584,55 @@ void MainFrame::togglePTT(void) {
         }
         
         // rx-> tx transition, swap to Mic In page to monitor speech
-        if (wxGetApp().appConfiguration.currentNotebookTab >= 0)
+
+        // Note: we should only save the previous page if the current selection is something on
+        // the same tab group as "Frm Mic".
+#if wxCHECK_VERSION(3,1,4)
+        wxAuiTabCtrl* fromMicTabControl = nullptr;
+        int fromMicTabIndex = 0;
+        bool validFromMicTabGroup = false;
+        if (m_panelSpeechIn != nullptr)
         {
-            wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
+            // Ignore return
+            validFromMicTabGroup = m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex);
         }
-        
+#endif // wxCHECK_VERSION(3,1,4)
+
+        // GetSelection() isn't the right choice here since more than one tab can be visible at
+        // the same time. We have to check the shown status of each of the other plots 
+        // AND make sure it's in the same tab control as "Frm Mic" before we can save off the
+        // current tab state.
+        // See https://forums.wxwidgets.org/viewtopic.php?t=14721 for info.
+        auto savedTab = m_auiNbookCtrl->GetSelection();
+#if wxCHECK_VERSION(3,1,4)
+        wxWindow* plotsToCheck[] = {
+            m_panelSpectrum,
+            m_panelWaterfall,
+            m_panelSpeechOut,
+            m_panelDemodIn,
+            m_panelSNR
+        };
+        for (size_t index = 0; validFromMicTabGroup && index < (sizeof(plotsToCheck) / sizeof(wxWindow*)); index++)
+        {
+            auto plot = plotsToCheck[index];
+            if (plot != nullptr && plot->IsShown())
+            {
+                // Plot is visible, now check to make sure it's in the same tab group.
+                wxAuiTabCtrl* tmpTabCtrl = nullptr;
+                int tmpTabIndex = 0;
+                if (m_auiNbookCtrl->FindTab(plot, &tmpTabCtrl, &tmpTabIndex) && tmpTabCtrl == fromMicTabControl)
+                {
+                    // Found it in the same tab group, use this index for switching back on RX.
+                    savedTab = m_auiNbookCtrl->GetPageIndex(plot);
+                    break;
+                }
+            }
+        }
+#endif // wxCHECK_VERSION(3,1,4)
+
+        // Save currently visible plot so we can go back to it on RX.
+        wxGetApp().appConfiguration.currentNotebookTab = savedTab;
+
         // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
         // the current page ourselves is a better bet.
         size_t index = 0;
@@ -2131,31 +2175,6 @@ void MainFrame::OnSystemColorChanged(wxSysColourChangedEvent& event)
     // Works around issues on wxWidgets with certain controls not changing backgrounds
     // when the user switches between light and dark mode.
     TopFrame::OnSystemColorChanged(event);
-}
-
-void MainFrame::OnNotebookPageChanged(wxAuiNotebookEvent& event)
-{
-    // Note: we should only save the previous page if the current selection is something on
-    // the same tab group as "Frm Mic".
-    bool setCurrentNotebookTab = true;
-#if wxCHECK_VERSION(3,1,4)
-    wxAuiTabCtrl* fromMicTabControl = nullptr;
-    int fromMicTabIndex = 0;
-    if (m_panelSpeechIn != nullptr && m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex))
-    {
-        if (m_auiNbookCtrl->GetActiveTabCtrl() != fromMicTabControl)
-        {
-            setCurrentNotebookTab = false;
-        }
-    }
-#endif // wxCHECK_VERSION(3,1,4)
-    if (setCurrentNotebookTab)
-    {
-        wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
-    }
-
-    // Allow regular processing to occur.
-    event.Skip();
 }
 
 void MainFrame::OnCenterRx(wxCommandEvent&)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1639,7 +1639,7 @@ void MainFrame::togglePTT(void) {
         for (; index < m_auiNbookCtrl->GetPageCount(); index++)
         {
             auto page = m_auiNbookCtrl->GetPage(index);
-            if (page == (wxWindow *)m_panelSpeechIn)
+            if (page != nullptr && page == (wxWindow *)m_panelSpeechIn)
             {
                 m_auiNbookCtrl->ChangeSelection(index);
                 page->Refresh();

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -989,8 +989,6 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_cboLastReportedCallsigns->Connect(wxEVT_COMBOBOX_CLOSEUP, wxCommandEventHandler(TopFrame::OnCloseCallsignList), NULL, this);
     m_cboLastReportedCallsigns->Connect(wxEVT_RIGHT_DOWN, wxMouseEventHandler(TopFrame::OnRightClickCallsignList), NULL, this);
 
-    m_auiNbookCtrl->Connect(wxEVT_AUINOTEBOOK_PAGE_CHANGED, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanged), NULL, this);
-
     m_reporterHidden->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnToggleReporterVisibility), NULL, this);
 
     m_btnTogTune->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnTune), NULL, this);
@@ -1000,9 +998,7 @@ TopFrame::~TopFrame()
 {
     //-------------------
     // Disconnect Events
-    //-------------------
-    m_auiNbookCtrl->Disconnect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanged), NULL, this);
-    
+    //-------------------   
     this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(TopFrame::topFrame_OnClose));
     this->Disconnect(wxEVT_PAINT, wxPaintEventHandler(TopFrame::topFrame_OnPaint));
     this->Disconnect(wxEVT_SIZE, wxSizeEventHandler(TopFrame::topFrame_OnSize));

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -989,7 +989,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_cboLastReportedCallsigns->Connect(wxEVT_COMBOBOX_CLOSEUP, wxCommandEventHandler(TopFrame::OnCloseCallsignList), NULL, this);
     m_cboLastReportedCallsigns->Connect(wxEVT_RIGHT_DOWN, wxMouseEventHandler(TopFrame::OnRightClickCallsignList), NULL, this);
 
-    m_auiNbookCtrl->Connect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanging), NULL, this);
+    m_auiNbookCtrl->Connect(wxEVT_AUINOTEBOOK_PAGE_CHANGED, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanged), NULL, this);
 
     m_reporterHidden->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnToggleReporterVisibility), NULL, this);
 
@@ -1001,7 +1001,7 @@ TopFrame::~TopFrame()
     //-------------------
     // Disconnect Events
     //-------------------
-    m_auiNbookCtrl->Disconnect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanging), NULL, this);
+    m_auiNbookCtrl->Disconnect(wxEVT_AUINOTEBOOK_PAGE_CHANGING, wxAuiNotebookEventHandler(TopFrame::OnNotebookPageChanged), NULL, this);
     
     this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(TopFrame::topFrame_OnClose));
     this->Disconnect(wxEVT_PAINT, wxPaintEventHandler(TopFrame::topFrame_OnPaint));

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -239,7 +239,7 @@ class TopFrame : public wxFrame
 
         virtual void OnSystemColorChanged(wxSysColourChangedEvent& event) { event.Skip(); }
         
-        virtual void OnNotebookPageChanging(wxAuiNotebookEvent& event) { event.Skip(); }
+        virtual void OnNotebookPageChanged(wxAuiNotebookEvent& event) { event.Skip(); }
         
         virtual void OnResetMicSpkrLevel(wxMouseEvent& event) { event.Skip(); }
         

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -238,9 +238,7 @@ class TopFrame : public wxFrame
         virtual void OnReportFrequencyKillFocus(wxFocusEvent& event) { event.Skip(); }
 
         virtual void OnSystemColorChanged(wxSysColourChangedEvent& event) { event.Skip(); }
-        
-        virtual void OnNotebookPageChanged(wxAuiNotebookEvent& event) { event.Skip(); }
-        
+                
         virtual void OnResetMicSpkrLevel(wxMouseEvent& event) { event.Skip(); }
         
         virtual void OnRightClickCallsignList(wxMouseEvent& event) { event.Skip(); }

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -30,7 +30,10 @@ void MainFrame::OnTogBtnVoiceKeyerClick (wxCommandEvent& event)
         m_togBtnVoiceKeyer->SetBackgroundColour(wxNullColour);
         
         // Switch back to previous tab once done with recording
-        m_auiNbookCtrl->ChangeSelection(wxGetApp().appConfiguration.currentNotebookTab);
+        if (wxGetApp().appConfiguration.currentNotebookTab >= 0)
+        {
+            m_auiNbookCtrl->ChangeSelection(wxGetApp().appConfiguration.currentNotebookTab);
+        }
     }
     else
     {
@@ -124,8 +127,19 @@ void MainFrame::OnRecordNewVoiceKeyerFile( wxCommandEvent& )
     vkFileName_ = soundFile;
     
     // Switch tab to "From Mic" during recording.
-    wxGetApp().appConfiguration.currentNotebookTab = m_auiNbookCtrl->GetSelection();
-    m_auiNbookCtrl->ChangeSelection(m_auiNbookCtrl->GetPageIndex((wxWindow *)m_panelSpeechIn));
+    // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
+    // the current page ourselves is a better bet.
+    size_t index = 0;
+    for (; index < m_auiNbookCtrl->GetPageCount(); index++)
+    {
+        auto page = m_auiNbookCtrl->GetPage(index);
+        if (page == (wxWindow *)m_panelSpeechIn)
+        {
+            m_auiNbookCtrl->ChangeSelection(index);
+            page->Refresh();
+            break;
+        }
+    }
     
     // Disable Analog and VK buttons while recording is happening
     m_togBtnAnalog->Enable(false);

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -127,6 +127,54 @@ void MainFrame::OnRecordNewVoiceKeyerFile( wxCommandEvent& )
     vkFileName_ = soundFile;
     
     // Switch tab to "From Mic" during recording.
+    // Note: we should only save the previous page if the current selection is something on
+    // the same tab group as "Frm Mic".
+#if wxCHECK_VERSION(3,1,4)
+    wxAuiTabCtrl* fromMicTabControl = nullptr;
+    int fromMicTabIndex = 0;
+    bool validFromMicTabGroup = false;
+    if (m_panelSpeechIn != nullptr)
+    {
+        // Ignore return
+        validFromMicTabGroup = m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex);
+    }
+#endif // wxCHECK_VERSION(3,1,4)
+
+    // GetSelection() isn't the right choice here since more than one tab can be visible at
+    // the same time. We have to check the shown status of each of the other plots 
+    // AND make sure it's in the same tab control as "Frm Mic" before we can save off the
+    // current tab state.
+    // See https://forums.wxwidgets.org/viewtopic.php?t=14721 for info.
+    auto savedTab = m_auiNbookCtrl->GetSelection();
+#if wxCHECK_VERSION(3,1,4)
+    wxWindow* plotsToCheck[] = {
+        m_panelSpectrum,
+        m_panelWaterfall,
+        m_panelSpeechOut,
+        m_panelDemodIn,
+        m_panelSNR
+    };
+    for (size_t index = 0; validFromMicTabGroup && index < (sizeof(plotsToCheck) / sizeof(wxWindow*)); index++)
+    {
+        auto plot = plotsToCheck[index];
+        if (plot != nullptr && plot->IsShown())
+        {
+            // Plot is visible, now check to make sure it's in the same tab group.
+            wxAuiTabCtrl* tmpTabCtrl = nullptr;
+            int tmpTabIndex = 0;
+            if (m_auiNbookCtrl->FindTab(plot, &tmpTabCtrl, &tmpTabIndex) && tmpTabCtrl == fromMicTabControl)
+            {
+                // Found it in the same tab group, use this index for switching back on RX.
+                savedTab = m_auiNbookCtrl->GetPageIndex(plot);
+                break;
+            }
+        }
+    }
+#endif // wxCHECK_VERSION(3,1,4)
+
+    // Save currently visible plot so we can go back to it on completion.
+    wxGetApp().appConfiguration.currentNotebookTab = savedTab;
+
     // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
     // the current page ourselves is a better bet.
     size_t index = 0;


### PR DESCRIPTION
I received a report of an issue using multiple tab groups:

1. Start with Waterfall as the active plot. Start and then immediately stop transmitting. FreeDV will show From Mic and then show Waterfall again.
2. Move Spectrum and SNR plots to the bottom half of the window. Click on the inactive one of those two to make it active.
3. Toggle TX again and then stop transmitting. FreeDV doesn't go back to the Waterfall tab when TX stops.

This is because we're unconditionally saving the previous tab instead of the previous tab that's in the same window as From Mic. This PR adjusts this behavior to only save the previous tab if it happened to be in the same group as the From Mic tab.