### PR TITLE
Windows/macOS: Zero audio on startup.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -972,6 +972,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix crash and long hang on main window close with an unresponsive rig (PR #1452) - thanks @barjac!
     * Fix Radio Frequency coloring on dark/light mode transition. (PR #1453)
     * Fix FreeDV Reporter column-order corruption and Last TX column width. (PR #1458) - thanks @barjac!
+    * Windows/macOS: Zero audio on startup. (PR #1463)
 2. Enhancements:
     * Add UDP broadcast of received callsigns. (PR #1367)
     * Add Time-Out Timer (TOT) capability to FreeDV. (PR #1366, #1398, #1405) - thanks @barjac!

--- a/src/audio/MacAudioDevice.cpp
+++ b/src/audio/MacAudioDevice.cpp
@@ -358,6 +358,7 @@ void MacAudioDevice::start()
         // Allocate buffers
         inputFrames_ = new short[(maxFrameSize + 1) * numChannels_];
         assert(inputFrames_ != nullptr);
+        memset(inputFrames_, 0, sizeof(short) * (maxFrameSize + 1) * numChannels_);
 
         if (direction_ == IAudioEngine::AUDIO_ENGINE_IN)
         {

--- a/src/audio/WASAPIAudioDevice.cpp
+++ b/src/audio/WASAPIAudioDevice.cpp
@@ -331,6 +331,7 @@ void WASAPIAudioDevice::start()
         // Allocate temporary buffer
         tmpBuf_ = new short[sampleRate_];
         assert(tmpBuf_ != nullptr);
+        memset(tmpBuf_, 0, bufferFrameCount_ * numChannels_ * sizeof(short));
 
         if (direction_ == IAudioEngine::AUDIO_ENGINE_OUT)
         {
@@ -355,7 +356,6 @@ void WASAPIAudioDevice::start()
                 return;
             }
 
-            memset(tmpBuf_, 0, bufferFrameCount_ * numChannels_ * sizeof(short));
             if (onAudioDataFunction)
             {
                 onAudioDataFunction(*this, tmpBuf_, bufferFrameCount_, onAudioDataState);


### PR DESCRIPTION
Ports change from `ms-rade-v2` that moves where audio is zeroed out on startup (Windows) and adds logic to zero out audio (macOS). This is to avoid intermittent noise on startup as well as help prevent random colors in the waterfall.