### PR TITLE
Fix mode-status color not flagging Digital mode with LSB selected on radio

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -841,7 +841,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 ## V3.0.0 TBD 2026
 
 1. Enhancements:
-    * RADEV2: Standardize mode as USB. (PR #1397)
+    * RADEV2: Standardize mode as USB. (PR #1397, #1454)
     * Combine all configuration into Settings->Edit Settings. (PR #1418)
     * Rework Easy Setup window into new Setup Wizard. (PR #1418, #1432)
 2. Other:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -841,7 +841,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 ## V3.0.0 TBD 2026
 
 1. Enhancements:
-    * RADEV2: Standardize mode as USB. (PR #1397, #1454)
+    * RADEV2: Standardize mode as USB. (PR #1397, #1454) - thanks @barjac!
     * Combine all configuration into Settings->Edit Settings. (PR #1418)
     * Rework Easy Setup window into new Setup Wizard. (PR #1418, #1432)
 2. Other:

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -399,10 +399,10 @@ void MainFrame::onFrequencyModeChange_(IRigFrequencyController*, uint64_t freq, 
         bool isUsbFreq = newFreq >= 10000000 || is60MeterBand;
         bool isLsbFreq = newFreq < 10000000 && !is60MeterBand;
 
-        bool isMatchingMode = 
+        bool isMatchingMode =
             (!g_analog && (mode == IRigFrequencyController::USB || mode == IRigFrequencyController::DIGU)) ||
-            (isUsbFreq && (mode == IRigFrequencyController::USB)) ||
-            (isLsbFreq && (mode == IRigFrequencyController::LSB));
+            (g_analog && isUsbFreq && (mode == IRigFrequencyController::USB)) ||
+            (g_analog && isLsbFreq && (mode == IRigFrequencyController::LSB));
 
         if (isMatchingMode)
         {


### PR DESCRIPTION
## Summary
- In Digital mode, manually selecting LSB on the radio was not turning the mode-status text red, because the band-relative sideband-matching clauses in `onFrequencyModeChange_()` weren't gated on whether Analog mode is active.
- Gates the USB/LSB-frequency matching clauses on `g_analog`, so in Digital mode only USB/DIGU count as a match; any other reported mode (e.g. LSB) now correctly flags as a mismatch.

## Test plan
- [x] Built and tested locally against `v3.0-dev`
- [x] Manually selecting LSB on the radio while in Digital mode now shows the mode status in red
- [x] Switching from Analog to Digital still correctly switches the radio to USB, shown in black