### PR TITLE
TEST: point at freedv-backend RADE EOO noise-estimate fix (do not merge)

### DIFF
--- a/cmake/BuildFreeDVBackend.cmake
+++ b/cmake/BuildFreeDVBackend.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     freedv_backend
     GIT_REPOSITORY https://github.com/tmiw/freedv-backend
-    GIT_TAG main
+    GIT_TAG ms-rade-text-payload-noise-var
 )
 
 FetchContent_MakeAvailable(freedv_backend)


### PR DESCRIPTION
## Summary
Test-only PR. Points the `FetchContent` `GIT_TAG` for freedv-backend at `ms-rade-text-payload-noise-var`, the branch backing tmiw/freedv-backend#34, so CI produces installers we can use to validate that fix in the actual app before it merges upstream.

**Not intended to merge as-is.** Once tmiw/freedv-backend#34 lands, this should either be closed or updated to point `GIT_TAG` back to `main`.

## Related
- tmiw/freedv-backend#34 — pools a payload-derived noise estimate into the RADE EOO callsign decode's `sigma2`, alongside the existing pilot-derived one, for LDPC(112,56) decode of the EOO text frame.

## Test plan
- [ ] CI builds installers for macOS/Windows/Linux from this branch
- [ ] Manually verify RADE callsign decode against known off-air recordings using the resulting build

🤖 Generated with [Claude Code](https://claude.com/claude-code)