### PR TITLE
Harden experimental tab layout persistence

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -965,6 +965,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
     * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
+    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, and incorrect tab restore with split tab groups. (PR #1434) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -965,7 +965,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
     * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
-    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, incorrect tab restore with split tab groups, and a saved layout getting silently overwritten by toggling Experimental Features off then back on before exiting. (PR #1434) - thanks @barjac!
+    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, incorrect tab restore with split tab groups, a saved layout getting silently overwritten by toggling Experimental Features off then back on before exiting, and a drag-and-drop assertion crash when an old saved layout leaves an empty tab group behind. (PR #1434) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -965,7 +965,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
     * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
-    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, and incorrect tab restore with split tab groups. (PR #1434) - thanks @barjac!
+    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, incorrect tab restore with split tab groups, and a saved layout getting silently overwritten by toggling Experimental Features off then back on before exiting. (PR #1434) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1184,7 +1184,12 @@ setDefaultMode:
         vkFileName_ = "";
     }
     
-    if (wxGetApp().appConfiguration.experimentalFeatures && wxGetApp().appConfiguration.tabLayout != "")
+    // Cache this now rather than re-reading the live config value at exit time: the
+    // checkbox can be toggled mid-session without reloading/reapplying a layout (that
+    // only happens here, at startup), so exit-time save must be gated on the same
+    // flag value the load decision above used, not whatever it's since been changed to.
+    tabLayoutPersistenceEnabledAtStartup_ = wxGetApp().appConfiguration.experimentalFeatures;
+    if (tabLayoutPersistenceEnabledAtStartup_ && wxGetApp().appConfiguration.tabLayout != "")
     {
         ((TabFreeAuiNotebook*)m_auiNbookCtrl)->LoadPerspective(wxGetApp().appConfiguration.tabLayout);
         const_cast<wxAuiManager&>(m_auiNbookCtrl->GetAuiManager()).Update();
@@ -1250,6 +1255,7 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     terminating_ = false;
     realigned_ = false;
     syncState_ = false;
+    tabLayoutPersistenceEnabledAtStartup_ = false;
     txChangeoverOccurring_ = false;
 
     // Add config file name to title bar if provided at the command line.
@@ -1631,7 +1637,7 @@ void MainFrame::exportConfiguration_(wxConfigBase* config)
         wxGetApp().appConfiguration.mainWindowHeight = h;
     }
 
-    if (wxGetApp().appConfiguration.experimentalFeatures)
+    if (tabLayoutPersistenceEnabledAtStartup_)
     {
         wxGetApp().appConfiguration.tabLayout = ((TabFreeAuiNotebook*)m_auiNbookCtrl)->SavePerspective();
     }

--- a/src/main.h
+++ b/src/main.h
@@ -623,6 +623,11 @@ class MainFrame : public TopFrame
         bool terminating_; // used for terminating FreeDV
         bool realigned_; // used to inhibit resize hack once already done
         bool syncState_; // GUI copy of current sync state
+
+        // Caches appConfiguration.experimentalFeatures as of the last tab layout load
+        // attempt, so exit-time save uses that instead of a possibly-since-toggled live
+        // value (toggling the checkbox mid-session doesn't reload/reapply a layout).
+        bool tabLayoutPersistenceEnabledAtStartup_;
         
         int         getSoundCardIDFromName(wxString& name, bool input);
         bool        validateSoundCardSetup();

--- a/src/main.h
+++ b/src/main.h
@@ -644,6 +644,7 @@ class MainFrame : public TopFrame
         
         void initializeFreeDVReporter_();
         void updateVoiceKeyerButtonLabel_();
+        int captureCurrentMicGroupTab_();
         
         void onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, IRigFrequencyController::Mode mode);
         void onRadioConnected_(IRigController* ptr);

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1376,6 +1376,35 @@ void MainFrame::OnTOTWarningTimer(wxTimerEvent&)
     }
 }
 
+// Returns the notebook page index that should be restored once we're done showing
+// "Frm Mic" (e.g. on RX, or after voice keyer recording finishes).
+//
+// GetSelection() isn't the right choice here since more than one tab group can be
+// visible at the same time once tabs have been split (e.g. via a saved custom tab
+// layout) - see https://forums.wxwidgets.org/viewtopic.php?t=14721. Instead, ask the
+// specific tab group that "Frm Mic" lives in what's actually active there.
+int MainFrame::captureCurrentMicGroupTab_()
+{
+    auto savedTab = m_auiNbookCtrl->GetSelection();
+
+#if wxCHECK_VERSION(3,1,4)
+    wxAuiTabCtrl* fromMicTabControl = nullptr;
+    int fromMicTabIndex = 0;
+    if (m_panelSpeechIn != nullptr &&
+        m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex))
+    {
+        int localActiveIdx = fromMicTabControl->GetActivePage();
+        if (localActiveIdx >= 0 && localActiveIdx < (int)fromMicTabControl->GetPageCount())
+        {
+            wxWindow* activeWindow = fromMicTabControl->GetWindowFromIdx(localActiveIdx);
+            savedTab = m_auiNbookCtrl->GetPageIndex(activeWindow);
+        }
+    }
+#endif // wxCHECK_VERSION(3,1,4)
+
+    return savedTab;
+}
+
 void MainFrame::togglePTT(void) {
     // Guard against re-entrant calls during the TX drain (Yield() processes events).
     // This is necessary because we are not disabling the button during the changeover,
@@ -1585,53 +1614,8 @@ void MainFrame::togglePTT(void) {
         
         // rx-> tx transition, swap to Mic In page to monitor speech
 
-        // Note: we should only save the previous page if the current selection is something on
-        // the same tab group as "Frm Mic".
-#if wxCHECK_VERSION(3,1,4)
-        wxAuiTabCtrl* fromMicTabControl = nullptr;
-        int fromMicTabIndex = 0;
-        bool validFromMicTabGroup = false;
-        if (m_panelSpeechIn != nullptr)
-        {
-            // Ignore return
-            validFromMicTabGroup = m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex);
-        }
-#endif // wxCHECK_VERSION(3,1,4)
-
-        // GetSelection() isn't the right choice here since more than one tab can be visible at
-        // the same time. We have to check the shown status of each of the other plots 
-        // AND make sure it's in the same tab control as "Frm Mic" before we can save off the
-        // current tab state.
-        // See https://forums.wxwidgets.org/viewtopic.php?t=14721 for info.
-        auto savedTab = m_auiNbookCtrl->GetSelection();
-#if wxCHECK_VERSION(3,1,4)
-        wxWindow* plotsToCheck[] = {
-            m_panelSpectrum,
-            m_panelWaterfall,
-            m_panelSpeechOut,
-            m_panelDemodIn,
-            m_panelSNR
-        };
-        for (size_t index = 0; validFromMicTabGroup && index < (sizeof(plotsToCheck) / sizeof(wxWindow*)); index++)
-        {
-            auto plot = plotsToCheck[index];
-            if (plot != nullptr && plot->IsShown())
-            {
-                // Plot is visible, now check to make sure it's in the same tab group.
-                wxAuiTabCtrl* tmpTabCtrl = nullptr;
-                int tmpTabIndex = 0;
-                if (m_auiNbookCtrl->FindTab(plot, &tmpTabCtrl, &tmpTabIndex) && tmpTabCtrl == fromMicTabControl)
-                {
-                    // Found it in the same tab group, use this index for switching back on RX.
-                    savedTab = m_auiNbookCtrl->GetPageIndex(plot);
-                    break;
-                }
-            }
-        }
-#endif // wxCHECK_VERSION(3,1,4)
-
         // Save currently visible plot so we can go back to it on RX.
-        wxGetApp().appConfiguration.currentNotebookTab = savedTab;
+        wxGetApp().appConfiguration.currentNotebookTab = captureCurrentMicGroupTab_();
 
         // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
         // the current page ourselves is a better bet.

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -274,7 +274,8 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
     };
 
     wxString tabs = layout.BeforeFirst(wxT('@'));
