### PR TITLE
Prevent PulseAudio/pipewire from quitting during CI tests.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -120,6 +120,13 @@ jobs:
            sudo apt-get install libpulse-dev sox git libasound2-dev libao-dev libgsm1-dev xvfb pulseaudio pulseaudio-utils metacity at-spi2-core libdbus-1-dev libgtk-3-dev python3 python3-dev python3-venv libebur128-dev pkg-config
            mkdir -p ~/.config/pulse
            echo "default-sample-rate = 48000" >~/.config/pulse/daemon.conf
+
+           # Prevent the socket-activated PulseAudio user service from exiting after its
+           # default 20s idle timeout -- if it exits between the TX and RX phases of a test,
+           # systemd respawns a fresh daemon with none of the pactl-loaded virtual devices,
+           # and the test fails with "device cannot be found" instead of a real failure.
+           echo "exit-idle-time = -1" >>~/.config/pulse/daemon.conf
+
            sudo sed 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa -i
            systemctl --user --now enable pulseaudio.service pulseaudio.socket
 
@@ -333,6 +340,13 @@ jobs:
       run: |
            mkdir -p ~/.config/pulse
            echo "default-sample-rate = 48000" >~/.config/pulse/daemon.conf
+
+           # Prevent the socket-activated PulseAudio user service from exiting after its
+           # default 20s idle timeout -- if it exits between the TX and RX phases of a test,
+           # systemd respawns a fresh daemon with none of the pactl-loaded virtual devices,
+           # and the test fails with "device cannot be found" instead of a real failure.
+           echo "exit-idle-time = -1" >>~/.config/pulse/daemon.conf
+
            sudo apt-get install pulseaudio pulseaudio-utils metacity
            sudo sed 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa -i
            systemctl --user --now enable pulseaudio.service pulseaudio.socket
@@ -501,6 +515,13 @@ jobs:
       run: |
            mkdir -p ~/.config/pulse
            echo "default-sample-rate = 48000" >~/.config/pulse/daemon.conf
+
+           # Prevent the socket-activated PulseAudio user service from exiting after its
+           # default 20s idle timeout -- if it exits between the TX and RX phases of a test,
+           # systemd respawns a fresh daemon with none of the pactl-loaded virtual devices,
+           # and the test fails with "device cannot be found" instead of a real failure.
+           echo "exit-idle-time = -1" >>~/.config/pulse/daemon.conf
+
            sudo apt-get install libwxgtk3.0-gtk3-dev pulseaudio 
            sudo sed 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa -i
            systemctl --user --now enable pulseaudio.service pulseaudio.socket

--- a/test/test_rade_loss.sh
+++ b/test/test_rade_loss.sh
@@ -91,7 +91,7 @@ RECORD_PID=$!
 
 # Start FreeDV in test mode to record TX
 TX_ARGS="-txfile $(pwd)/tx_in.wav -txfeaturefile $(pwd)/txfeatures.f32 "
-$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut tx -utmode RADEV1 $TX_ARGS >tmp.log 2>&1 &
+($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut tx -utmode RADEV1 $TX_ARGS 2>&1 | tee tmp.log) &
 
 FDV_PID=$!
 
@@ -105,14 +105,14 @@ FDV_PID=$!
 #pw-top -b -n 5
 wait $FDV_PID
 FREEDV_EXIT_CODE=$?
-cat tmp.log
+#cat tmp.log
 
 # Stop recording, play back in RX mode
 kill $RECORD_PID
 #cp $(pwd)/gmon.out $(pwd)/gmon.out.tx
 
 if [ $FREEDV_EXIT_CODE -eq 0 ]; then
-    $FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav -rxfeaturefile $(pwd)/rxfeatures.f32 >tmp.log 2>&1 &
+    ($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav -rxfeaturefile $(pwd)/rxfeatures.f32 2>&1 | tee tmp.log) &
     FDV_PID=$!
 
     #if [ "$OPERATING_SYSTEM" != "Linux" ]; then
