### PR TITLE
Fix Voice Keyer/PTT context menu positioning under native Wayland

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -978,6 +978,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Allow 8k sample rate for 'radio' devices. (PR #1416)
     * FreeDV Reporter: Connect to server via TLS by default. (PR #1422, #1427)
     * Block special characters in recording file name suffixes and default the voice keyer file selector to show .wav and .mp3. (PR #1424) - thanks @barjac!
+    * Fix Voice Keyer/PTT context menu positioning under native Wayland. (PR #1438) - thanks @barjac!
 3. Build system:
     * Clear CMake deprecation warnings in FreeDV. (PR #1383, #1386)
     * Upgrade Hamlib to 4.7.2. (PR #1413)

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1186,8 +1186,7 @@ void MainFrame::OnSetMonitorTxAudioVol( wxCommandEvent& )
 //-------------------------------------------------------------------------
 void MainFrame::OnTogBtnPTTRightClick( wxContextMenuEvent& )
 {
-    auto sz = m_btnTogPTT->GetSize();
-    m_btnTogPTT->PopupMenu(pttPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
+    m_btnTogPTT->PopupMenu(pttPopupMenu_, LeftOffsetContextMenuPosition(m_btnTogPTT));
 }
 
 //-------------------------------------------------------------------------

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -33,7 +33,29 @@
 #include "gui/util/LabelOverrideAccessible.h"
 #include "util/logging/ulog.h"
 
+#if defined(__WXGTK__) && defined(HAS_GTK3)
+#include <gtk/gtk.h>
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif // GDK_WINDOWING_WAYLAND
+#endif // defined(__WXGTK__) && defined(HAS_GTK3)
+
 extern int g_playFileToMicInEventId;
+
+wxPoint LeftOffsetContextMenuPosition(wxWindow* btn)
+{
+#if defined(__WXGTK__) && defined(HAS_GTK3) && defined(GDK_WINDOWING_WAYLAND)
+    GdkDisplay* display = gdk_display_get_default();
+    if (display != nullptr && GDK_IS_WAYLAND_DISPLAY(display))
+    {
+        return wxDefaultPosition;
+    }
+#endif // defined(__WXGTK__) && defined(HAS_GTK3) && defined(GDK_WINDOWING_WAYLAND)
+
+    auto sz = btn->GetSize();
+    return wxPoint(-sz.GetWidth() - 25, 0);
+}
+
 extern int g_recFileFromRadioEventId;
 extern int g_recFileFromDecoderEventId;
 extern int g_playFileFromRadioEventId;

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -78,6 +78,14 @@
 
 class wxListViewComboPopup;
 
+// Popup position for a right-click menu anchored to the left of btn (to
+// avoid running off the right screen edge on X11). On GTK/Wayland, GDK's
+// own popup placement already avoids screen edges correctly, and this
+// manual offset doesn't translate to Wayland's surface-relative anchor
+// model (it ends up placed at the toplevel's origin instead), so this
+// returns wxDefaultPosition there and lets GTK position it automatically.
+wxPoint LeftOffsetContextMenuPosition(wxWindow* btn);
+
 ///////////////////////////////////////////////////////////////////////////////
 /// Class TopFrame
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/voicekeyer.cpp
+++ b/src/voicekeyer.cpp
@@ -211,8 +211,7 @@ void MainFrame::OnTogBtnVoiceKeyerRightClick( wxContextMenuEvent& )
 
     // Trigger right-click menu popup in a location that will prevent it from
     // ending up off the screen.
-    auto sz = m_togBtnVoiceKeyer->GetSize();
-    m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, wxPoint(-sz.GetWidth() - 25, 0));
+    m_togBtnVoiceKeyer->PopupMenu(voiceKeyerPopupMenu_, LeftOffsetContextMenuPosition(m_togBtnVoiceKeyer));
 }
 
 void MainFrame::OnSetMonitorVKAudio( wxCommandEvent& event )


### PR DESCRIPTION
Follow-on from #1437, which fixed these menus dismissing before they
could be read on GTK. Testing that fix under native Wayland surfaced a
separate positioning issue.

## Summary
- The Voice Keyer and PTT right-click menus use a manual left-offset
  (`wxPoint(-sz.GetWidth() - 25, 0)`, added 2023 to keep the menu on
  screen on X11) that assumes X11-style absolute screen coordinates
- Wayland's `xdg_popup` protocol doesn't support that, so the menu was
  appearing at the top of the window instead of next to the button
- Added `LeftOffsetContextMenuPosition()`, which detects a Wayland GDK
  display at runtime (`GDK_IS_WAYLAND_DISPLAY`) and returns
  `wxDefaultPosition` there, letting GTK's own popup placement handle
  it correctly (as already happens for the Reporter Send/Clear menus,
  which never used a manual offset) -- X11 keeps the original offset
  unchanged

## Test plan
- [x] Confirmed fixed under native Wayland, no regression on X11 (desktop)
- [x] Confirmed fixed under native Wayland and X11 on RPi4 as well