### PR TITLE
Use Python RADE implementation of loss script.

### DIFF
--- a/test/test_rade_loss.sh
+++ b/test/test_rade_loss.sh
@@ -123,10 +123,6 @@ if [ $FREEDV_EXIT_CODE -eq 0 ]; then
     cat tmp.log
 
     # Run feature files through loss tool
-    if [ ! -d $(pwd)/rade_src ]; then
-        git clone https://github.com/peterbmarks/radae_nopy $(pwd)/rade_src
-    fi
-
     $PYTHON_BINARY $(pwd)/rade_src/loss.py txfeatures.f32 rxfeatures.f32 --loss_test 0.15
 fi
 

--- a/test/test_rade_reporting.sh
+++ b/test/test_rade_reporting.sh
@@ -87,7 +87,7 @@ RECORD_PID=$!
 
 # Make sure prerequisites are available
 if [ ! -d $(pwd)/rade_src ]; then
-    git clone https://github.com/peterbmarks/radae_nopy $(pwd)/rade_src
+    git clone https://github.com/drowe67/radae $(pwd)/rade_src
 fi
 
 # Start "radio"


### PR DESCRIPTION
loss.py is going to be deleted from the radae_nopy repo, so we need to use the one from the official Python version of RADE for our tests.