### PR TITLE
Fix HAS_GTK3 not reaching fdv_gui_util, silently disabling window position restore

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -964,7 +964,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Suppress button flicker in Linux light themes. (PR #1419, PR #1421) - thanks @barjac!
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
-    * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431) - thanks @barjac!
+    * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,14 @@ if(LINUX)
             target_include_directories(freedv PRIVATE ${GTK3_INCLUDE_DIRS})
             target_link_libraries(freedv ${GTK3_LIBRARIES})
             add_definitions(-DHAS_GTK3)
+
+            # fdv_gui_util (added via add_subdirectory(gui) above, before this
+            # point) needs these too -- WindowPositionRestore.cpp lives there,
+            # not in freedv's own sources. add_definitions()/directory-scoped
+            # include dirs only propagate to subdirectories added *after* this
+            # point, so it has to be set on the already-created target directly.
+            target_compile_definitions(fdv_gui_util PRIVATE HAS_GTK3)
+            target_include_directories(fdv_gui_util PRIVATE ${GTK3_INCLUDE_DIRS})
         else(GTK3_FOUND)
             message(WARNING "GTK3 development files (gtk+-3.0.pc, e.g. package libgtk-3-dev) not found -- Linux-specific GUI workarounds (including window position restore) will be disabled")
         endif(GTK3_FOUND)


### PR DESCRIPTION
## Summary

Follow-up to #1431. `WindowPositionRestore.cpp`'s GTK-specific position-polling mechanism (added in #1431) has been silently inactive on every Linux/GTK3 build since that PR merged — it was always falling back to the plain, pre-#1431 deferred `Move()` with no protection against a window manager's asynchronous placement override.

## Root cause

`WindowPositionRestore.cpp` is compiled as part of the `fdv_gui_util` static library target (`src/gui/util/CMakeLists.txt`). In `src/CMakeLists.txt`, `add_subdirectory(gui)` runs at line 29, but the GTK3 detection block — which does `add_definitions(-DHAS_GTK3)` — doesn't run until line ~124. `add_definitions()` is directory-scoped and only propagates to subdirectories added *after* it runs, so `fdv_gui_util` never received the define, even though the main `freedv` executable target did (that block also does `target_include_directories(freedv ...)`/`target_link_libraries(freedv ...)` directly on that target).

Net effect: `#if defined(__WXGTK__) && defined(HAS_GTK3)` was always false for `WindowPositionRestore.cpp`, so the intended `map-event` + timed re-assertion logic was compiled out entirely, silently, on every Linux build — regardless of distro or window manager.

## Fix

Add the missing target-scoped compile definition and include directory for `fdv_gui_util` alongside the existing `freedv`-target calls in the same `if(GTK3_FOUND)` block.

## Testing

- Confirmed the bug first via `flags.make`: `freedv.dir` had `-DHAS_GTK3`, `fdv_gui_util.dir` did not.
- After the fix, both do; `nm`/`strings` on the resulting object file show real GTK symbols (`g_timeout_add`, `g_signal_connect_data`, `"map-event"`) instead of just the fallback path.
- Live-tested on the machine that exposed this (Mageia 10, KWin 6.5.5) via temporary diagnostic logging: confirmed the window manager's asynchronous placement override is real and still happens (window drifted from the target position roughly 120ms after mapping), and that the fix's polling mechanism now correctly catches and corrects it. Restarted 5+ times with no regression.
