### PR TITLE
Fix right-click context menus dismissing before they can be read (GTK)

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -965,7 +965,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
     * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
-    * Harden experimental tab layout persistence: fix positional index corruption across version upgrades, a crash on malformed saved layouts, incorrect tab restore with split tab groups, a saved layout getting silently overwritten by toggling Experimental Features off then back on before exiting, and a drag-and-drop assertion crash when an old saved layout leaves an empty tab group behind. (PR #1434) - thanks @barjac!
+    * Harden experimental tab layout persistence. (PR #1434) - thanks @barjac!
+    * Fix right-click context menus dismissing before they can be read (GTK) (PR #1437) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -629,10 +629,11 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_statusMessage->Connect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
     m_buttonClear->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
-#if wxCHECK_VERSION(3, 3, 0)
+#if wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__)
     // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press, causing GTK to
     // dismiss PopupMenu on button release (see topFrame.cpp for the same
-    // workaround on other widgets); use RIGHT_UP instead.
+    // workaround on other widgets); use RIGHT_UP instead. MSW/OSX are
+    // unaffected, so this is GTK-specific.
     m_buttonSend->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextSendContextMenu(ctx); });
     m_buttonClear->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextClearContextMenu(ctx); });
 #else
@@ -711,7 +712,7 @@ FreeDVReporterDialog::~FreeDVReporterDialog()
     m_statusMessage->Disconnect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
     m_buttonClear->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
-#if !wxCHECK_VERSION(3, 3, 0)
+#if !(wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__))
     m_buttonSend->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextSendContextMenu), NULL, this);
     m_buttonClear->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextClearContextMenu), NULL, this);
 #endif

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -628,9 +628,17 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
 
     m_statusMessage->Connect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
-    m_buttonSend->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextSendContextMenu), NULL, this);
     m_buttonClear->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
+#if wxCHECK_VERSION(3, 3, 0)
+    // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press, causing GTK to
+    // dismiss PopupMenu on button release (see topFrame.cpp for the same
+    // workaround on other widgets); use RIGHT_UP instead.
+    m_buttonSend->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextSendContextMenu(ctx); });
+    m_buttonClear->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextClearContextMenu(ctx); });
+#else
+    m_buttonSend->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextSendContextMenu), NULL, this);
     m_buttonClear->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextClearContextMenu), NULL, this);
+#endif
 
     m_buttonOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnOK), NULL, this);
     m_buttonSendQSY->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnSendQSY), NULL, this);
@@ -703,8 +711,10 @@ FreeDVReporterDialog::~FreeDVReporterDialog()
     m_statusMessage->Disconnect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
     m_buttonClear->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
+#if !wxCHECK_VERSION(3, 3, 0)
     m_buttonSend->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextSendContextMenu), NULL, this);
     m_buttonClear->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextClearContextMenu), NULL, this);
+#endif
 
     m_buttonOK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnOK), NULL, this);
     m_buttonSendQSY->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnSendQSY), NULL, this);

--- a/src/gui/dialogs/freedv_reporter.cpp
+++ b/src/gui/dialogs/freedv_reporter.cpp
@@ -629,11 +629,12 @@ FreeDVReporterDialog::FreeDVReporterDialog(wxWindow* parent, wxWindowID id, cons
     m_statusMessage->Connect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
     m_buttonClear->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
-#if wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__)
-    // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press, causing GTK to
+#if defined(__WXGTK__)
+    // wxGTK fires wxEVT_CONTEXT_MENU on button-press, causing GTK to
     // dismiss PopupMenu on button release (see topFrame.cpp for the same
     // workaround on other widgets); use RIGHT_UP instead. MSW/OSX are
-    // unaffected, so this is GTK-specific.
+    // unaffected, so this is GTK-specific. Confirmed present on both
+    // wxGTK 3.2 and 3.3+, so no version gate here.
     m_buttonSend->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextSendContextMenu(ctx); });
     m_buttonClear->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnStatusTextClearContextMenu(ctx); });
 #else
@@ -712,7 +713,7 @@ FreeDVReporterDialog::~FreeDVReporterDialog()
     m_statusMessage->Disconnect(wxEVT_TEXT, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextChange), NULL, this);
     m_buttonSend->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextSend), NULL, this);
     m_buttonClear->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(FreeDVReporterDialog::OnStatusTextClear), NULL, this);
-#if !(wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__))
+#if !defined(__WXGTK__)
     m_buttonSend->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextSendContextMenu), NULL, this);
     m_buttonClear->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(FreeDVReporterDialog::OnStatusTextClearContextMenu), NULL, this);
 #endif

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -971,9 +971,11 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_togBtnVoiceKeyer->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
     m_btnTogPTT->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
 
