### PR TITLE
Ensure wxWidgets actually uses GTK3 before enabling workarounds.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -964,7 +964,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Suppress button flicker in Linux light themes. (PR #1419, PR #1421) - thanks @barjac!
     * Only preserve previously selected tab on TX if it's in the same group as 'From Mic'. (PR #1428)
     * Scalar plot label alignment fix for Y axis of Frm Decoder/Mic/Radio, SNR and Spectrum plots. (PR #1429) - thanks @barjac!
-    * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433) - thanks @barjac!
+    * Fix window position restore under KWin and labwc (main window + FreeDV Reporter window). (PR #1431, #1433, #1449) - thanks @barjac!
     * Harden experimental tab layout persistence. (PR #1434) - thanks @barjac!
     * Fix right-click context menus dismissing before they can be read (GTK) (PR #1437) - thanks @barjac!
     * Unconditionally add new station to Heard Station list if first heard. (PR #1444)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,18 +118,46 @@ if(LINUX)
     if(PkgConfig_FOUND)
         pkg_check_modules(GTK3 QUIET gtk+-3.0)
         if(GTK3_FOUND)
-            message(STATUS "GTK3 development files found, will implement Linux-specific GUI workarounds")
-            target_include_directories(freedv PRIVATE ${GTK3_INCLUDE_DIRS})
-            target_link_libraries(freedv ${GTK3_LIBRARIES})
-            add_definitions(-DHAS_GTK3)
+            # gtk+-3.0.pc being present only means GTK3 *headers* exist
+            # somewhere on the system -- it says nothing about whether the
+            # wxWidgets we're linking against was itself built against GTK3.
+            # wx/defs.h unconditionally forward-declares a stand-in
+            # `GdkWindow` typedef whenever __WXGTK__ is set, and picks
+            # between the real GTK3 layout (struct _GdkWindow) or the
+            # legacy GTK2 one (struct _GdkDrawable) based on whether
+            # __WXGTK3__ is *also* defined by wx's own (toolkit-specific)
+            # setup.h. If wx was actually built for GTK2 -- e.g. a system
+            # with both gtk2-devel and gtk3-devel installed, where wx-config
+            # resolves to a GTK2 build -- directly #include-ing <gtk/gtk.h>
+            # alongside wx headers gets two conflicting GdkWindow
+            # declarations in the same translation unit, regardless of
+            # include order. Probe for __WXGTK3__ using wx's own headers
+            # before trusting the independent pkg-config detection.
+            include(CheckCXXSymbolExists)
+            set(CMAKE_REQUIRED_INCLUDES ${wxWidgets_INCLUDE_DIRS})
+            set(CMAKE_REQUIRED_DEFINITIONS ${wxWidgets_DEFINITIONS})
+            set(CMAKE_REQUIRED_FLAGS "${wxWidgets_CXX_FLAGS}")
+            check_cxx_symbol_exists(__WXGTK3__ "wx/defs.h" WX_BUILT_FOR_GTK3)
+            unset(CMAKE_REQUIRED_INCLUDES)
+            unset(CMAKE_REQUIRED_DEFINITIONS)
+            unset(CMAKE_REQUIRED_FLAGS)
 
-            # fdv_gui_util (added via add_subdirectory(gui) above, before this
-            # point) needs these too -- WindowPositionRestore.cpp lives there,
-            # not in freedv's own sources. add_definitions()/directory-scoped
-            # include dirs only propagate to subdirectories added *after* this
-            # point, so it has to be set on the already-created target directly.
-            target_compile_definitions(fdv_gui_util PRIVATE HAS_GTK3)
-            target_include_directories(fdv_gui_util PRIVATE ${GTK3_INCLUDE_DIRS})
+            if(WX_BUILT_FOR_GTK3)
+                message(STATUS "GTK3 development files found, will implement Linux-specific GUI workarounds")
+                target_include_directories(freedv PRIVATE ${GTK3_INCLUDE_DIRS})
+                target_link_libraries(freedv ${GTK3_LIBRARIES})
+                add_definitions(-DHAS_GTK3)
+
+                # fdv_gui_util (added via add_subdirectory(gui) above, before this
+                # point) needs these too -- WindowPositionRestore.cpp lives there,
+                # not in freedv's own sources. add_definitions()/directory-scoped
+                # include dirs only propagate to subdirectories added *after* this
+                # point, so it has to be set on the already-created target directly.
+                target_compile_definitions(fdv_gui_util PRIVATE HAS_GTK3)
+                target_include_directories(fdv_gui_util PRIVATE ${GTK3_INCLUDE_DIRS})
+            else(WX_BUILT_FOR_GTK3)
+                message(WARNING "GTK3 development files (gtk+-3.0.pc) were found, but the detected wxWidgets does not define __WXGTK3__ (it appears to target GTK2) -- including <gtk/gtk.h> directly alongside wx headers would conflict, so Linux-specific GUI workarounds (including window position restore) will be disabled")
+            endif(WX_BUILT_FOR_GTK3)
         else(GTK3_FOUND)
             message(WARNING "GTK3 development files (gtk+-3.0.pc, e.g. package libgtk-3-dev) not found -- Linux-specific GUI workarounds (including window position restore) will be disabled")
         endif(GTK3_FOUND)


### PR DESCRIPTION
Per @claude re: #1447:

*Diagnosis:* src/CMakeLists.txt enabled the GTK3-specific code path (HAS_GTK3, which makes WindowPositionRestore.cpp/main.cpp/topFrame.cpp #include <gtk/gtk.h> directly alongside wx headers) purely based on pkg_check_modules(gtk+-3.0) finding GTK3 dev files somewhere on the system — with no check on whether the linked wxWidgets was actually built against GTK3. wx's wx/defs.h always forward-declares a stand-in GdkWindow type, choosing between the real GTK3 layout or the legacy GTK2 one based on __WXGTK3__, which is set only in wx's own toolkit-specific setup.h. On a system where wx-config resolves to a GTK2-linked wxWidgets while GTK3 dev headers are independently installed (plausible on rolling-release distros like Tumbleweed with both gtk2-devel and gtk3-devel present), you get both declarations in the same translation unit → the exact conflict Rick hit, independent of include order.

*Fix:* before trusting the pkg-config GTK3 detection, I added a check_cxx_symbol_exists(__WXGTK3__ "wx/defs.h" ...) probe using wx's own resolved include dirs/flags. If wx doesn't report __WXGTK3__, the build now falls back to the existing warning-and-disable path (same pattern already used when GTK3 isn't found at all) instead of hard-failing — so normal Linux systems where wx and pkg-config agree are unaffected, and mismatched systems like Rick's just lose the window-position-restore workaround with a clear warning instead of a broken build.