-    wxAuiTabCtrl *dest_tabs = nullptr;
+    wxAuiTabCtrl *dest_tabs = nullptr; // last group known to hold >= 1 page
+    bool anyEmptyGroupsCreated = false;
     while (1)
      {
        const wxString tab_part = tabs.BeforeFirst(wxT('|'));
@@ -285,7 +286,7 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 
        // Get pane name
        const wxString pane_name = tab_part.BeforeFirst(wxT('='));
-       dest_tabs = createTabGroup(pane_name);
+       wxAuiTabCtrl* new_group = createTabGroup(pane_name);
 
        // Get list of tab id's and move them to pane
        wxString tab_list = tab_part.AfterFirst(wxT('='));
@@ -298,7 +299,7 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
           // Check if this page has an 'active' marker
           const wxChar c = tab[0];
           if (c == wxT('+') || c == wxT('*')) {
-             tab = tab.Mid(1); 
+             tab = tab.Mid(1);
           }
 
           auto captionIt = captionToIdx.find(tab);
@@ -307,17 +308,36 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 
           // Move tab to pane
           wxAuiNotebookPage& page = m_tabs.GetPage(tab_idx);
-          const size_t newpage_idx = dest_tabs->GetPageCount();
-          dest_tabs->InsertPage(page.window, page, newpage_idx);
+          const size_t newpage_idx = new_group->GetPageCount();
+          new_group->InsertPage(page.window, page, newpage_idx);
           readdedTabs.insert(tab);
 
           if (c == wxT('+')) activePage = newpage_idx;
           else if ( c == wxT('*')) sel_page = tab_idx;
        }