-#if wxCHECK_VERSION(3, 3, 0)
+#if wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__)
     // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press for these widget types,
     // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP instead.
+    // MSW/OSX are unaffected (MSW generates the event on button-up already;
+    // OSX uses ctrl-click), so this is GTK-specific.
     m_togBtnVoiceKeyer->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnVoiceKeyerRightClick(ctx); });
     m_btnTogPTT->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnPTTRightClick(ctx); });
 #else
@@ -1004,15 +1006,18 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_btnTxLevelPP->Connect(wxEVT_MOUSEWHEEL, wxMouseEventHandler(TopFrame::OnTxLevelMouseWheel), NULL, this);
     m_btnTogTune->Connect(wxEVT_MOUSEWHEEL, wxMouseEventHandler(TopFrame::OnTxLevelMouseWheel), NULL, this);
 
-#if wxCHECK_VERSION(3, 3, 0)
+#if wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__)
     // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press for these widget types,
     // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP instead.
+    // MSW/OSX are unaffected (MSW generates the event on button-up already;
+    // OSX uses ctrl-click), so this is GTK-specific.
     m_txLevelBox->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTxLevelContextMenu(ctx); });
     m_txtTxLevelNum->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTxLevelContextMenu(ctx); });
     m_btnTogTune->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTuneAttenContextMenu(ctx); });
 #else
     // wxGTK < 3.3 does not generate RIGHT_UP for windowless widget types
     // (wxStaticBox, wxStaticText); CONTEXT_MENU works without the dismiss issue.
+    // (Also used as-is on MSW/OSX regardless of wx version -- see above.)
     m_txLevelBox->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
     m_txtTxLevelNum->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
     m_btnTogTune->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTuneAttenContextMenu), NULL, this);
@@ -1098,7 +1103,7 @@ TopFrame::~TopFrame()
     m_togBtnAnalog->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnAnalogClick), NULL, this);
     m_togBtnVoiceKeyer->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
-#if !wxCHECK_VERSION(3, 3, 0)
+#if !(wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__))
     m_togBtnVoiceKeyer->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnPTTRightClick), NULL, this);
 #endif
@@ -1118,7 +1123,7 @@ TopFrame::~TopFrame()
     m_btnTxLevelM->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelDecr), NULL, this);
     m_btnTxLevelP->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelIncr), NULL, this);
     m_btnTxLevelPP->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTxLevelIncrBig), NULL, this);
-#if !wxCHECK_VERSION(3, 3, 0)
+#if !(wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__))
     m_txLevelBox->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
     m_txtTxLevelNum->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTxLevelContextMenu), NULL, this);
     m_btnTogTune->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTuneAttenContextMenu), NULL, this);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -971,11 +971,13 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_togBtnVoiceKeyer->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
     m_btnTogPTT->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
 
-#if wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__)
-    // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press for these widget types,
-    // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP instead.
-    // MSW/OSX are unaffected (MSW generates the event on button-up already;
-    // OSX uses ctrl-click), so this is GTK-specific.
+#if defined(__WXGTK__)
+    // wxGTK fires wxEVT_CONTEXT_MENU on button-press for these widgets,
+    // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP
+    // instead. MSW/OSX are unaffected (MSW generates the event on
+    // button-up already; OSX uses ctrl-click), so this is GTK-specific.
+    // Confirmed present on both wxGTK 3.2 and 3.3+, unlike the windowless
+    // widget case below, so no version gate here.
     m_togBtnVoiceKeyer->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnVoiceKeyerRightClick(ctx); });
     m_btnTogPTT->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnPTTRightClick(ctx); });
 #else
@@ -1103,7 +1105,7 @@ TopFrame::~TopFrame()
     m_togBtnAnalog->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnAnalogClick), NULL, this);
     m_togBtnVoiceKeyer->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
-#if !(wxCHECK_VERSION(3, 3, 0) && defined(__WXGTK__))
+#if !defined(__WXGTK__)
     m_togBtnVoiceKeyer->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnPTTRightClick), NULL, this);
 #endif

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -969,9 +969,17 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_togBtnOnOff->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnOnOff), NULL, this);
     m_togBtnAnalog->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnAnalogClick), NULL, this);
     m_togBtnVoiceKeyer->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
