### PR TITLE
Fix window position restore under KWin and labwc (main window + FreeDV Reporter window)

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -964,6 +964,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Suppress button flicker in Linux light themes. (PR #1419, PR #1421) - thanks @barjac!
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
+    * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ set(FREEDV_SOURCES
     playrec.cpp
     ongui.cpp
     freedv_interface.cpp
-    gui/util/WindowPositionRestore.cpp
 )
 
 set(FREEDV_LINK_LIBS_OSX

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(FREEDV_SOURCES
     playrec.cpp
     ongui.cpp
     freedv_interface.cpp
+    gui/util/WindowPositionRestore.cpp
 )
 
 set(FREEDV_LINK_LIBS_OSX
@@ -122,7 +123,11 @@ if(LINUX)
             target_include_directories(freedv PRIVATE ${GTK3_INCLUDE_DIRS})
             target_link_libraries(freedv ${GTK3_LIBRARIES})
             add_definitions(-DHAS_GTK3)
+        else(GTK3_FOUND)
+            message(WARNING "GTK3 development files (gtk+-3.0.pc, e.g. package libgtk-3-dev) not found -- Linux-specific GUI workarounds (including window position restore) will be disabled")
         endif(GTK3_FOUND)
+    else(PkgConfig_FOUND)
+        message(WARNING "pkg-config not found -- cannot detect GTK3 development files, Linux-specific GUI workarounds (including window position restore) will be disabled")
     endif(PkgConfig_FOUND)
 endif(LINUX)
 

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -30,6 +30,7 @@
 #include <wx/textdlg.h>
 #include "../controls/MsgListPopup.h"
 #include "../util/FrequencyOps.h"
+#include "../util/WindowPositionRestore.h"
 
 #if wxCHECK_VERSION(3,2,0)
 #include <wx/uilocale.h>
@@ -464,7 +465,7 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     SetPosition(wxPoint(
         wxGetApp().appConfiguration.reporterWindowLeft,
         wxGetApp().appConfiguration.reporterWindowTop));
-    
+
     // Make sure we didn't end up placing it off the screen in a location that can't
     // easily be brought back.
 #if wxCHECK_VERSION(3,2,0)
@@ -493,7 +494,7 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     }
     wxGetApp().appConfiguration.reporterWindowLeft = actualPos.x;
     wxGetApp().appConfiguration.reporterWindowTop = actualPos.y;
-    SetPosition(actualPos);
+    RestoreWindowPosition(this, actualPos.x, actualPos.y);
 
     // Set up timers. Highlight clear timer has a slightly longer interval
     // to reduce CPU usage.
@@ -660,6 +661,11 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
             getFilterForFrequency_(wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency);
         setBandFilter(freq);
     }
+}
+
+void FreeDVReporterDialog::stopTrackingPosition()
+{
+    this->Disconnect(wxEVT_MOVE, wxMoveEventHandler(FreeDVReporterDialog::OnMove));
 }
 
 FreeDVReporterDialog::~FreeDVReporterDialog()
@@ -1040,7 +1046,7 @@ void FreeDVReporterDialog::OnSize(wxSizeEvent& event)
 void FreeDVReporterDialog::OnMove(wxMoveEvent& event)
 {
     auto pos = event.GetPosition();
-   
+
     wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
     wxGetApp().appConfiguration.reporterWindowTop = pos.y;
     

--- a/src/gui/dialogs/freedv_reporter.h
+++ b/src/gui/dialogs/freedv_reporter.h
@@ -68,6 +68,14 @@ class FreeDVReporterDialog : public wxFrame
         void setReporter(std::shared_ptr<FreeDVReporter> const& reporter);
         void refreshQSYButtonState();
         void refreshLayout();
+
+        // Stops the window from live-tracking/persisting its own position via
+        // OnMove. Callers should invoke this after deliberately grabbing and
+        // saving the final position but before Close()/Destroy() -- closing
+        // can trigger one last stray wxEVT_MOVE (observed reporting a
+        // position with the title bar's height already stripped off) that
+        // would otherwise silently overwrite the correct saved position.
+        void stopTrackingPosition();
         
         void setBandFilter(FilterFrequency freq);
 

--- a/src/gui/util/CMakeLists.txt
+++ b/src/gui/util/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(fdv_gui_util STATIC
     LabelOverrideAccessible.cpp
     NameOverrideAccessible.cpp
-    wxListViewComboPopup.cpp)
+    wxListViewComboPopup.cpp
+    WindowPositionRestore.cpp)
 
 target_compile_options(fdv_gui_util PRIVATE ${WARNINGS_AS_ERRORS_FLAGS})
     

