### PR TITLE
Fix crash and long hang on main window close with an unresponsive rig

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -969,6 +969,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix right-click context menus dismissing before they can be read (GTK) (PR #1437) - thanks @barjac!
     * Unconditionally add new station to Heard Station list if first heard. (PR #1444)
     * Fix heard-stations callsign combo stuck-highlight, right-click behaviour, and a stale-index crash (PR #1448) - thanks @barjac!
+    * Fix crash and long hang on main window close with an unresponsive rig (PR #1452) - thanks @barjac!
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2445,23 +2445,39 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
 void MainFrame::topFrame_OnClose( wxCloseEvent& event )
 {
-    // Grab and save the final position explicitly rather than relying
-    // solely on OnMove's live tracking -- Close()/Destroy() below trigger
-    // one last stray wxEVT_MOVE reporting a position with the title bar's
-    // height already stripped off, so position tracking must be stopped
-    // first or that stray event silently overwrites the correct value
-    // saved here.
-    auto pos = m_reporterDialog->GetPosition();
-    wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
-    wxGetApp().appConfiguration.reporterWindowTop = pos.y;
-    m_reporterDialog->stopTrackingPosition();
+    if (terminating_)
+    {
+        // A previous close request already kicked off the async RX/PTT
+        // shutdown below, which calls Destroy() itself once done (see
+        // OnTogBtnOnOff()) -- nothing left to do here. Without this guard,
+        // a repeat close request while that shutdown is still in progress
+        // (e.g. slow Hamlib rig disconnect against an unresponsive radio)
+        // re-enters this handler with m_reporterDialog already null
+        // (cleared on the first pass below), crashing on the unconditional
+        // GetPosition() call.
+        return;
+    }
 
-    m_reporterDialog->setReporter(nullptr);
-    wxGetApp().SafeYield(nullptr, false); // make sure we handle any remaining Reporter messages before dispose
-    m_reporterDialog->Close();
-    m_reporterDialog->Destroy();
-    m_reporterDialog = nullptr;
-    
+    if (m_reporterDialog != nullptr)
+    {
+        // Grab and save the final position explicitly rather than relying
+        // solely on OnMove's live tracking -- Close()/Destroy() below trigger
+        // one last stray wxEVT_MOVE reporting a position with the title bar's
+        // height already stripped off, so position tracking must be stopped
+        // first or that stray event silently overwrites the correct value
+        // saved here.
+        auto pos = m_reporterDialog->GetPosition();
+        wxGetApp().appConfiguration.reporterWindowLeft = pos.x;
+        wxGetApp().appConfiguration.reporterWindowTop = pos.y;
+        m_reporterDialog->stopTrackingPosition();
+
+        m_reporterDialog->setReporter(nullptr);
+        wxGetApp().SafeYield(nullptr, false); // make sure we handle any remaining Reporter messages before dispose
+        m_reporterDialog->Close();
+        m_reporterDialog->Destroy();
+        m_reporterDialog = nullptr;
+    }
+
     if (m_RxRunning)
     {
         if (m_btnTogPTT->GetValue())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2449,12 +2449,13 @@ void MainFrame::topFrame_OnClose( wxCloseEvent& event )
     {
         // A previous close request already kicked off the async RX/PTT
         // shutdown below, which calls Destroy() itself once done (see
-        // OnTogBtnOnOff()) -- nothing left to do here. Without this guard,
-        // a repeat close request while that shutdown is still in progress
-        // (e.g. slow Hamlib rig disconnect against an unresponsive radio)
-        // re-enters this handler with m_reporterDialog already null
-        // (cleared on the first pass below), crashing on the unconditional
-        // GetPosition() call.
+        // OnTogBtnOnOff()) -- nothing left to do here. This guards more than
+        // just the m_reporterDialog dereference below: m_RxRunning isn't
+        // cleared until deep inside that shutdown (stopRxStream(), called
+        // after the rig-disconnect code), so a repeat close request arriving
+        // first would otherwise fall into the `if (m_RxRunning)` block again
+        // and re-enter OnTogBtnOnOff() a second time concurrently with the
+        // shutdown already in progress.
         return;
     }
 
@@ -2988,21 +2989,29 @@ void MainFrame::performFreeDVOff_()
     // last reference onto a detached thread so that wait can't hold up
     // turning the modem off (or app shutdown) -- the controller stays
     // alive exactly as long as it needs to, just off to the side rather
-    // than blocking here.
-    std::thread([ptr = std::move(wxGetApp().rigPttController)]() mutable
+    // than blocking here. The associated future lets a terminating shutdown
+    // (see OnTogBtnOnOff()) wait a bounded amount of time for this to finish
+    // before the process exits out from under the thread.
+    std::promise<void> pttDisconnectProm;
+    rigPttDisconnectFuture_ = pttDisconnectProm.get_future();
+    std::thread([ptr = std::move(wxGetApp().rigPttController), prom = std::move(pttDisconnectProm)]() mutable
     {
         SetThreadName("RigPttDisconnect");
         ptr = nullptr;
+        prom.set_value();
     }).detach();
 
     if (wxGetApp().rigFrequencyController != nullptr && wxGetApp().rigFrequencyController->isConnected())
     {
         wxGetApp().rigFrequencyController->disconnect();
     }
-    std::thread([ptr = std::move(wxGetApp().rigFrequencyController)]() mutable
+    std::promise<void> freqDisconnectProm;
+    rigFreqDisconnectFuture_ = freqDisconnectProm.get_future();
+    std::thread([ptr = std::move(wxGetApp().rigFrequencyController), prom = std::move(freqDisconnectProm)]() mutable
     {
         SetThreadName("RigFreqDisconnect");
         ptr = nullptr;
+        prom.set_value();
     }).detach();
 
     if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTTInput)
@@ -3123,7 +3132,27 @@ void MainFrame::OnTogBtnOnOff(wxCommandEvent&)
             SetThreadName("TurningOff");
 
             performFreeDVOff_();
-            
+
+            if (terminating_)
+            {
+                // We're about to destroy the frame and let the process exit,
+                // which would kill the detached rig-disconnect threads from
+                // performFreeDVOff_() mid-flight if a slow/unresponsive rig
+                // hasn't finished with them yet -- e.g. a queued ptt(false)
+                // might never reach the radio. Give them a bounded chance to
+                // finish first; an unresponsive rig still can't hang shutdown
+                // indefinitely, it just gets abandoned after the grace period.
+                auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+                if (rigPttDisconnectFuture_.valid())
+                {
+                    rigPttDisconnectFuture_.wait_until(deadline);
+                }
+                if (rigFreqDisconnectFuture_.valid())
+                {
+                    rigFreqDisconnectFuture_.wait_until(deadline);
+                }
+            }
+
             // On/Off actions complete, re-enable button.
             executeOnUiThreadAndWait_([&]() {
                 m_togBtnAnalog->Enable(m_RxRunning);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2979,13 +2979,31 @@ void MainFrame::performFreeDVOff_()
         wxGetApp().rigPttController->ptt(false);
         wxGetApp().rigPttController->disconnect();
     }
-    wxGetApp().rigPttController = nullptr;
+    // Dropping the last shared_ptr reference below runs the controller's
+    // destructor, which blocks until the rig actually finishes
+    // disconnecting. Against an unresponsive radio (e.g. powered off, via
+    // rigctld) that can take far longer than Hamlib's own client-side
+    // timeout/retry settings suggest, since those don't bound however long
+    // rigctld itself waits on the physical radio it's talking to. Move the
+    // last reference onto a detached thread so that wait can't hold up
+    // turning the modem off (or app shutdown) -- the controller stays
+    // alive exactly as long as it needs to, just off to the side rather
+    // than blocking here.
+    std::thread([ptr = std::move(wxGetApp().rigPttController)]() mutable
+    {
+        SetThreadName("RigPttDisconnect");
+        ptr = nullptr;
+    }).detach();
 
     if (wxGetApp().rigFrequencyController != nullptr && wxGetApp().rigFrequencyController->isConnected())
     {
         wxGetApp().rigFrequencyController->disconnect();
     }
-    wxGetApp().rigFrequencyController = nullptr;
+    std::thread([ptr = std::move(wxGetApp().rigFrequencyController)]() mutable
+    {
+        SetThreadName("RigFreqDisconnect");
+        ptr = nullptr;
+    }).detach();
 
     if (wxGetApp().appConfiguration.rigControlConfiguration.useSerialPTTInput)
     {

--- a/src/main.h
+++ b/src/main.h
@@ -49,6 +49,7 @@
 #include <wx/numformatter.h>
 
 #include <stdint.h>
+#include <future>
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
 #include <cpuid.h>
 #endif
@@ -623,6 +624,15 @@ class MainFrame : public TopFrame
         bool terminating_; // used for terminating FreeDV
         bool realigned_; // used to inhibit resize hack once already done
         bool syncState_; // GUI copy of current sync state
+
+        // Signalled once the detached rig PTT/frequency controller disconnect
+        // threads (see performFreeDVOff_()) finish tearing down. Only waited on,
+        // with a bounded timeout, when terminating_ is set -- lets a responsive
+        // rig disconnect cleanly before the process exits out from under the
+        // detached thread, without reintroducing an unbounded hang against an
+        // unresponsive one.
+        std::future<void> rigPttDisconnectFuture_;
+        std::future<void> rigFreqDisconnectFuture_;
 
         // Caches appConfiguration.experimentalFeatures as of the last tab layout load
         // attempt, so exit-time save uses that instead of a possibly-since-toggled live


### PR DESCRIPTION
## Summary
- Fix a SIGSEGV in `MainFrame::topFrame_OnClose()` when a repeat close request arrives while the async RX/PTT shutdown from a first close is still in progress -- `m_reporterDialog` is already null by the second entry, and the unconditional `GetPosition()` call on it crashes, skipping window position save to config.
- Stop turning the modem off (whether via the Stop Modem button or app close) from blocking on rig disconnect against an unresponsive radio (e.g. powered off, connected via `rigctld`) -- this could hang for over a minute with no feedback to the user, since Hamlib's own client-side timeout/retry settings don't bound how long `rigctld` itself waits on the physical radio.

## Test plan
- [x] Radio on, Hamlib happy, modem stopped -> close: immediate, single click.
- [x] Radio on, Hamlib happy, modem running -> close: single click, brief delay while rig returns to previous frequency.
- [x] Radio off (via rigctld), modem running -> close, then close again while shutdown still in progress: no crash, no hang, closes promptly; window position/size correctly saved to config in all cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)