-    m_togBtnVoiceKeyer->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Connect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
+
+#if wxCHECK_VERSION(3, 3, 0)
+    // wxGTK 3.3+ fires wxEVT_CONTEXT_MENU on button-press for these widget types,
+    // causing GTK to dismiss PopupMenu on button release; use RIGHT_UP instead.
+    m_togBtnVoiceKeyer->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnVoiceKeyerRightClick(ctx); });
+    m_btnTogPTT->Bind(wxEVT_RIGHT_UP, [this](wxMouseEvent&) { wxContextMenuEvent ctx; OnTogBtnPTTRightClick(ctx); });
+#else
+    m_togBtnVoiceKeyer->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Connect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnPTTRightClick), NULL, this);
+#endif
 
     m_BtnCallSignReset->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnCallSignReset), NULL, this);
     m_BtnBerReset->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnBerReset), NULL, this);
@@ -1089,9 +1097,11 @@ TopFrame::~TopFrame()
     m_togBtnOnOff->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnOnOff), NULL, this);
     m_togBtnAnalog->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnAnalogClick), NULL, this);
     m_togBtnVoiceKeyer->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnVoiceKeyerClick), NULL, this);
-    m_togBtnVoiceKeyer->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnTogBtnPTT), NULL, this);
+#if !wxCHECK_VERSION(3, 3, 0)
+    m_togBtnVoiceKeyer->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnVoiceKeyerRightClick), NULL, this);
     m_btnTogPTT->Disconnect(wxEVT_CONTEXT_MENU, wxContextMenuEventHandler(TopFrame::OnTogBtnPTTRightClick), NULL, this);
+#endif
     
     m_btnCenterRx->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(TopFrame::OnCenterRx), NULL, this);
 

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -199,7 +199,7 @@ class TopFrame : public wxFrame
         virtual void OnTogBtnAnalogClick( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnVoiceKeyerClick( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& event ) { event.Skip(); }
-        
+
         virtual void OnTogBtnPTT( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnTogBtnPTTRightClick( wxContextMenuEvent& event ) { event.Skip(); }
 

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -210,15 +210,9 @@ void MainFrame::OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& )
     recordNewVoiceKeyerFileMenuItem_->Enable(enabled);
 
     // Trigger right-click menu popup in a location that will prevent it from
-    // ending up off the screen. Deferred via CallAfter so it opens after the
-    // originating right-click's press/release (and its implicit pointer
-    // grab) has fully completed -- otherwise on GTK the matching button-up
-    // is delivered straight to the freshly-opened menu, selecting whatever
-    // is under the cursor before the menu can be read.
+    // ending up off the screen.
     auto sz = m_togBtnVoiceKeyer->GetSize();
-    CallAfter([this, sz]() {
-        m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
-    });
+    m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
 }
 
 void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -208,11 +208,17 @@ void MainFrame::OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& )
     bool enabled = vk_state == VK_IDLE && !m_btnTogPTT->GetValue();
     chooseVKFileMenuItem_->Enable(vk_state == VK_IDLE);
     recordNewVoiceKeyerFileMenuItem_->Enable(enabled);
-    
+
     // Trigger right-click menu popup in a location that will prevent it from
-    // ending up off the screen.
+    // ending up off the screen. Deferred via CallAfter so it opens after the
+    // originating right-click's press/release (and its implicit pointer
+    // grab) has fully completed -- otherwise on GTK the matching button-up
+    // is delivered straight to the freshly-opened menu, selecting whatever
+    // is under the cursor before the menu can be read.
     auto sz = m_togBtnVoiceKeyer->GetSize();
-    m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
+    CallAfter([this, sz]() {
+        m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
+    });
 }
 
 void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )


### PR DESCRIPTION
## Summary
- On wxGTK, right-click context menus shown from `wxEVT_CONTEXT_MENU` open
  while the same click's button-release is still pending, so GTK delivers
  that release straight into the menu as a selection instead of leaving
  it open to read
- Fixes this for the Voice Keyer and PTT buttons' right-click menus, and
  the FreeDV Reporter dialog's Send/Clear status message buttons, using
  the same `wxEVT_RIGHT_UP`-based workaround already in place elsewhere
  in topFrame.cpp for other widgets
- Confirmed present on both wxGTK 3.2 and 3.3+, so the fix is gated on
  `__WXGTK__` only, not a wx version check
- MSW/OSX untouched (already release-based/ctrl-click respectively, so
  unaffected)

## Test plan
- [x] Confirmed fixed on Mageia 10 / Plasma 6, wxGTK 3.3 build
- [x] Confirmed fixed on wxGTK 3.2 build (`build_linux_wx32`)
- [x] No regressions found in either build