--- a/src/gui/util/WindowPositionRestore.cpp
+++ b/src/gui/util/WindowPositionRestore.cpp
@@ -1,0 +1,94 @@
+#include "WindowPositionRestore.h"
+
+#include <wx/frame.h>
+
+#if defined(__WXGTK__) && defined(HAS_GTK3)
+#include <gtk/gtk.h>
+
+namespace
+{
+
+// How long after mapping to keep re-asserting the target position. Some
+// compositors (observed: KWin on Plasma 6, labwc on Wayland) apply their
+// own placement decision asynchronously, at no fixed, observable event --
+// sometimes even after the position already happened to match the target
+// once -- so this polls for a while rather than stopping at the first
+// match.
+constexpr gint64 kSettleWatchDurationUs = 2000000; // 2 seconds
+
+struct SettlePositionContext_
+{
+    wxFrame* frame;
+    int targetX;
+    int targetY;
+    gint64 deadlineUs;
+    guint timeoutId;
+};
+
+void OnFrameDestroyed_(GtkWidget*, gpointer userData)
+{
+    auto* ctx = static_cast<SettlePositionContext_*>(userData);
+    if (ctx->timeoutId != 0)
+    {
+        g_source_remove(ctx->timeoutId);
+    }
+    delete ctx;
+}
+
+gboolean OnSettleTick_(gpointer userData)
+{
+    auto* ctx = static_cast<SettlePositionContext_*>(userData);
+    wxPoint pos = ctx->frame->GetPosition();
+
+    if (pos.x != ctx->targetX || pos.y != ctx->targetY)
+    {
+        ctx->frame->Move(ctx->targetX, ctx->targetY);
+    }
+
+    if (g_get_monotonic_time() >= ctx->deadlineUs)
+    {
+        ctx->timeoutId = 0;
+        g_signal_handlers_disconnect_by_func(
+            GTK_WIDGET(ctx->frame->GetHandle()), (gpointer)OnFrameDestroyed_, ctx);
+        delete ctx;
+        return G_SOURCE_REMOVE;
+    }
+
+    return G_SOURCE_CONTINUE;
+}
+
+gboolean OnFrameMapEvent_(GtkWidget* widget, GdkEventAny*, gpointer userData)
+{
+    auto* ctx = static_cast<SettlePositionContext_*>(userData);
+    ctx->frame->Move(ctx->targetX, ctx->targetY);
+    ctx->deadlineUs = g_get_monotonic_time() + kSettleWatchDurationUs;
+
+    // Only the first map (initial startup) should apply the saved position --
+    // later maps, e.g. un-minimizing, should leave the window where the user
+    // last put it.
+    g_signal_handlers_disconnect_by_func(widget, (gpointer)OnFrameMapEvent_, userData);
+    ctx->timeoutId = g_timeout_add(100, OnSettleTick_, ctx);
+    return FALSE;
+}
+
+} // namespace
+
+void RestoreWindowPosition(wxFrame* frame, int x, int y)
+{
+    auto* ctx = new SettlePositionContext_{frame, x, y, 0, 0};
+    GtkWidget* widget = GTK_WIDGET(frame->GetHandle());
+    g_signal_connect(widget, "map-event", G_CALLBACK(OnFrameMapEvent_), ctx);
+    g_signal_connect(widget, "destroy", G_CALLBACK(OnFrameDestroyed_), ctx);
+}
+
+#else
+
+void RestoreWindowPosition(wxFrame* frame, int x, int y)
+{
+    frame->CallAfter([frame, x, y]()
+    {
+        frame->Move(x, y);
+    });
+}
+
+#endif // defined(__WXGTK__) && defined(HAS_GTK3)