-       if (activePage >= 0) dest_tabs->SetActivePage(activePage);
-       dest_tabs->DoShowHide();
+
+       if (new_group->GetPageCount() == 0)
+       {
+           // None of this group's saved entries resolved to a current tab (e.g. an
+           // old, pre-caption-keyed saved layout - see SavePerspective()). Leaving a
+           // zero-page tab group behind confuses wxAuiNotebook's own drag-and-drop
+           // handling (crashes with an assertion failure in GetPage() when the user
+           // later drags a tab near it), so sweep it up below instead.
+           anyEmptyGroupsCreated = true;
+       }
+       else
+       {
+           if (activePage >= 0) new_group->SetActivePage(activePage);
+           new_group->DoShowHide();
+           dest_tabs = new_group;
+       }
 
        tabs = tabs.AfterFirst(wxT('|'));
+    }
+
+    if (anyEmptyGroupsCreated)
+    {
+        RemoveEmptyTabFrames();
     }
 
     // Load the frame perspective

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -20,6 +20,7 @@
 //
 //==========================================================================
 
+#include <map>
 #include <set>
 
 #include <wx/regex.h>
@@ -205,18 +206,20 @@ wxString TabFreeAuiNotebook::SavePerspective() {
        tabs += pane.name;
        tabs += wxT("=");
   
-       // add tab id's
+       // Add tabs, keyed by caption rather than position. Position (AddPage() call
+       // order) isn't stable across app versions if a tab is ever added, removed, or
+       // reordered, which would silently corrupt previously-saved layouts.
        size_t page_count = tabframe->m_tabs->GetPageCount();
        for (size_t p = 0; p < page_count; ++p)
        {
           wxAuiNotebookPage& page = tabframe->m_tabs->GetPage(p);
           const size_t page_idx = m_tabs.GetIdxFromWindow(page.window);
-     
+
           if (p) tabs += wxT(",");
 
           if ((int)page_idx == m_curPage) tabs += wxT("*");
           else if ((int)p == tabframe->m_tabs->GetActivePage()) tabs += wxT("+");
-          tabs += wxString::Format(wxT("%zu"), page_idx);
+          tabs += page.caption;
        }
     }
     tabs += wxT("@");
