### PR TITLE
Fix Radio Frequency coloring on dark/light mode transition.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -970,6 +970,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Unconditionally add new station to Heard Station list if first heard. (PR #1444)
     * Fix heard-stations callsign combo stuck-highlight, right-click behaviour, and a stale-index crash (PR #1448) - thanks @barjac!
     * Fix crash and long hang on main window close with an unresponsive rig (PR #1452) - thanks @barjac!
+    * Fix Radio Frequency coloring on dark/light mode transition. (PR #1453)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -471,7 +471,7 @@ void PlotWaterfall::plotPixelData()
         index = px;
         assert(index < MODEM_STATS_NSPEC);
 
-        intensity = std::clamp((int)(intensity_per_dB * (m_magDb[index] - m_min_mag)), 0, 255);
+        intensity = (int)std::clamp((intensity_per_dB * (m_magDb[index] - m_min_mag)), 0.f, 255.f);
 
         int pixelPos = (px * 3);
             

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -2175,8 +2175,16 @@ void MainFrame::OnReportFrequencyKillFocus(wxFocusEvent& event)
 
 void MainFrame::OnSystemColorChanged(wxSysColourChangedEvent& event)
 {
-    // Works around issues on wxWidgets with certain controls not changing backgrounds
+    // Works around issues on wxWidgets with certain controls not changing colors
     // when the user switches between light and dark mode.
+    if (wxGetApp().appConfiguration.reportingConfiguration.reportingFrequency > 0)
+    {
+        m_cboReportFrequency->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    }
+    else
+    {
+        m_cboReportFrequency->SetForegroundColour(*wxRED);
+    }
     TopFrame::OnSystemColorChanged(event);
 }
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -852,7 +852,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     reportFrequencySizer->Add(txtReportFreqSizer, 1, static_cast<int>(wxEXPAND), 1);
     //reportFrequencySizer->Add(reportFrequencyUnits, 0, wxALIGN_CENTER_VERTICAL, 1);
     
-    rightSizer->Add(reportFrequencySizer, 0, static_cast<int>(wxALL), 2);
+    rightSizer->Add(reportFrequencySizer, 0, static_cast<int>(wxALL) | static_cast<int>(wxEXPAND), 2);
     
     /* new --- */
 


### PR DESCRIPTION
Discovered some preexisting sizing and coloring issues for the Radio Frequency box (see https://github.com/drowe67/freedv-gui/pull/1445#issuecomment-5188541669 for context). This PR resolves those as well as an unrelated UBSan error found in the last CI run.