--- a/src/gui/util/WindowPositionRestore.cpp
+++ b/src/gui/util/WindowPositionRestore.cpp
@@ -1,3 +1,24 @@
+//==========================================================================
+// Name:            WindowPositionRestore.cpp
+// Purpose:         Helper to enable restoration of window position.
+// Created:         Jul 14, 2026
+// Authors:         Barry Jackson
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
 #include "WindowPositionRestore.h"
 
 #include <wx/frame.h>

--- a/src/gui/util/WindowPositionRestore.h
+++ b/src/gui/util/WindowPositionRestore.h
@@ -1,4 +1,26 @@
-#pragma once
+//==========================================================================
+// Name:            WindowPositionRestore.h
+// Purpose:         Helper to enable restoration of window position.
+// Created:         Jul 14, 2026
+// Authors:         Barry Jackson
+// 
+// License:
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.1,
+//  as published by the Free Software Foundation.  This program is
+//  distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+//  License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+//==========================================================================
+
+#ifndef WINDOW_POSITION_RESTORE_H
+#define WINDOW_POSITION_RESTORE_H
 
 class wxFrame;
 
@@ -15,3 +37,5 @@ class wxFrame;
 // then stops so it won't fight the user's own later repositioning. On
 // other platforms this is just a straightforward deferred move.
 void RestoreWindowPosition(wxFrame* frame, int x, int y);
+
+#endif // WINDOW_POSITION_RESTORE_H

--- a/src/gui/util/WindowPositionRestore.h
+++ b/src/gui/util/WindowPositionRestore.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class wxFrame;
+
+// Restores a top-level frame's position from saved configuration.
+//
+// Must be called before the frame is shown. On Linux/GTK3, some window
+// managers/compositors (observed: KWin on Plasma 6, labwc on Wayland)
+// apply their own asynchronous initial-placement policy shortly after the
+// window is mapped, silently overriding whatever position the client
+// already set -- no matter how early or late the client's own move
+// happens, and sometimes even after the position has already happened to
+// match once. This re-asserts the requested position for a couple of
+// seconds after mapping so it can catch and correct a delayed override,
+// then stops so it won't fight the user's own later repositioning. On
+// other platforms this is just a straightforward deferred move.
+void RestoreWindowPosition(wxFrame* frame, int x, int y);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@
 #include "gui/dialogs/dlg_filter.h"
 #include "gui/dialogs/dlg_easy_setup.h"
 #include "gui/dialogs/freedv_reporter.h"
+#include "gui/util/WindowPositionRestore.h"
 
 #include "util/logging/ulog.h"
 #include "util/audio_spin_mutex.h"
@@ -812,6 +813,7 @@ static void SuppressButtonPressFlicker_()
     g_free(cssColour);
     g_object_unref(provider);
 }
+
 #endif // defined(__WXGTK__) && defined(HAS_GTK3)
 
 // OnInit()
@@ -917,12 +919,13 @@ void MainFrame::loadConfiguration_()
     g_SquelchLevel = wxGetApp().appConfiguration.squelchLevel;
     g_SquelchLevel /= 2.0;
     
-    Move(x, y);
     wxSize size = GetMinSize();
 
     if (w < size.GetWidth()) w = size.GetWidth();
     if (h < size.GetHeight()) h = size.GetHeight();
-    
+
+    RestoreWindowPosition(this, x, y);
+
     // XXX - with really short windows, wxWidgets sometimes doesn't size
     // the components properly until the user resizes the window (even if only
     // by a pixel or two). As a really hacky workaround, we emulate this behavior
@@ -2408,7 +2411,7 @@ void MainFrame::topFrame_OnClose( wxCloseEvent& event )
     auto pos = m_reporterDialog->GetPosition();
     wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
     wxGetApp().appConfiguration.reporterWindowTop = pos.y;
