### PR TITLE
Remove CLIP indicator from main window.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -986,6 +986,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Block special characters in recording file name suffixes and default the voice keyer file selector to show .wav and .mp3. (PR #1424) - thanks @barjac!
     * Fix Voice Keyer/PTT context menu positioning under native Wayland. (PR #1438) - thanks @barjac!
     * Automatically start decoding on FreeDV startup. (PR #1436)
+    * Remove "Clip" indicator from main window to reduce confusion. (PR #1461)
 3. Build system:
     * Clear CMake deprecation warnings in FreeDV. (PR #1383, #1386)
     * Upgrade Hamlib to 4.7.2. (PR #1413)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1240,7 +1240,6 @@ MainFrame::MainFrame(wxWindow *parent) : TopFrame(parent, wxID_ANY, _("FreeDV ")
     SYNC_UNK_LABEL("Sync: unk"),
     VAR_UNK_LABEL("Var: unk"),
     CLK_OFF_UNK_LABEL("ClkOff: unk"),
-    TOO_HIGH_LABEL("Clip"),
     MIC_SPKR_LEVEL_FORMAT_STR("%s%s"),
     DECIBEL_STR("dB"),
     CURRENT_TIME_FORMAT_STR("%s %s"),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2392,7 +2392,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         // Level Gauge -----------------------------------------------------------------------
 
         bool updated = false;
-        float tooHighThresh;
         if (timerId == ID_TIMER_DEMOD_IN && !txState && m_RxRunning)
         {
             // receive mode - display From Radio peaks
@@ -2406,7 +2405,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             if (maxDemodIn > m_maxLevel)
                 m_maxLevel = maxDemodIn;
 
-            tooHighThresh = FROM_RADIO_MAX;
             updated = true;
         }
         else if (timerId == ID_TIMER_SPEECH_IN)
@@ -2423,7 +2421,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             if (maxSpeechIn > m_maxLevel)
                 m_maxLevel = maxSpeechIn;
 
-           tooHighThresh = FROM_MIC_MAX;
            updated = true;
         }
 
@@ -2432,11 +2429,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             // Peak Reading meter: updates peaks immediately, then slowly decays
             int maxScaled = (int)(100.0 * ((float)m_maxLevel/32767.0));
             m_gaugeLevel->SetValue(maxScaled);
-            if (((float)maxScaled/100) > tooHighThresh)
-                m_textLevel->SetLabel(TOO_HIGH_LABEL);
-            else
-                m_textLevel->SetLabel(EMPTY_STR);
-
             m_maxLevel *= LEVEL_BETA;
         }
     }
@@ -2744,7 +2736,6 @@ void MainFrame::performFreeDVOn_()
     m_maxLevel = 0;
     executeOnUiThreadAndWait_([&]() 
     {
-        m_textLevel->SetLabel(wxT(""));
         m_gaugeLevel->SetValue(0);
         
         if (wxGetApp().logger != nullptr)

--- a/src/main.h
+++ b/src/main.h
@@ -545,7 +545,6 @@ class MainFrame : public TopFrame
         const wxString SYNC_UNK_LABEL;
         const wxString VAR_UNK_LABEL;
         const wxString CLK_OFF_UNK_LABEL;
-        const wxString TOO_HIGH_LABEL;
         const wxString MIC_SPKR_LEVEL_FORMAT_STR;
         const wxString DECIBEL_STR;
         const wxString CURRENT_TIME_FORMAT_STR;

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1650,7 +1650,6 @@ void MainFrame::togglePTT(void) {
     // reset level gauge
 
     m_maxLevel = 0;
-    m_textLevel->SetLabel(wxT(""));
     m_gaugeLevel->SetValue(0);
     
     // Report TX change to registered reporters

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -572,14 +572,10 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     wxStaticBox* levelBox = new wxStaticBox(m_panel, wxID_ANY, _("Level"), wxDefaultPosition, wxSize(100,-1));
     levelSizer = new wxStaticBoxSizer(levelBox, wxHORIZONTAL);
 
-    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(100,15), wxGA_SMOOTH);
-    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode.  If Red you should reduce your levels"));
+    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
+    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
     levelSizer->Add(m_gaugeLevel, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
     
-    m_textLevel = new wxStaticText(levelBox, wxID_ANY, wxT(""), wxDefaultPosition, wxSize(35,-1), wxALIGN_CENTRE);
-    m_textLevel->SetForegroundColour(wxColour(255,0,0));
-    levelSizer->Add(m_textLevel, 0, wxALIGN_CENTER_VERTICAL, 1);
-
     leftSizer->Add(levelSizer, 0, static_cast<int>(wxALL)|static_cast<int>(wxEXPAND), 2);
     
     //------------------------------

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -103,7 +103,6 @@ class TopFrame : public wxFrame
         wxStaticText* m_textSNR;
         wxCheckBox* m_ckboxSNR;
         wxGauge* m_gaugeLevel;
-        wxStaticText* m_textLevel;
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;


### PR DESCRIPTION
Based on feedback in #1459, this PR removes the CLIP indicator from the main window. Other issues with e.g. AGC will be handled separately.