@@ -120,7 +120,7 @@ if [ $FREEDV_EXIT_CODE -eq 0 ]; then
     #fi
     wait $FDV_PID
     FREEDV_EXIT_CODE=$?
-    cat tmp.log
+    #cat tmp.log
 
     # Run feature files through loss tool
     $PYTHON_BINARY $(pwd)/rade_src/loss.py txfeatures.f32 rxfeatures.f32 --loss_test 0.15

--- a/test/test_rade_reporting.sh
+++ b/test/test_rade_reporting.sh
@@ -105,7 +105,7 @@ if [ "$2" == "mpp" ]; then
 else
     TX_ARGS="-txtime 1 -txattempts 2 "
 fi
-$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut tx -utmode RADEV1 -txfile $(pwd)/rade_src/wav/mooneer.wav $TX_ARGS >tmp.log 2>&1 &
+($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut tx -utmode RADEV1 -txfile $(pwd)/rade_src/wav/mooneer.wav $TX_ARGS 2>&1 | tee tmp.log) &
 
 FDV_PID=$!
 
@@ -119,7 +119,7 @@ FDV_PID=$!
 #pw-top -b -n 5
 wait $FDV_PID
 FREEDV_EXIT_CODE=$?
-cat tmp.log
+#cat tmp.log
 
 # Stop recording, play back in RX mode
 kill $RECORD_PID
@@ -137,7 +137,7 @@ if [ $FREEDV_EXIT_CODE -eq 0 ]; then
         mv $(pwd)/testwithnoise.wav $(pwd)/test.wav
     fi
 
-    $FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav >tmp.log 2>&1 &
+    ($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut rx -utmode RADEV1 -rxfile $(pwd)/test.wav 2>&1 | tee tmp.log) &
     FDV_PID=$!
 
     #if [ "$OPERATING_SYSTEM" != "Linux" ]; then
@@ -145,7 +145,7 @@ if [ $FREEDV_EXIT_CODE -eq 0 ]; then
     #fi
     wait $FDV_PID
     FREEDV_EXIT_CODE=$?
-    cat tmp.log
+    #cat tmp.log
 fi
 
 # Clean up PulseAudio virtual devices

--- a/test/test_zeros.sh
+++ b/test/test_zeros.sh
@@ -108,7 +108,7 @@ if [ "$FREEDV_TEST" == "tx" ]; then
 fi
 
 # Start FreeDV in test mode
-($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut $FREEDV_TEST -utmode $FREEDV_MODE 2>&1 & | tee tmp.log) &
+($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut $FREEDV_TEST -utmode $FREEDV_MODE 2>&1 | tee tmp.log) &
 
 FDV_PID=$!
 

--- a/test/test_zeros.sh
+++ b/test/test_zeros.sh
@@ -108,7 +108,7 @@ if [ "$FREEDV_TEST" == "tx" ]; then
 fi
 
 # Start FreeDV in test mode
-$FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut $FREEDV_TEST -utmode $FREEDV_MODE >tmp.log 2>&1 & #| tee tmp.log
+($FREEDV_BINARY -f $(pwd)/$FREEDV_CONF_FILE -ut $FREEDV_TEST -utmode $FREEDV_MODE 2>&1 & | tee tmp.log) &
 
 FDV_PID=$!
 
@@ -122,7 +122,7 @@ FDV_PID=$!
 #pw-top -b -n 5
 wait $FDV_PID
 FREEDV_EXIT_STATUS=$?
-cat tmp.log
+#cat tmp.log
 
 # Stop recording/playback and process data
 if [ "$FREEDV_TEST" == "rx" ]; then


### PR DESCRIPTION
Ports Claude-assisted changes to CI from ms-rade-v2 to prevent PulseAudio/pipewire from quitting during tests (preventing a semi-common cause of CI failures).