-    
+
     m_reporterDialog->setReporter(nullptr);
     wxGetApp().SafeYield(nullptr, false); // make sure we handle any remaining Reporter messages before dispose
     m_reporterDialog->Close();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1670,11 +1670,16 @@ MainFrame::~MainFrame()
     
     if (m_reporterDialog != nullptr)
     {
-        // wxWidgets doesn't fire wxEVT_MOVE events on Linux for some
-        // reason, so we need to grab and save the current position again.
+        // Grab and save the final position explicitly rather than relying
+        // solely on OnMove's live tracking -- Close()/Destroy() below
+        // trigger one last stray wxEVT_MOVE reporting a position with the
+        // title bar's height already stripped off, so position tracking
+        // must be stopped first or that stray event silently overwrites
+        // the correct value saved here.
         auto pos = m_reporterDialog->GetPosition();
         wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
         wxGetApp().appConfiguration.reporterWindowTop = pos.y;
+        m_reporterDialog->stopTrackingPosition();
 
         m_reporterDialog->setReporter(nullptr);
         wxGetApp().SafeYield(nullptr, false); // make sure we handle any remaining Reporter messages before dispose
@@ -2406,11 +2411,16 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
 void MainFrame::topFrame_OnClose( wxCloseEvent& event )
 {
-    // wxWidgets doesn't fire wxEVT_MOVE events on Linux for some
-    // reason, so we need to grab and save the current position again.
+    // Grab and save the final position explicitly rather than relying
+    // solely on OnMove's live tracking -- Close()/Destroy() below trigger
+    // one last stray wxEVT_MOVE reporting a position with the title bar's
+    // height already stripped off, so position tracking must be stopped
+    // first or that stray event silently overwrites the correct value
+    // saved here.
     auto pos = m_reporterDialog->GetPosition();
     wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
     wxGetApp().appConfiguration.reporterWindowTop = pos.y;
+    m_reporterDialog->stopTrackingPosition();
 
     m_reporterDialog->setReporter(nullptr);
     wxGetApp().SafeYield(nullptr, false); // make sure we handle any remaining Reporter messages before dispose


### PR DESCRIPTION
Branch: `fix/window-position-restore-race` (pushed to `barjac/freedv-gui`)
Target: `drowe67/freedv-gui` `master`

## Title

Fix window position restore under KWin and labwc (main window + FreeDV Reporter window)

## Body

### Summary

- Fixes the main window and FreeDV Reporter window not restoring to their saved
  on-screen position on startup under KWin (Plasma 6) and labwc (a wlroots-based
  Wayland compositor, tested on Raspberry Pi 4/Debian trixie). Both apply their
  own placement decision asynchronously, at no fixed, client-observable event —
  overriding whatever position the client already requested, sometimes even
  *after* the position has already happened to match the target once. The fix
  re-asserts the requested position for a couple of seconds after the window is
  first mapped (long enough to catch and correct a delayed override on either
  platform), then stops so it won't fight the user's own later repositioning.

- Fixes a related, previously-unnoticed bug this surfaced: the FreeDV
  Reporter window's saved position would drift upward by about one title-bar
  height on every close/restart cycle. Root cause: `topFrame_OnClose()` /
  `~MainFrame()` correctly grab and save the reporter's final position right
  before closing it, but `Close()`/`Destroy()` themselves fire one more
  `wxEVT_MOVE` reporting a position with the title bar's height already
  stripped off, and `FreeDVReporterDialog::OnMove` unconditionally overwrites
  the saved config value on every move event — so that stray event silently
  clobbered the correct save. Fixed by disconnecting `OnMove`
  (`stopTrackingPosition()`) right after the deliberate save, before
  `Close()`/`Destroy()`.

- Extracted the restore logic into a shared utility
  (`src/gui/util/WindowPositionRestore.h/.cpp`) used by both windows instead
  of duplicating the GTK-specific plumbing.

### Platform scope

- All new logic only compiles under `#if defined(__WXGTK__) && defined(HAS_GTK3)`
  (Linux/GTK3 builds). Windows and Mac fall through to the same
  `CallAfter`-deferred `Move()` that was already in place before this change,
  so their behavior is unchanged.
- The reporter drift fix (`stopTrackingPosition()`) is platform-neutral and
  applies everywhere; it's purely defensive (disconnects a handler after the
  correct value is already saved), so it should be a no-op on platforms that
  don't exhibit the stray-move-on-close behavior.
- Also added a loud `message(WARNING ...)` in `src/CMakeLists.txt` for the case
  where GTK3 development files (or pkg-config itself) aren't found at configure
  time — previously this silently disabled `HAS_GTK3` and, with it, all of
  this fix, with zero build-time signal that anything was skipped.
- Built and tested on: Mageia 10 (x86_64, wxGTK 3.3), KWin/Plasma 6 (two
  machines, both X11 and Wayland+XWayland sessions); Raspberry Pi 4 (aarch64,
  wxGTK 3.2), Debian trixie, labwc compositor (XWayland); and a Manjaro VM
  after an update. No Windows/Mac hardware available to test directly, but
  the platform-guard analysis above means their code path is unchanged from
  current master.

### How this was diagnosed

The KWin case: two earlier fix attempts based on a "the WM won't honor a
not-yet-mapped window's position" theory (deferring `Move()` via `CallAfter()`,
then via GTK's `map-event` alone) both failed. Root cause was only found via
targeted instrumented logging (`GetPosition()` at construction, at every
WM-triggered `configure-event`, and at close time) — which showed the WM's
placement override happens *after* the move already succeeds, not before it,
so no amount of moving earlier could win that race. An initial fix based on
watching `configure-event` and stopping as soon as the position matched fixed
this case.

The labwc/RPi4 case (found afterward, during separate testing on a different
machine/WM) exposed a further issue layered on top of the same disease:
1. A use-after-free crash appeared, found via `gdb` on a core dump: the
   original design shared one heap-allocated context between `map-event` and
   `configure-event` handlers, with only the latter's convergence path freeing
   it — but if the position already matched the target the instant the
   restore function was called (true for the Reporter, because an earlier
   `SetPosition()` call had already taken effect at the X11 level),
   `configure-event` converged and freed the context *before* the real,
   asynchronous `map-event` ever fired, which then dereferenced freed memory.
2. After that was fixed, positions still didn't hold — confirmed via
   `xwininfo` (X11 ground truth) that the compositor was still overriding the
   position *after* our old "stop watching once matched" logic had already
   declared victory and disconnected. This is the same underlying disease as
   the KWin bug, just exposed by different timing: labwc can override even
   after an early coincidental match. The final fix replaces the
   event-driven `configure-event` watcher with a straightforward time-based
   poll (fixed 2-second window after mapping, regardless of early matches),
   which was then reconfirmed fixing the original KWin case too.

### Testing performed

- Verified across multiple restart cycles that both windows now restore to a
  stable saved position (no drift) on the originally-failing KWin/Plasma 6
  laptop, and on a Raspberry Pi 4 running labwc.
- Confirmed via logging on both platforms that the poll catches and corrects a
  delayed WM/compositor override within the settle window (observed ~320ms on
  KWin, matching the previously-diagnosed timing) and gives up cleanly
  afterward without fighting the user's own repositioning.
- Reproduced and fixed a segfault (via `gdb` backtrace on a core dump) that
  only appeared once GTK3 was actually enabled on the RPi4 build.

---

## Commit history

Squashed to two clean commits (the full debugging trail, including the RPi4
detour, is preserved locally under the tag `backup-before-squash-2` if ever
needed):

1. `Fix main window position not restoring on startup under KWin`
2. `Fix FreeDV Reporter window position not restoring, and a close-time drift bug`

Branch is pushed to `barjac/freedv-gui` (`fix/window-position-restore-race`).

Note: DIAG (`log_info`) instrumentation used throughout this investigation was
stripped from the final commits. It's preserved separately as
`~/freedv-rade-build/patches/window-position-diag-overlay.patch` — not applied
by default, but available to reapply quickly if a similar issue surfaces on
another WM/compositor in the future.

Thanks to Claude Code.
