### PR TITLE
Setup Wizard: fix crash on initial start with invalid config file.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -843,7 +843,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Enhancements:
     * RADEV2: Standardize mode as USB. (PR #1397)
     * Combine all configuration into Settings->Edit Settings. (PR #1418)
-    * Rework Easy Setup window into new Setup Wizard. (PR #1418)
+    * Rework Easy Setup window into new Setup Wizard. (PR #1418, #1432)
 2. Other:
     * Remove legacy FreeDV modes (700D/700E/1600). (PR #1407, #1411, #1415)
 

--- a/src/gui/dialogs/dlg_setup_wizard.cpp
+++ b/src/gui/dialogs/dlg_setup_wizard.cpp
@@ -503,6 +503,7 @@ void SetupWizard::loadConfig()
     auto& cfg = wxGetApp().appConfiguration;
 
     auto audioEngine = AudioEngineFactory::GetAudioEngine();
+    audioEngine->start();
 
     // Page 0: Receive Audio
     m_cbRadioIn->SetValue(cfg.audioConfiguration.soundCard1In.deviceName);
@@ -570,6 +571,8 @@ void SetupWizard::loadConfig()
     m_ckReportingEnable->SetValue(cfg.reportingConfiguration.reportingEnabled);
     m_txtCallsign->SetValue(cfg.reportingConfiguration.reportingCallsign);
     m_txtGridSquare->SetValue(cfg.reportingConfiguration.reportingGridSquare);
+
+    audioEngine->stop();
 }
 
 void SetupWizard::saveConfig()


### PR DESCRIPTION
Fixes crash on Linux on initial startup with an invalid/empty configuration. Found during RADEV2 OTC testing.