@@ -230,7 +233,15 @@ wxString TabFreeAuiNotebook::SavePerspective() {
 bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
     // Remove all tab ctrls (but still keep them in main index)
     const size_t tab_count = m_tabs.GetPageCount();
-    std::set<size_t> readdedTabs;
+    std::set<wxString> readdedTabs;
+
+    // Caption -> master index lookup, so saved entries resolve by tab identity
+    // rather than by position (see SavePerspective()).
+    std::map<wxString, size_t> captionToIdx;
+    for (size_t i = 0; i < tab_count; ++i) {
+        captionToIdx[m_tabs.GetPage(i).caption] = i;
+    }
+
     for (size_t i = 0; i < tab_count; ++i) {
        wxWindow* wnd = m_tabs.GetWindowFromIdx(i);
 
@@ -248,35 +259,33 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 
     size_t sel_page = 0;
 
+    // Creates a new (empty) tab group pane, docked at the bottom, named paneName.
+    auto createTabGroup = [&](const wxString& paneName) -> wxAuiTabCtrl* {
+        wxTabFrameOurs* new_tabs = new wxTabFrameOurs();
+        new_tabs->m_tabs = new wxAuiTabCtrl(this, m_tabIdCounter++);
+        new_tabs->m_tabs->SetArtProvider(m_tabs.GetArtProvider()->Clone());
+        new_tabs->m_tabCtrlHeight = m_tabCtrlHeight;
+        new_tabs->m_tabs->SetFlags(m_flags);
+
+        wxAuiPaneInfo pane_info = wxAuiPaneInfo().Name(paneName).Bottom().CaptionVisible(false);
+        m_mgr.AddPane(new_tabs, pane_info);
+
+        return new_tabs->m_tabs;
+    };
+
     wxString tabs = layout.BeforeFirst(wxT('@'));
     wxAuiTabCtrl *dest_tabs = nullptr;
     while (1)
      {
        const wxString tab_part = tabs.BeforeFirst(wxT('|'));
-  
+
        // if the string is empty, we're done parsing
          if (tab_part.empty())
              break;
 
        // Get pane name
        const wxString pane_name = tab_part.BeforeFirst(wxT('='));
-
-       // create a new tab frame
-       wxTabFrameOurs* new_tabs = new wxTabFrameOurs();
-       new_tabs->m_tabs = new wxAuiTabCtrl(this,
-                                  m_tabIdCounter++);
- //                            wxDefaultPosition,
- //                            wxDefaultSize,
- //                            wxNO_BORDER|wxWANTS_CHARS);
-       new_tabs->m_tabs->SetArtProvider(m_tabs.GetArtProvider()->Clone());
-       new_tabs->m_tabCtrlHeight = m_tabCtrlHeight;
-       new_tabs->m_tabs->SetFlags(m_flags);
-       dest_tabs = new_tabs->m_tabs;
-
-       // create a pane info structure with the information
-       // about where the pane should be added
-       wxAuiPaneInfo pane_info = wxAuiPaneInfo().Name(pane_name).Bottom().CaptionVisible(false);
-       m_mgr.AddPane(new_tabs, pane_info);
+       dest_tabs = createTabGroup(pane_name);
 
        // Get list of tab id's and move them to pane
        wxString tab_list = tab_part.AfterFirst(wxT('='));
@@ -292,14 +301,15 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
              tab = tab.Mid(1); 
           }
 
-          const size_t tab_idx = wxAtoi(tab.c_str());
-          if (tab_idx >= GetPageCount()) continue;
+          auto captionIt = captionToIdx.find(tab);
+          if (captionIt == captionToIdx.end()) continue; // tab no longer exists (e.g. removed in a newer version)
+          const size_t tab_idx = captionIt->second;
 
           // Move tab to pane
           wxAuiNotebookPage& page = m_tabs.GetPage(tab_idx);
           const size_t newpage_idx = dest_tabs->GetPageCount();
           dest_tabs->InsertPage(page.window, page, newpage_idx);
-          readdedTabs.insert(tab_idx);
+          readdedTabs.insert(tab);
 
           if (c == wxT('+')) activePage = newpage_idx;
           else if ( c == wxT('*')) sel_page = tab_idx;
@@ -312,16 +322,31 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
 
     // Load the frame perspective
     const wxString frames = layout.AfterFirst(wxT('@'));
-    m_mgr.LoadPerspective(frames);
+    bool framesLoaded = m_mgr.LoadPerspective(frames);
+
+    bool ok = true;
+    if (dest_tabs == nullptr)
+    {
+        // Saved layout string parsed to zero tab groups (e.g. empty/corrupted). Rather
+        // than crash on the dereference below, fall back to one default group holding
+        // every tab, matching what a first-run/no-saved-layout state looks like.
+        log_warn("Tab layout persistence: saved layout produced no tab groups; falling back to default layout.");
+        dest_tabs = createTabGroup(wxT("default"));
+        ok = false;
+    }
+    else if (!framesLoaded)
+    {
+        log_warn("Tab layout persistence: failed to restore frame perspective; layout may not match what was saved.");
+        ok = false;
+    }
 
     // Reinsert tabs that weren't persisted before
-    assert(dest_tabs != nullptr); // We should have found/created at least one tab group already.
     for (size_t i = 0; i < tab_count; ++i) {
-        if (readdedTabs.find(i) != readdedTabs.end())
+        wxAuiNotebookPage& page = m_tabs.GetPage(i);
+        if (readdedTabs.find(page.caption) != readdedTabs.end())
         {
             continue;
         }
-        wxAuiNotebookPage& page = m_tabs.GetPage(i);
         const size_t newpage_idx = dest_tabs->GetPageCount();
         dest_tabs->InsertPage(page.window, page, newpage_idx);
     }
@@ -330,7 +355,7 @@ bool TabFreeAuiNotebook::LoadPerspective(const wxString& layout) {
     m_curPage = -1;
     SetSelection(sel_page);
 
-    return true;
+    return ok;
 }
 
 //=========================================================================

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -127,53 +127,8 @@ void MainFrame::OnRecordNewVoiceKeyerFile( wxCommandEvent& )
     vkFileName_ = soundFile;
     
     // Switch tab to "From Mic" during recording.
-    // Note: we should only save the previous page if the current selection is something on
-    // the same tab group as "Frm Mic".
-#if wxCHECK_VERSION(3,1,4)
-    wxAuiTabCtrl* fromMicTabControl = nullptr;
-    int fromMicTabIndex = 0;
-    bool validFromMicTabGroup = false;
-    if (m_panelSpeechIn != nullptr)
-    {
-        // Ignore return
-        validFromMicTabGroup = m_auiNbookCtrl->FindTab(m_panelSpeechIn, &fromMicTabControl, &fromMicTabIndex);
-    }
-#endif // wxCHECK_VERSION(3,1,4)
-
-    // GetSelection() isn't the right choice here since more than one tab can be visible at
-    // the same time. We have to check the shown status of each of the other plots 
-    // AND make sure it's in the same tab control as "Frm Mic" before we can save off the
-    // current tab state.
-    // See https://forums.wxwidgets.org/viewtopic.php?t=14721 for info.
-    auto savedTab = m_auiNbookCtrl->GetSelection();
-#if wxCHECK_VERSION(3,1,4)
-    wxWindow* plotsToCheck[] = {
-        m_panelSpectrum,
-        m_panelWaterfall,
-        m_panelSpeechOut,
-        m_panelDemodIn,
-        m_panelSNR
-    };
-    for (size_t index = 0; validFromMicTabGroup && index < (sizeof(plotsToCheck) / sizeof(wxWindow*)); index++)
-    {
-        auto plot = plotsToCheck[index];
-        if (plot != nullptr && plot->IsShown())
-        {
-            // Plot is visible, now check to make sure it's in the same tab group.
-            wxAuiTabCtrl* tmpTabCtrl = nullptr;
-            int tmpTabIndex = 0;
-            if (m_auiNbookCtrl->FindTab(plot, &tmpTabCtrl, &tmpTabIndex) && tmpTabCtrl == fromMicTabControl)
-            {
-                // Found it in the same tab group, use this index for switching back on RX.
-                savedTab = m_auiNbookCtrl->GetPageIndex(plot);
-                break;
-            }
-        }
-    }
-#endif // wxCHECK_VERSION(3,1,4)
-
     // Save currently visible plot so we can go back to it on completion.
-    wxGetApp().appConfiguration.currentNotebookTab = savedTab;
+    wxGetApp().appConfiguration.currentNotebookTab = captureCurrentMicGroupTab_();
 
     // Note: GetPageIndex sometimes returns the incorrect results, so iterating and finding
     // the current page ourselves is a better bet.


### PR DESCRIPTION
## Note

Once this is fully tested on all platforms, then with these changes I think it would be time to take this feature out of "Experimental Features" and bring it into mainstream.
It could have a 'disable' setting under the 'Display' tab for users who don't use it.
For now this remains under the "Enable Experimental Features" check box where it is rather lonely!

## Summary

Tab layout persistence (Tools->Options->Debugging->Enable Experimental Features)
saves/restores how the Waterfall/Spectrum/Frm Radio/Frm Mic/Frm Decoder/SNR tabs
are arranged, including splitting them into multiple groups. This PR hardens that
feature - it stays behind the same checkbox, nothing about the gating changes.

Five issues were found and fixed, all confirmed via live use on two machines
(including against an existing saved layout from before this PR):

- Saved tabs were keyed by their `AddPage()` position rather than a stable
  identity, so any future change to the tab list could silently corrupt
  previously-saved layouts (this is what required the hang fix in a7aab5d7 when
  the SNR plot was added). Tabs are now keyed by caption text instead.
- `LoadPerspective()` had an `assert()` that compiles out in release (`NDEBUG`)
  builds, so a saved layout that couldn't be parsed into any tab groups would
  null-deref instead of failing safely. It now falls back to one default group.
- `togglePTT()`/`OnTogBtnVoiceKeyerClick()` each scanned a fixed list of 5 plot
  windows to determine which tab to restore when tabs are split across groups
  (needed because `wxAuiNotebook::GetSelection()` is ambiguous once more than one
  group is visible). Replaced both copies with a shared
  `captureCurrentMicGroupTab_()` helper that reads the target group's active page
  directly, so it isn't tied to a specific set of panels.
- Save (on exit) and load (on startup) were each independently gated on the live
  `experimentalFeatures` flag. Since load only happens at startup, toggling the
  checkbox off then back on before quitting could silently overwrite a saved
  layout with the session's unloaded/flat state. Save is now gated on the flag
  value cached at startup instead.
- `LoadPerspective()` could leave a zero-page tab group in the layout when an old
  saved layout's entries don't resolve to a current tab (e.g. exactly the
  upgrade case above). `wxAuiNotebook`'s own drag-and-drop handling doesn't
  tolerate that and asserts; empty groups are now cleaned up via
  `RemoveEmptyTabFrames()`.

## Test plan

- [x] Split tabs into multiple groups; layout saves and restores correctly across restart
- [x] TX/RX toggling and voice keyer recording switch to/from the correct tab with a split "Frm Mic" group
- [x] An existing saved layout from before this PR degrades gracefully (collapses to one group) instead of hanging or crashing
- [x] Reproduced and fixed a drag-and-drop crash caused by an empty tab group left over from an old-format saved layout
- [x] Toggling Experimental Features off then back on before exiting no longer overwrites a good saved layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)