### PR TITLE
An alternative TX mic level meter approach

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -87,16 +87,26 @@
 #define FROM_RADIO_MAX       0.8
 #define FROM_MIC_MAX         0.8
 
-// Running average (NOT an instantaneous peak-follower) of the level
-// meter's per-tick peaks, deliberately slow so a single loud
-// syllable/plosive gets smoothed into the average instead of individually
-// pegging the meter -- confirmed needed 2026-08-24: an instant-attack
-// design pegged on the 't' of "two" while ebumeter hadn't even reached
-// -23 LUFS and the pre-encode plot was well within normal limits. A
-// symmetric exponential average with tau=LEVEL_METER_TIME_CONSTANT_SEC;
-// the trade-off is added latency to genuine level changes, accepted
-// deliberately in exchange for not reacting to short-lived extremes.
-#define LEVEL_METER_TIME_CONSTANT_SEC 1.0
+// Running average (NOT a simple instantaneous peak-follower) of the level
+// meter's per-tick peaks. Uses an adaptive time constant rather than one
+// fixed value: slow (LEVEL_METER_TIME_CONSTANT_SEC) across the acceptable
+// LEVEL_METER_TARGET_LOW_PCT..HIGH_PCT range, so genuine level-setting is
+// smoothed against individual syllables/plosives (confirmed needed
+// 2026-08-24: a fixed instant-attack design pegged on the 't' of "two"
+// while ebumeter hadn't even reached -23 LUFS and the pre-encode plot was
+// well within normal limits) -- but fast (LEVEL_METER_FAST_TIME_CONSTANT_SEC)
+// below LEVEL_METER_RAMP_LOW_PCT or above LEVEL_METER_RAMP_HIGH_PCT, so the
+// meter snaps up quickly when speech starts from silence and doesn't hang
+// around in the red after a genuine overload, ramping linearly between the
+// two rates across LEVEL_METER_RAMP_LOW_PCT..TARGET_LOW_PCT and
+// LEVEL_METER_TARGET_HIGH_PCT..RAMP_HIGH_PCT. Which zone applies is decided
+// by the meter's own previous (already-smoothed) reading, not the raw
+// incoming peak, so the ramp itself moves gradually and doesn't flicker
+// between rates right at a boundary.
+#define LEVEL_METER_TIME_CONSTANT_SEC 1.5
+#define LEVEL_METER_FAST_TIME_CONSTANT_SEC 0.02
+#define LEVEL_METER_RAMP_LOW_PCT  15
+#define LEVEL_METER_RAMP_HIGH_PCT 85
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings
@@ -110,7 +120,9 @@
 
 // Acceptable-range marker drawn as a thin green strip below the level
 // meter's gauge, in % of the gauge's own 0-100 scale. Centred on the
-// ~50% mid-scale target from LEVEL_METER_REFERENCE_DB above.
+// ~50% mid-scale target from LEVEL_METER_REFERENCE_DB above. Also used
+// as the inner edge of the adaptive time-constant ramp above, so the
+// meter's slowest ballistics line up exactly with the visible green zone.
 #define LEVEL_METER_TARGET_LOW_PCT  30
 #define LEVEL_METER_TARGET_HIGH_PCT 70
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -96,7 +96,7 @@
 // symmetric exponential average with tau=LEVEL_METER_TIME_CONSTANT_SEC;
 // the trade-off is added latency to genuine level changes, accepted
 // deliberately in exchange for not reacting to short-lived extremes.
-#define LEVEL_METER_TIME_CONSTANT_SEC 2.0
+#define LEVEL_METER_TIME_CONSTANT_SEC 1.0
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings
@@ -107,6 +107,12 @@
 // gauge-contamination bug fixed, -23 LUFS measured ~20% on the old 0dBFS
 // scale; -8dB brings that to ~50%.
 #define LEVEL_METER_REFERENCE_DB (-8.0)
+
+// Acceptable-range marker drawn as a thin green strip above the level
+// meter's gauge, in % of the gauge's own 0-100 scale. Centred on the
+// ~50% mid-scale target from LEVEL_METER_REFERENCE_DB above.
+#define LEVEL_METER_TARGET_LOW_PCT  40
+#define LEVEL_METER_TARGET_HIGH_PCT 60
 
 // TX Attenuation (0.1 dB increments)
 #define TX_ATTENUATION_MIN (-300) /* -30 dB */

--- a/src/defines.h
+++ b/src/defines.h
@@ -87,14 +87,16 @@
 #define FROM_RADIO_MAX       0.8
 #define FROM_MIC_MAX         0.8
 
-// PPM-style ballistics for the peak level meter: instant attack (jump
-// straight to each tick's peak, catching transients with no added latency),
-// release at a fixed dB/sec rate (a straight-line fall, not an average --
-// avoids the bounce/latency a running average causes). 15dB/sec is in the
-// range typical broadcast PPMs use (IEC 60268-10 ballpark). The original
-// peak-hold code effectively released at ~0.87dB/sec (0.99 per 100ms
-// tick), which is why a transient used to visibly linger for ~20+ seconds.
-#define LEVEL_METER_RELEASE_DB_PER_SEC 15.0
+// Running average (NOT an instantaneous peak-follower) of the level
+// meter's per-tick peaks, deliberately slow so a single loud
+// syllable/plosive gets smoothed into the average instead of individually
+// pegging the meter -- confirmed needed 2026-08-24: an instant-attack
+// design pegged on the 't' of "two" while ebumeter hadn't even reached
+// -23 LUFS and the pre-encode plot was well within normal limits. A
+// symmetric exponential average with tau=LEVEL_METER_TIME_CONSTANT_SEC;
+// the trade-off is added latency to genuine level changes, accepted
+// deliberately in exchange for not reacting to short-lived extremes.
+#define LEVEL_METER_TIME_CONSTANT_SEC 2.0
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings

--- a/src/defines.h
+++ b/src/defines.h
@@ -92,6 +92,16 @@
 // ~300ms rise/fall time constant at our DT=100ms update rate.
 #define LEVEL_METER_ALPHA    0.28
 
+// dBFS level that maps to 100% on the TX level meter's scale, set below
+// true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings
+// around half scale (matching the old meter's look/feel that users are
+// used to), while genuine full-scale peaks still show above the old
+// meter's normal operating range instead of pegging at the same point as
+// everyday speech. -8dB chosen empirically (2026-08-24): with the RX/TX
+// gauge-contamination bug fixed, -23 LUFS measured ~20% on the old 0dBFS
+// scale; -8dB brings that to ~50%.
+#define LEVEL_METER_REFERENCE_DB (-8.0)
+
 // TX Attenuation (0.1 dB increments)
 #define TX_ATTENUATION_MIN (-300) /* -30 dB */
 #define TX_ATTENUATION_MAX (0)

--- a/src/defines.h
+++ b/src/defines.h
@@ -106,7 +106,7 @@
 // everyday speech. -8dB chosen empirically (2026-08-24): with the RX/TX
 // gauge-contamination bug fixed, -23 LUFS measured ~20% on the old 0dBFS
 // scale; -8dB brings that to ~50%.
-#define LEVEL_METER_REFERENCE_DB (-8.0)
+#define LEVEL_METER_REFERENCE_DB (-11.0)
 
 // Acceptable-range marker drawn as a thin green strip below the level
 // meter's gauge, in % of the gauge's own 0-100 scale. Centred on the

--- a/src/defines.h
+++ b/src/defines.h
@@ -106,7 +106,7 @@
 // everyday speech. -8dB chosen empirically (2026-08-24): with the RX/TX
 // gauge-contamination bug fixed, -23 LUFS measured ~20% on the old 0dBFS
 // scale; -8dB brings that to ~50%.
-#define LEVEL_METER_REFERENCE_DB (-5.0)
+#define LEVEL_METER_REFERENCE_DB (-6.0)
 
 // Acceptable-range marker drawn as a thin green strip below the level
 // meter's gauge, in % of the gauge's own 0-100 scale. Centred on the

--- a/src/defines.h
+++ b/src/defines.h
@@ -86,7 +86,11 @@
 // Level Gauge
 #define FROM_RADIO_MAX       0.8
 #define FROM_MIC_MAX         0.8
-#define LEVEL_BETA           0.99
+
+// Moving-average ("moving coil meter") ballistics for the peak level meter.
+// alpha = 1 - exp(-DT/tau), with tau=0.3s approximating a real VU meter's
+// ~300ms rise/fall time constant at our DT=100ms update rate.
+#define LEVEL_METER_ALPHA    0.28
 
 // TX Attenuation (0.1 dB increments)
 #define TX_ATTENUATION_MIN (-300) /* -30 dB */

--- a/src/defines.h
+++ b/src/defines.h
@@ -102,9 +102,16 @@
 // LEVEL_METER_TARGET_HIGH_PCT..RAMP_HIGH_PCT. Which zone applies is decided
 // by the meter's own previous (already-smoothed) reading, not the raw
 // incoming peak, so the ramp itself moves gradually and doesn't flicker
-// between rates right at a boundary.
+// between rates right at a boundary. LEVEL_METER_FAST_TIME_CONSTANT_SEC
+// must stay comfortably above DT (the ~100ms tick period) -- a value much
+// smaller than one tick gives the EMA essentially no memory between ticks
+// (alpha -> 1), so it just displays whichever single 100ms window's raw
+// peak happened to land; a lone plosive/quiet gap could then snap the
+// meter straight to an end-stop or straight to zero with nothing to damp
+// it (confirmed 2026-08-27: seen live with the original 0.02s value).
+// 0.15s (~1.5 ticks) still reads as snappy but blends 2-3 windows.
 #define LEVEL_METER_TIME_CONSTANT_SEC 1.5
-#define LEVEL_METER_FAST_TIME_CONSTANT_SEC 0.02
+#define LEVEL_METER_FAST_TIME_CONSTANT_SEC 0.15
 #define LEVEL_METER_RAMP_LOW_PCT  15
 #define LEVEL_METER_RAMP_HIGH_PCT 85
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -108,11 +108,11 @@
 // scale; -8dB brings that to ~50%.
 #define LEVEL_METER_REFERENCE_DB (-8.0)
 
-// Acceptable-range marker drawn as a thin green strip above the level
+// Acceptable-range marker drawn as a thin green strip below the level
 // meter's gauge, in % of the gauge's own 0-100 scale. Centred on the
 // ~50% mid-scale target from LEVEL_METER_REFERENCE_DB above.
-#define LEVEL_METER_TARGET_LOW_PCT  40
-#define LEVEL_METER_TARGET_HIGH_PCT 60
+#define LEVEL_METER_TARGET_LOW_PCT  30
+#define LEVEL_METER_TARGET_HIGH_PCT 70
 
 // TX Attenuation (0.1 dB increments)
 #define TX_ATTENUATION_MIN (-300) /* -30 dB */

--- a/src/defines.h
+++ b/src/defines.h
@@ -106,7 +106,7 @@
 // everyday speech. -8dB chosen empirically (2026-08-24): with the RX/TX
 // gauge-contamination bug fixed, -23 LUFS measured ~20% on the old 0dBFS
 // scale; -8dB brings that to ~50%.
-#define LEVEL_METER_REFERENCE_DB (-11.0)
+#define LEVEL_METER_REFERENCE_DB (-5.0)
 
 // Acceptable-range marker drawn as a thin green strip below the level
 // meter's gauge, in % of the gauge's own 0-100 scale. Centred on the

--- a/src/defines.h
+++ b/src/defines.h
@@ -96,7 +96,7 @@
 // symmetric exponential average with tau=LEVEL_METER_TIME_CONSTANT_SEC;
 // the trade-off is added latency to genuine level changes, accepted
 // deliberately in exchange for not reacting to short-lived extremes.
-#define LEVEL_METER_TIME_CONSTANT_SEC 0.5
+#define LEVEL_METER_TIME_CONSTANT_SEC 1.0
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings

--- a/src/defines.h
+++ b/src/defines.h
@@ -96,7 +96,7 @@
 // symmetric exponential average with tau=LEVEL_METER_TIME_CONSTANT_SEC;
 // the trade-off is added latency to genuine level changes, accepted
 // deliberately in exchange for not reacting to short-lived extremes.
-#define LEVEL_METER_TIME_CONSTANT_SEC 1.0
+#define LEVEL_METER_TIME_CONSTANT_SEC 0.5
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings

--- a/src/defines.h
+++ b/src/defines.h
@@ -87,10 +87,14 @@
 #define FROM_RADIO_MAX       0.8
 #define FROM_MIC_MAX         0.8
 
-// Moving-average ("moving coil meter") ballistics for the peak level meter.
-// alpha = 1 - exp(-DT/tau), with tau=0.3s approximating a real VU meter's
-// ~300ms rise/fall time constant at our DT=100ms update rate.
-#define LEVEL_METER_ALPHA    0.28
+// PPM-style ballistics for the peak level meter: instant attack (jump
+// straight to each tick's peak, catching transients with no added latency),
+// release at a fixed dB/sec rate (a straight-line fall, not an average --
+// avoids the bounce/latency a running average causes). 15dB/sec is in the
+// range typical broadcast PPMs use (IEC 60268-10 ballpark). The original
+// peak-hold code effectively released at ~0.87dB/sec (0.99 per 100ms
+// tick), which is why a transient used to visibly linger for ~20+ seconds.
+#define LEVEL_METER_RELEASE_DB_PER_SEC 15.0
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings

--- a/src/defines.h
+++ b/src/defines.h
@@ -94,24 +94,33 @@
 // smoothed against individual syllables/plosives (confirmed needed
 // 2026-08-24: a fixed instant-attack design pegged on the 't' of "two"
 // while ebumeter hadn't even reached -23 LUFS and the pre-encode plot was
-// well within normal limits) -- but fast (LEVEL_METER_FAST_TIME_CONSTANT_SEC)
-// below LEVEL_METER_RAMP_LOW_PCT or above LEVEL_METER_RAMP_HIGH_PCT, so the
-// meter snaps up quickly when speech starts from silence and doesn't hang
-// around in the red after a genuine overload, ramping linearly between the
-// two rates across LEVEL_METER_RAMP_LOW_PCT..TARGET_LOW_PCT and
+// well within normal limits) -- but fast below LEVEL_METER_RAMP_LOW_PCT
+// (LEVEL_METER_FAST_LOW_TIME_CONSTANT_SEC) or above LEVEL_METER_RAMP_HIGH_PCT
+// (LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC -- deliberately slower than the
+// low end, see below), so the meter snaps up quickly when speech starts
+// from silence and doesn't hang around in the red after a genuine
+// overload, ramping linearly between the two rates across
+// LEVEL_METER_RAMP_LOW_PCT..TARGET_LOW_PCT and
 // LEVEL_METER_TARGET_HIGH_PCT..RAMP_HIGH_PCT. Which zone applies is decided
 // by the meter's own previous (already-smoothed) reading, not the raw
 // incoming peak, so the ramp itself moves gradually and doesn't flicker
-// between rates right at a boundary. LEVEL_METER_FAST_TIME_CONSTANT_SEC
-// must stay comfortably above DT (the ~100ms tick period) -- a value much
-// smaller than one tick gives the EMA essentially no memory between ticks
+// between rates right at a boundary. Both fast constants must stay
+// comfortably above DT (the ~100ms tick period) -- a value much smaller
+// than one tick gives the EMA essentially no memory between ticks
 // (alpha -> 1), so it just displays whichever single 100ms window's raw
 // peak happened to land; a lone plosive/quiet gap could then snap the
 // meter straight to an end-stop or straight to zero with nothing to damp
-// it (confirmed 2026-08-27: seen live with the original 0.02s value).
-// 0.15s (~1.5 ticks) still reads as snappy but blends 2-3 windows.
+// it (confirmed 2026-08-27: seen live with the original single 0.02s
+// value used at both ends).
 #define LEVEL_METER_TIME_CONSTANT_SEC 1.5
-#define LEVEL_METER_FAST_TIME_CONSTANT_SEC 0.15
+// Low end (near silence): 0.15s (~1.5 ticks) reads as snappy but still
+// blends 2-3 windows.
+#define LEVEL_METER_FAST_LOW_TIME_CONSTANT_SEC 0.15
+// High end (at/above overload): kept deliberately slower than the low end
+// -- test value, raised from 0.15s on the theory that a too-fast release
+// out of the red risks the meter dropping away before a genuine overload
+// has actually registered with the user.
+#define LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC 0.5
 #define LEVEL_METER_RAMP_LOW_PCT  15
 #define LEVEL_METER_RAMP_HIGH_PCT 85
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -122,7 +122,21 @@
 // has actually registered with the user.
 #define LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC 0.5
 #define LEVEL_METER_RAMP_LOW_PCT  15
-#define LEVEL_METER_RAMP_HIGH_PCT 85
+// High-end ramp taken all the way to 100% (the scale's ceiling) rather
+// than stopping at 85% -- with the ramp ending at 85%, the last 15% of
+// scale was already flat at the fully-fast
+// LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC rate, which read as a rapid
+// jump once a loud excursion crossed 85%. Extending the ramp's top edge
+// to 100% keeps tau decreasing all the way to the ceiling, so the meter
+// keeps damping itself further into the red instead of hitting full
+// responsiveness 15% of the scale early. Safe even for genuine clipping
+// readings above 100% (m_maxLevel/prevPct are not clamped) because the
+// `prevPct >= LEVEL_METER_RAMP_HIGH_PCT` flat-tau branch still catches
+// everything at or above this boundary before the ramp's linear
+// interpolation is evaluated, so tau can never extrapolate past
+// LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC. Confirmed on-air 2026-08-29
+// on the sibling v3.0-dev+PR-1464 build.
+#define LEVEL_METER_RAMP_HIGH_PCT 100
 
 // dBFS level that maps to 100% on the TX level meter's scale, set below
 // true digital full scale (0 dBFS) so a nominal -23 LUFS test signal swings

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2450,16 +2450,39 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
         if (updated)
         {
-            // Running average of tickPeak, deliberately slow (see
-            // LEVEL_METER_TIME_CONSTANT_SEC in defines.h) so brief
-            // transients wash out instead of individually pegging the
-            // meter -- this is NOT a peak-follower.
-            static const float levelMeterAlpha = 1.0f - expf(-(float)DT / (float)LEVEL_METER_TIME_CONSTANT_SEC);
-            m_maxLevel += ((float)tickPeak - m_maxLevel) * levelMeterAlpha;
-
             // 100% maps to LEVEL_METER_REFERENCE_DB, not true 0dBFS -- see
             // that constant's comment in defines.h for why.
             static const float levelMeterRefAmplitude = 32767.0f * powf(10.0f, (float)LEVEL_METER_REFERENCE_DB / 20.0f);
+
+            // Adaptive time constant (see defines.h): slow through the
+            // acceptable TARGET_LOW..HIGH_PCT range, fast outside
+            // RAMP_LOW..HIGH_PCT, ramping linearly between. Keyed off the
+            // meter's own previous reading (not tickPeak) so the ramp
+            // itself can't flicker tick-to-tick right at a boundary.
+            float prevPct = 100.0f * ((float)m_maxLevel / levelMeterRefAmplitude);
+            float tau;
+            if (prevPct <= LEVEL_METER_RAMP_LOW_PCT || prevPct >= LEVEL_METER_RAMP_HIGH_PCT)
+            {
+                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC;
+            }
+            else if (prevPct < LEVEL_METER_TARGET_LOW_PCT)
+            {
+                float frac = (prevPct - LEVEL_METER_RAMP_LOW_PCT) / (float)(LEVEL_METER_TARGET_LOW_PCT - LEVEL_METER_RAMP_LOW_PCT);
+                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_TIME_CONSTANT_SEC);
+            }
+            else if (prevPct > LEVEL_METER_TARGET_HIGH_PCT)
+            {
+                float frac = (LEVEL_METER_RAMP_HIGH_PCT - prevPct) / (float)(LEVEL_METER_RAMP_HIGH_PCT - LEVEL_METER_TARGET_HIGH_PCT);
+                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_TIME_CONSTANT_SEC);
+            }
+            else
+            {
+                tau = LEVEL_METER_TIME_CONSTANT_SEC;
+            }
+
+            float levelMeterAlpha = 1.0f - expf(-(float)DT / tau);
+            m_maxLevel += ((float)tickPeak - m_maxLevel) * levelMeterAlpha;
+
             int maxScaled = (int)(100.0 * ((float)m_maxLevel/levelMeterRefAmplitude));
             maxScaled = std::min(maxScaled, 100);
             m_gaugeLevel->SetValue(maxScaled);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2404,9 +2404,13 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
         bool updated = false;
         int tickPeak = 0;
-        if (timerId == ID_TIMER_DEMOD_IN && !txState && m_RxRunning)
+        if (timerId == ID_TIMER_DEMOD_IN && !g_tx.load(std::memory_order_relaxed) && m_RxRunning)
         {
             // receive mode - display From Radio peaks
+            // Note: txState is a per-call local only populated when timerId
+            // is ID_TIMER_UPDATE_OTHER/ID_TIMER_SNR, so it's stale (always
+            // false) here -- read g_tx directly instead, otherwise this
+            // branch also fires during TX and stomps the TX mic reading.
             // peak from this DT sampling period
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
                 if (tickPeak < abs(demodInPlotSamples[i]))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2418,10 +2418,10 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
                     tickPeak = abs(demodInPlotSamples[i]);
 
             // Target-range marker is TX-only.
-            if (m_levelTargetMarker->IsShown())
+            if (m_levelTargetMarkerActive)
             {
-                m_levelTargetMarker->Hide();
-                m_levelTargetMarker->GetParent()->Layout();
+                m_levelTargetMarkerActive = false;
+                m_levelTargetMarker->Refresh();
             }
 
             updated = true;
@@ -2439,22 +2439,10 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
                 if (tickPeak < abs(levelMeterMicSamples[i]))
                     tickPeak = abs(levelMeterMicSamples[i]);
 
-            if (!m_levelTargetMarker->IsShown())
+            if (!m_levelTargetMarkerActive)
             {
-                m_levelTargetMarker->Show();
-                m_levelTargetMarker->GetParent()->Layout();
-
-                // DIAGNOSTIC ONLY: previous geometry log was captured while
-                // still hidden (GTK doesn't allocate hidden widgets, so it
-                // read back as (0,0)) -- log again now that it's actually
-                // visible, to see the real position/size once shown.
-                wxSize gaugeSz = m_gaugeLevel->GetSize();
-                wxPoint gaugePos = m_gaugeLevel->GetPosition();
-                wxSize markerSz = m_levelTargetMarker->GetSize();
-                wxPoint markerPos = m_levelTargetMarker->GetPosition();
-                log_debug("LevelBox geometry (on TX show): gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
-                    gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
-                    markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
+                m_levelTargetMarkerActive = true;
+                m_levelTargetMarker->Refresh();
             }
 
            updated = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2437,12 +2437,12 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
         if (updated)
         {
-            // PPM-style ballistics: instant attack (jump straight to a new
-            // peak), fixed dB/sec release (a straight-line fall rather than
-            // a running average, so it doesn't bounce/lag chasing dips --
-            // see LEVEL_METER_RELEASE_DB_PER_SEC in defines.h).
-            static const float levelMeterReleaseFactor = powf(10.0f, -(float)(LEVEL_METER_RELEASE_DB_PER_SEC * DT) / 20.0f);
-            m_maxLevel = std::max((float)tickPeak, m_maxLevel * levelMeterReleaseFactor);
+            // Running average of tickPeak, deliberately slow (see
+            // LEVEL_METER_TIME_CONSTANT_SEC in defines.h) so brief
+            // transients wash out instead of individually pegging the
+            // meter -- this is NOT a peak-follower.
+            static const float levelMeterAlpha = 1.0f - expf(-(float)DT / (float)LEVEL_METER_TIME_CONSTANT_SEC);
+            m_maxLevel += ((float)tickPeak - m_maxLevel) * levelMeterAlpha;
 
             // 100% maps to LEVEL_METER_REFERENCE_DB, not true 0dBFS -- see
             // that constant's comment in defines.h for why.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,10 @@ GenericFIFO<short>  g_plotDemodInFifo(PLOT_BUF_MULTIPLIER*WAVEFORM_PLOT_BUF);
 GenericFIFO<short>  g_plotSpeechOutFifo(PLOT_BUF_MULTIPLIER*WAVEFORM_PLOT_BUF);
 GenericFIFO<short>  g_plotSpeechInFifo(PLOT_BUF_MULTIPLIER*WAVEFORM_PLOT_BUF);
 
+// Separate pre-AGC/pre-EQ tap for the TX level meter, so it reflects true
+// mic drive rather than the "Frm Mic" plot's post-AGC/EQ encoder input.
+GenericFIFO<short>  g_levelMeterMicFifo(PLOT_BUF_MULTIPLIER*WAVEFORM_PLOT_BUF);
+
 // Soundcard config
 int                 g_nSoundCards;
 
@@ -1834,6 +1838,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
     short speechInPlotSamples[WAVEFORM_PLOT_BUF];
     short speechOutPlotSamples[WAVEFORM_PLOT_BUF];
     short demodInPlotSamples[WAVEFORM_PLOT_BUF];
+    short levelMeterMicSamples[WAVEFORM_PLOT_BUF];
     bool txState = false;
     bool halfDuplexState = false;
     int syncState = 0;
@@ -2411,12 +2416,16 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         }
         else if (timerId == ID_TIMER_SPEECH_IN)
         {
-            // transmit mode - display From Mic peaks
+            // transmit mode - display true mic drive (pre-AGC/EQ), separate
+            // from the "Frm Mic" plot which shows post-AGC/EQ encoder input.
+            if (g_levelMeterMicFifo.read(levelMeterMicSamples, WAVEFORM_PLOT_BUF)) {
+                memset(levelMeterMicSamples, 0, WAVEFORM_PLOT_BUF*sizeof(short));
+            }
 
             // peak from this DT sampling period
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
-                if (tickPeak < abs(speechInPlotSamples[i]))
-                    tickPeak = abs(speechInPlotSamples[i]);
+                if (tickPeak < abs(levelMeterMicSamples[i]))
+                    tickPeak = abs(levelMeterMicSamples[i]);
 
            updated = true;
         }
@@ -2599,6 +2608,7 @@ void MainFrame::performFreeDVOn_()
         g_plotDemodInFifo.reset();
         g_plotSpeechOutFifo.reset();
         g_plotSpeechInFifo.reset();
+        g_levelMeterMicFifo.reset();
 
         m_txtCtrlCallSign->SetValue(wxT(""));
         m_lastReportedCallsignListView->DeleteAllItems();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2417,6 +2417,13 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
                 if (tickPeak < abs(demodInPlotSamples[i]))
                     tickPeak = abs(demodInPlotSamples[i]);
 
+            // Target-range marker is TX-only.
+            if (m_levelTargetMarker->IsShown())
+            {
+                m_levelTargetMarker->Hide();
+                m_levelTargetMarker->GetParent()->Layout();
+            }
+
             updated = true;
         }
         else if (timerId == ID_TIMER_SPEECH_IN)
@@ -2431,6 +2438,12 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
                 if (tickPeak < abs(levelMeterMicSamples[i]))
                     tickPeak = abs(levelMeterMicSamples[i]);
+
+            if (!m_levelTargetMarker->IsShown())
+            {
+                m_levelTargetMarker->Show();
+                m_levelTargetMarker->GetParent()->Layout();
+            }
 
            updated = true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 //==========================================================================
 
 #include <algorithm>
+#include <cmath>
 #include <inttypes.h>
 #include <time.h>
 #include <fstream>
@@ -2443,7 +2444,12 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             // in both directions, approximating a real VU meter's needle
             // swing (see LEVEL_METER_ALPHA in defines.h).
             m_maxLevel += (tickPeak - m_maxLevel) * LEVEL_METER_ALPHA;
-            int maxScaled = (int)(100.0 * ((float)m_maxLevel/32767.0));
+
+            // 100% maps to LEVEL_METER_REFERENCE_DB, not true 0dBFS -- see
+            // that constant's comment in defines.h for why.
+            static const float levelMeterRefAmplitude = 32767.0f * powf(10.0f, (float)LEVEL_METER_REFERENCE_DB / 20.0f);
+            int maxScaled = (int)(100.0 * ((float)m_maxLevel/levelMeterRefAmplitude));
+            maxScaled = std::min(maxScaled, 100);
             m_gaugeLevel->SetValue(maxScaled);
 
             // DIAGNOSTIC ONLY: confirm whether a low reading traces back to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2461,19 +2461,23 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             // itself can't flicker tick-to-tick right at a boundary.
             float prevPct = 100.0f * ((float)m_maxLevel / levelMeterRefAmplitude);
             float tau;
-            if (prevPct <= LEVEL_METER_RAMP_LOW_PCT || prevPct >= LEVEL_METER_RAMP_HIGH_PCT)
+            if (prevPct <= LEVEL_METER_RAMP_LOW_PCT)
             {
-                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC;
+                tau = LEVEL_METER_FAST_LOW_TIME_CONSTANT_SEC;
+            }
+            else if (prevPct >= LEVEL_METER_RAMP_HIGH_PCT)
+            {
+                tau = LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC;
             }
             else if (prevPct < LEVEL_METER_TARGET_LOW_PCT)
             {
                 float frac = (prevPct - LEVEL_METER_RAMP_LOW_PCT) / (float)(LEVEL_METER_TARGET_LOW_PCT - LEVEL_METER_RAMP_LOW_PCT);
-                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_TIME_CONSTANT_SEC);
+                tau = LEVEL_METER_FAST_LOW_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_LOW_TIME_CONSTANT_SEC);
             }
             else if (prevPct > LEVEL_METER_TARGET_HIGH_PCT)
             {
                 float frac = (LEVEL_METER_RAMP_HIGH_PCT - prevPct) / (float)(LEVEL_METER_RAMP_HIGH_PCT - LEVEL_METER_TARGET_HIGH_PCT);
-                tau = LEVEL_METER_FAST_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_TIME_CONSTANT_SEC);
+                tau = LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC + frac * (LEVEL_METER_TIME_CONSTANT_SEC - LEVEL_METER_FAST_HIGH_TIME_CONSTANT_SEC);
             }
             else
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2450,14 +2450,6 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             int maxScaled = (int)(100.0 * ((float)m_maxLevel/levelMeterRefAmplitude));
             maxScaled = std::min(maxScaled, 100);
             m_gaugeLevel->SetValue(maxScaled);
-
-            // DIAGNOSTIC ONLY: confirm whether a low reading traces back to
-            // a low tickPeak (upstream tap/fifo issue) or to the ballistics
-            // math (this calculation) eating a healthy peak.
-            if (timerId == ID_TIMER_SPEECH_IN)
-            {
-                log_debug("LevelMeter TX: tickPeak=%d m_maxLevel=%.1f maxScaled=%d", tickPeak, m_maxLevel, maxScaled);
-            }
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2441,6 +2441,14 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             m_maxLevel += (tickPeak - m_maxLevel) * LEVEL_METER_ALPHA;
             int maxScaled = (int)(100.0 * ((float)m_maxLevel/32767.0));
             m_gaugeLevel->SetValue(maxScaled);
+
+            // DIAGNOSTIC ONLY: confirm whether a low reading traces back to
+            // a low tickPeak (upstream tap/fifo issue) or to the ballistics
+            // math (this calculation) eating a healthy peak.
+            if (timerId == ID_TIMER_SPEECH_IN)
+            {
+                log_debug("LevelMeter TX: tickPeak=%d m_maxLevel=%.1f maxScaled=%d", tickPeak, m_maxLevel, maxScaled);
+            }
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2398,18 +2398,14 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         // Level Gauge -----------------------------------------------------------------------
 
         bool updated = false;
+        int tickPeak = 0;
         if (timerId == ID_TIMER_DEMOD_IN && !txState && m_RxRunning)
         {
             // receive mode - display From Radio peaks
             // peak from this DT sampling period
-            int maxDemodIn = 0;
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
-                if (maxDemodIn < abs(demodInPlotSamples[i]))
-                    maxDemodIn = abs(demodInPlotSamples[i]);
-
-            // peak from last second
-            if (maxDemodIn > m_maxLevel)
-                m_maxLevel = maxDemodIn;
+                if (tickPeak < abs(demodInPlotSamples[i]))
+                    tickPeak = abs(demodInPlotSamples[i]);
 
             updated = true;
         }
@@ -2418,24 +2414,24 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             // transmit mode - display From Mic peaks
 
             // peak from this DT sampling period
-            int maxSpeechIn = 0;
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
-                if (maxSpeechIn < abs(speechInPlotSamples[i]))
-                    maxSpeechIn = abs(speechInPlotSamples[i]);
-
-            // peak from last second
-            if (maxSpeechIn > m_maxLevel)
-                m_maxLevel = maxSpeechIn;
+                if (tickPeak < abs(speechInPlotSamples[i]))
+                    tickPeak = abs(speechInPlotSamples[i]);
 
            updated = true;
         }
 
         if (updated)
         {
-            // Peak Reading meter: updates peaks immediately, then slowly decays
+            // Moving-average ("moving coil meter") ballistics: the bar swings
+            // toward each tick's peak instead of jumping straight to it and
+            // only slowly decaying, so a single brief transient no longer
+            // reads as a full-scale spike. Same attack/release time constant
+            // in both directions, approximating a real VU meter's needle
+            // swing (see LEVEL_METER_ALPHA in defines.h).
+            m_maxLevel += (tickPeak - m_maxLevel) * LEVEL_METER_ALPHA;
             int maxScaled = (int)(100.0 * ((float)m_maxLevel/32767.0));
             m_gaugeLevel->SetValue(maxScaled);
-            m_maxLevel *= LEVEL_BETA;
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2437,13 +2437,12 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
 
         if (updated)
         {
-            // Moving-average ("moving coil meter") ballistics: the bar swings
-            // toward each tick's peak instead of jumping straight to it and
-            // only slowly decaying, so a single brief transient no longer
-            // reads as a full-scale spike. Same attack/release time constant
-            // in both directions, approximating a real VU meter's needle
-            // swing (see LEVEL_METER_ALPHA in defines.h).
-            m_maxLevel += (tickPeak - m_maxLevel) * LEVEL_METER_ALPHA;
+            // PPM-style ballistics: instant attack (jump straight to a new
+            // peak), fixed dB/sec release (a straight-line fall rather than
+            // a running average, so it doesn't bounce/lag chasing dips --
+            // see LEVEL_METER_RELEASE_DB_PER_SEC in defines.h).
+            static const float levelMeterReleaseFactor = powf(10.0f, -(float)(LEVEL_METER_RELEASE_DB_PER_SEC * DT) / 20.0f);
+            m_maxLevel = std::max((float)tickPeak, m_maxLevel * levelMeterReleaseFactor);
 
             // 100% maps to LEVEL_METER_REFERENCE_DB, not true 0dBFS -- see
             // that constant's comment in defines.h for why.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2443,6 +2443,18 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
             {
                 m_levelTargetMarker->Show();
                 m_levelTargetMarker->GetParent()->Layout();
+
+                // DIAGNOSTIC ONLY: previous geometry log was captured while
+                // still hidden (GTK doesn't allocate hidden widgets, so it
+                // read back as (0,0)) -- log again now that it's actually
+                // visible, to see the real position/size once shown.
+                wxSize gaugeSz = m_gaugeLevel->GetSize();
+                wxPoint gaugePos = m_gaugeLevel->GetPosition();
+                wxSize markerSz = m_levelTargetMarker->GetSize();
+                wxPoint markerPos = m_levelTargetMarker->GetPosition();
+                log_debug("LevelBox geometry (on TX show): gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
+                    gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
+                    markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
             }
 
            updated = true;

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -96,6 +96,7 @@ extern bool g_loopPlayFileToMicIn;
 extern std::atomic<float> g_TxFreqOffsetHz;
 extern GenericFIFO<short> g_plotSpeechInFifo;
 extern GenericFIFO<short> g_plotDemodInFifo;
+extern GenericFIFO<short> g_levelMeterMicFifo;
 extern GenericFIFO<short> g_plotSpeechOutFifo;
 extern int g_mode;
 extern int g_txLevel;
@@ -216,6 +217,21 @@ void TxRxThread::initializePipeline_()
             eitherOrProcessRNNoise,
             eitherOrBypassRNNoise);
         pipeline_->appendPipelineStep(eitherOrRNNoiseStep);
+
+        // Level meter tap (pre-AGC, pre-EQ). Kept separate from the "Frm Mic"
+        // plot tap below, which intentionally reflects post-AGC/EQ encoder
+        // input -- this one exists so the TX level meter can show true mic
+        // drive/overdrive, which AGC would otherwise mask.
+        auto levelMeterTapStep = new ResampleForPlotStep(&g_levelMeterMicFifo);
+        auto levelMeterTapPipeline = new AudioPipeline(inputSampleRate_, levelMeterTapStep->getOutputSampleRate());
+#if defined(ENABLE_FASTER_PLOTS)
+        auto levelMeterTapResampler = new ResampleStep(inputSampleRate_, levelMeterTapStep->getInputSampleRate(), true); // need to create manually to get access to "plot only" optimizations
+        levelMeterTapPipeline->appendPipelineStep(levelMeterTapResampler);
+#endif // defined(ENABLE_FASTER_PLOTS)
+        levelMeterTapPipeline->appendPipelineStep(levelMeterTapStep);
+
+        auto levelMeterTap = new TapStep(inputSampleRate_, levelMeterTapPipeline);
+        pipeline_->appendPipelineStep(levelMeterTap);
 
         // AGC step (optional)
         auto eitherOrProcessAgc = new AudioPipeline(inputSampleRate_, inputSampleRate_);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -605,19 +605,25 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     // through more rebuild cycles.
     levelBox->Bind(wxEVT_SIZE, [this, levelBox](wxSizeEvent& evt) {
         evt.Skip();
-        static bool logged = false;
-        if (!logged)
+        static bool scheduled = false;
+        if (!scheduled)
         {
-            logged = true;
-            wxSize gaugeSz = m_gaugeLevel->GetSize();
-            wxPoint gaugePos = m_gaugeLevel->GetPosition();
-            wxSize markerSz = m_levelTargetMarker->GetSize();
-            wxPoint markerPos = m_levelTargetMarker->GetPosition();
-            wxSize boxSz = levelBox->GetSize();
-            log_debug("LevelBox geometry: box=%dx%d gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
-                boxSz.GetWidth(), boxSz.GetHeight(),
-                gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
-                markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
+            scheduled = true;
+            // Deferred via CallAfter -- reading geometry directly in the size
+            // handler ran ahead of the sizer's own layout pass for that same
+            // event (both children read back as (0,0)). CallAfter queues
+            // this for after the current event cycle, once layout's settled.
+            this->CallAfter([this, levelBox]() {
+                wxSize gaugeSz = m_gaugeLevel->GetSize();
+                wxPoint gaugePos = m_gaugeLevel->GetPosition();
+                wxSize markerSz = m_levelTargetMarker->GetSize();
+                wxPoint markerPos = m_levelTargetMarker->GetPosition();
+                wxSize boxSz = levelBox->GetSize();
+                log_debug("LevelBox geometry (deferred): box=%dx%d gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
+                    boxSz.GetWidth(), boxSz.GetHeight(),
+                    gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
+                    markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
+            });
         }
     });
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -590,6 +590,16 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
         wxSize sz = m_levelTargetMarker->GetClientSize();
         dc.SetBackground(wxBrush(m_levelTargetMarker->GetParent()->GetBackgroundColour()));
         dc.Clear();
+
+        // Outline the panel's full extent so its bounds are visible even
+        // when the off-target background matches the surrounding UI --
+        // DIAGNOSTIC, confirming whether the panel itself is sized/placed
+        // correctly (2026-08-24: user couldn't tell where the widget's
+        // bounds were without this reference).
+        dc.SetPen(wxPen(wxColour(128, 128, 128), 1));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(0, 0, sz.GetWidth(), sz.GetHeight());
+
         int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
         int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
         dc.SetPen(*wxTRANSPARENT_PEN);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -575,11 +575,16 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     wxBoxSizer* levelGaugeSizer = new wxBoxSizer(wxVERTICAL);
 
-    // Thin static strip marking the acceptable range (LEVEL_METER_TARGET_LOW_PCT
-    // to LEVEL_METER_TARGET_HIGH_PCT) just above the gauge -- a plain painted
-    // panel rather than a custom meter widget.
-    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
-    m_levelTargetMarker->SetToolTip(_("Acceptable level range"));
+    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
+    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
+    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
+
+    // Thin static strip marking the acceptable TX range (LEVEL_METER_TARGET_LOW_PCT
+    // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel
+    // rather than a custom meter widget. TX-only: shown/hidden alongside the
+    // gauge's RX/TX branch switch in OnTimer().
+    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(270,5));
+    m_levelTargetMarker->SetToolTip(_("Acceptable TX level range"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);
         wxSize sz = m_levelTargetMarker->GetClientSize();
@@ -591,11 +596,8 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
         dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
         dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
     });
-    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
-
-    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
-    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 2);
+    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|wxTOP, 2);
+    m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -585,8 +585,8 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     // diagnostic). TX-only-ness is now purely a paint-time decision via
     // m_levelTargetMarkerActive, toggled+Refresh()'d by OnTimer() instead.
     m_levelTargetMarkerActive = false;
-    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
-    m_levelTargetMarker->SetToolTip(_("Acceptable level range"));
+    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,3));
+    m_levelTargetMarker->SetToolTip(_("Acceptable level range (amber = too low, green = target, red = too high)"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);
         wxSize sz = m_levelTargetMarker->GetClientSize();
@@ -597,15 +597,19 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
             int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
             int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
             dc.SetPen(*wxTRANSPARENT_PEN);
+            dc.SetBrush(wxBrush(wxColour(255, 165, 0)));
+            dc.DrawRectangle(0, 0, loX, sz.GetHeight());
             dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
             dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
+            dc.SetBrush(wxBrush(*wxRED));
+            dc.DrawRectangle(hiX, 0, sz.GetWidth() - hiX, sz.GetHeight());
         }
     });
     levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
 
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 2);
+    levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 0);
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -577,7 +577,14 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     // Thin static strip marking the acceptable range (LEVEL_METER_TARGET_LOW_PCT
     // to LEVEL_METER_TARGET_HIGH_PCT) just above the gauge -- a plain painted
-    // panel rather than a custom meter widget.
+    // panel rather than a custom meter widget. Always visible (never
+    // Show()/Hide()'d) -- GTK doesn't finish allocating a widget's real
+    // on-screen position until it's been shown once, and reading its
+    // geometry immediately after a first Show()+Layout() during TX
+    // confirmed it was still stuck at (0,0) regardless (2026-08-24
+    // diagnostic). TX-only-ness is now purely a paint-time decision via
+    // m_levelTargetMarkerActive, toggled+Refresh()'d by OnTimer() instead.
+    m_levelTargetMarkerActive = false;
     m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
     m_levelTargetMarker->SetToolTip(_("Acceptable level range"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
@@ -585,47 +592,22 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
         wxSize sz = m_levelTargetMarker->GetClientSize();
         dc.SetBackground(wxBrush(m_levelTargetMarker->GetParent()->GetBackgroundColour()));
         dc.Clear();
-        int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
-        int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
-        dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
-        dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
+        if (m_levelTargetMarkerActive)
+        {
+            int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
+            int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
+            dc.SetPen(*wxTRANSPARENT_PEN);
+            dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
+            dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
+        }
     });
     levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
-    m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
     levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 2);
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
-
-    // DIAGNOSTIC ONLY: log the actual widget geometry once, to see exactly
-    // why the marker isn't aligning with the gauge instead of guessing
-    // through more rebuild cycles.
-    levelBox->Bind(wxEVT_SIZE, [this, levelBox](wxSizeEvent& evt) {
-        evt.Skip();
-        static bool scheduled = false;
-        if (!scheduled)
-        {
-            scheduled = true;
-            // Deferred via CallAfter -- reading geometry directly in the size
-            // handler ran ahead of the sizer's own layout pass for that same
-            // event (both children read back as (0,0)). CallAfter queues
-            // this for after the current event cycle, once layout's settled.
-            this->CallAfter([this, levelBox]() {
-                wxSize gaugeSz = m_gaugeLevel->GetSize();
-                wxPoint gaugePos = m_gaugeLevel->GetPosition();
-                wxSize markerSz = m_levelTargetMarker->GetSize();
-                wxPoint markerPos = m_levelTargetMarker->GetPosition();
-                wxSize boxSz = levelBox->GetSize();
-                log_debug("LevelBox geometry (deferred): box=%dx%d gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
-                    boxSz.GetWidth(), boxSz.GetHeight(),
-                    gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
-                    markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
-            });
-        }
-    });
 
     leftSizer->Add(levelSizer, 0, static_cast<int>(wxALL)|static_cast<int>(wxEXPAND), 2);
     

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -583,7 +583,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel
     // rather than a custom meter widget. TX-only: shown/hidden alongside the
     // gauge's RX/TX branch switch in OnTimer().
-    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(270,5));
+    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
     m_levelTargetMarker->SetToolTip(_("Acceptable TX level range"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -29,6 +29,7 @@
 #include <wx/numformatter.h>
 
 #include "topFrame.h"
+#include "defines.h"
 
 #if !wxCHECK_VERSION(3, 3, 0)
 #include <set>

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -575,20 +575,11 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     wxBoxSizer* levelGaugeSizer = new wxBoxSizer(wxVERTICAL);
 
-    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
-    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
-
-    // Thin static strip marking the acceptable TX range (LEVEL_METER_TARGET_LOW_PCT
-    // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel
-    // rather than a custom meter widget. TX-only: shown/hidden alongside the
-    // gauge's RX/TX branch switch in OnTimer(). SetMinSize() is required --
-    // unlike wxGauge, a plain wxPanel doesn't report its constructor size as
-    // a sizer min-size on its own, which was leaving it at some smaller
-    // size and left-anchored instead of centred under the gauge.
+    // Thin static strip marking the acceptable range (LEVEL_METER_TARGET_LOW_PCT
+    // to LEVEL_METER_TARGET_HIGH_PCT) just above the gauge -- a plain painted
+    // panel rather than a custom meter widget.
     m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
-    m_levelTargetMarker->SetMinSize(wxSize(135,5));
-    m_levelTargetMarker->SetToolTip(_("Acceptable TX level range"));
+    m_levelTargetMarker->SetToolTip(_("Acceptable level range"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);
         wxSize sz = m_levelTargetMarker->GetClientSize();
@@ -600,21 +591,12 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
         dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
         dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
     });
-    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|wxTOP, 2);
+    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
     m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
-    // Sizer-based centering of a plain wxPanel against a native wxGauge
-    // proved unreliable in testing (kept coming out left-anchored despite
-    // matching requested sizes/flags) -- force the marker's X/width to
-    // exactly match the gauge's actual rendered rectangle instead, synced
-    // whenever the box is laid out/resized.
-    levelBox->Bind(wxEVT_SIZE, [this](wxSizeEvent& evt) {
-        evt.Skip();
-        wxPoint gaugePos = m_gaugeLevel->GetPosition();
-        wxSize gaugeSize = m_gaugeLevel->GetSize();
-        wxPoint markerPos = m_levelTargetMarker->GetPosition();
-        m_levelTargetMarker->SetSize(gaugePos.x, markerPos.y, gaugeSize.GetWidth(), m_levelTargetMarker->GetSize().GetHeight());
-    });
+    m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
+    m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
+    levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 2);
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
 

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -577,35 +577,30 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxEXPAND));
+    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
 
     // Thin static strip marking the acceptable TX range (LEVEL_METER_TARGET_LOW_PCT
     // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel
     // rather than a custom meter widget. TX-only: shown/hidden alongside the
-    // gauge's RX/TX branch switch in OnTimer().
+    // gauge's RX/TX branch switch in OnTimer(). SetMinSize() is required --
+    // unlike wxGauge, a plain wxPanel doesn't report its constructor size as
+    // a sizer min-size on its own, which was leaving it at some smaller
+    // size and left-anchored instead of centred under the gauge.
     m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
+    m_levelTargetMarker->SetMinSize(wxSize(135,5));
     m_levelTargetMarker->SetToolTip(_("Acceptable TX level range"));
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);
         wxSize sz = m_levelTargetMarker->GetClientSize();
-
-        // DIAGNOSTIC (2026-08-24): solid, distinct off-target colour instead
-        // of matching the surrounding UI, so background-blending can't be
-        // mistaken for (or mask) a real positioning bug. Outline confirms
-        // the panel's own true bounds too.
-        dc.SetBackground(wxBrush(wxColour(220, 220, 220)));
+        dc.SetBackground(wxBrush(m_levelTargetMarker->GetParent()->GetBackgroundColour()));
         dc.Clear();
-        dc.SetPen(wxPen(wxColour(128, 128, 128), 1));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(0, 0, sz.GetWidth(), sz.GetHeight());
-
         int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
         int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
         dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
     });
-    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxEXPAND)|wxTOP, 2);
+    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|wxTOP, 2);
     m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -600,6 +600,27 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
 
+    // DIAGNOSTIC ONLY: log the actual widget geometry once, to see exactly
+    // why the marker isn't aligning with the gauge instead of guessing
+    // through more rebuild cycles.
+    levelBox->Bind(wxEVT_SIZE, [this, levelBox](wxSizeEvent& evt) {
+        evt.Skip();
+        static bool logged = false;
+        if (!logged)
+        {
+            logged = true;
+            wxSize gaugeSz = m_gaugeLevel->GetSize();
+            wxPoint gaugePos = m_gaugeLevel->GetPosition();
+            wxSize markerSz = m_levelTargetMarker->GetSize();
+            wxPoint markerPos = m_levelTargetMarker->GetPosition();
+            wxSize boxSz = levelBox->GetSize();
+            log_debug("LevelBox geometry: box=%dx%d gauge pos=(%d,%d) size=%dx%d marker pos=(%d,%d) size=%dx%d",
+                boxSz.GetWidth(), boxSz.GetHeight(),
+                gaugePos.x, gaugePos.y, gaugeSz.GetWidth(), gaugeSz.GetHeight(),
+                markerPos.x, markerPos.y, markerSz.GetWidth(), markerSz.GetHeight());
+        }
+    });
+
     leftSizer->Add(levelSizer, 0, static_cast<int>(wxALL)|static_cast<int>(wxEXPAND), 2);
     
     //------------------------------

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -577,7 +577,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
+    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|static_cast<int>(wxEXPAND));
 
     // Thin static strip marking the acceptable TX range (LEVEL_METER_TARGET_LOW_PCT
     // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel
@@ -596,7 +596,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
         dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
         dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
     });
-    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|wxTOP, 2);
+    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxEXPAND)|wxTOP, 2);
     m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -577,7 +577,7 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
 
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|static_cast<int>(wxEXPAND));
+    levelGaugeSizer->Add(m_gaugeLevel, 0, static_cast<int>(wxEXPAND));
 
     // Thin static strip marking the acceptable TX range (LEVEL_METER_TARGET_LOW_PCT
     // to LEVEL_METER_TARGET_HIGH_PCT) below the gauge -- a plain painted panel

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -603,6 +603,19 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL)|wxTOP, 2);
     m_levelTargetMarker->Hide(); // TX-only; OnTimer() shows/hides it with the RX/TX branch switch.
 
+    // Sizer-based centering of a plain wxPanel against a native wxGauge
+    // proved unreliable in testing (kept coming out left-anchored despite
+    // matching requested sizes/flags) -- force the marker's X/width to
+    // exactly match the gauge's actual rendered rectangle instead, synced
+    // whenever the box is laid out/resized.
+    levelBox->Bind(wxEVT_SIZE, [this](wxSizeEvent& evt) {
+        evt.Skip();
+        wxPoint gaugePos = m_gaugeLevel->GetPosition();
+        wxSize gaugeSize = m_gaugeLevel->GetSize();
+        wxPoint markerPos = m_levelTargetMarker->GetPosition();
+        m_levelTargetMarker->SetSize(gaugePos.x, markerPos.y, gaugeSize.GetWidth(), m_levelTargetMarker->GetSize().GetHeight());
+    });
+
     levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
 
     leftSizer->Add(levelSizer, 0, static_cast<int>(wxALL)|static_cast<int>(wxEXPAND), 2);

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -588,14 +588,13 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(m_levelTargetMarker);
         wxSize sz = m_levelTargetMarker->GetClientSize();
-        dc.SetBackground(wxBrush(m_levelTargetMarker->GetParent()->GetBackgroundColour()));
-        dc.Clear();
 
-        // Outline the panel's full extent so its bounds are visible even
-        // when the off-target background matches the surrounding UI --
-        // DIAGNOSTIC, confirming whether the panel itself is sized/placed
-        // correctly (2026-08-24: user couldn't tell where the widget's
-        // bounds were without this reference).
+        // DIAGNOSTIC (2026-08-24): solid, distinct off-target colour instead
+        // of matching the surrounding UI, so background-blending can't be
+        // mistaken for (or mask) a real positioning bug. Outline confirms
+        // the panel's own true bounds too.
+        dc.SetBackground(wxBrush(wxColour(220, 220, 220)));
+        dc.Clear();
         dc.SetPen(wxPen(wxColour(128, 128, 128), 1));
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
         dc.DrawRectangle(0, 0, sz.GetWidth(), sz.GetHeight());

--- a/src/topFrame.cpp
+++ b/src/topFrame.cpp
@@ -572,10 +572,32 @@ TopFrame::TopFrame(wxWindow* parent, wxWindowID id, const wxString& title, const
     wxStaticBox* levelBox = new wxStaticBox(m_panel, wxID_ANY, _("Level"), wxDefaultPosition, wxSize(100,-1));
     levelSizer = new wxStaticBoxSizer(levelBox, wxHORIZONTAL);
 
+    wxBoxSizer* levelGaugeSizer = new wxBoxSizer(wxVERTICAL);
+
+    // Thin static strip marking the acceptable range (LEVEL_METER_TARGET_LOW_PCT
+    // to LEVEL_METER_TARGET_HIGH_PCT) just above the gauge -- a plain painted
+    // panel rather than a custom meter widget.
+    m_levelTargetMarker = new wxPanel(levelBox, wxID_ANY, wxDefaultPosition, wxSize(135,5));
+    m_levelTargetMarker->SetToolTip(_("Acceptable level range"));
+    m_levelTargetMarker->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
+        wxPaintDC dc(m_levelTargetMarker);
+        wxSize sz = m_levelTargetMarker->GetClientSize();
+        dc.SetBackground(wxBrush(m_levelTargetMarker->GetParent()->GetBackgroundColour()));
+        dc.Clear();
+        int loX = sz.GetWidth() * LEVEL_METER_TARGET_LOW_PCT / 100;
+        int hiX = sz.GetWidth() * LEVEL_METER_TARGET_HIGH_PCT / 100;
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        dc.SetBrush(wxBrush(wxColour(0, 200, 0)));
+        dc.DrawRectangle(loX, 0, hiX - loX, sz.GetHeight());
+    });
+    levelGaugeSizer->Add(m_levelTargetMarker, 0, static_cast<int>(wxALIGN_CENTER_HORIZONTAL));
+
     m_gaugeLevel = new wxGauge(levelBox, wxID_ANY, 100, wxDefaultPosition, wxSize(135,15), wxGA_SMOOTH);
     m_gaugeLevel->SetToolTip(_("Peak of From Radio in Rx, or peak of From Mic in Tx mode."));
-    levelSizer->Add(m_gaugeLevel, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
-    
+    levelGaugeSizer->Add(m_gaugeLevel, 0, wxTOP, 2);
+
+    levelSizer->Add(levelGaugeSizer, 1, wxALIGN_CENTER_VERTICAL|static_cast<int>(wxALL), 10);
+
     leftSizer->Add(levelSizer, 0, static_cast<int>(wxALL)|static_cast<int>(wxEXPAND), 2);
     
     //------------------------------

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -104,6 +104,7 @@ class TopFrame : public wxFrame
         wxCheckBox* m_ckboxSNR;
         wxGauge* m_gaugeLevel;
         wxPanel* m_levelTargetMarker;
+        bool m_levelTargetMarkerActive;
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;

--- a/src/topFrame.h
+++ b/src/topFrame.h
@@ -103,6 +103,7 @@ class TopFrame : public wxFrame
         wxStaticText* m_textSNR;
         wxCheckBox* m_ckboxSNR;
         wxGauge* m_gaugeLevel;
+        wxPanel* m_levelTargetMarker;
 
         wxButton*     m_BtnCallSignReset;
         wxTextCtrl*   m_txtCtrlCallSign;


### PR DESCRIPTION
This is a modification to the existing peak level meter in order to smooth the action and make level adjustment easier. It should help to avoid the issues raised in #1459. 

To effectively avoid narrow audio spikes from causing rapid jumps in the meter reading an exponential moving average (EMA) has been applied to smooth the action.

Also, since the optimum meter reading is around 50% of full scale, there is a
colour guide to make this obvious immediately above the gauge. Shown in transmit only.

Please test and comment if you find this would be an acceptable alternative.

The intended method for setting the system mic gain would be to start transmitting whilst speaking continuously at your normal level and mic position. Adjust the system mic level to set the meter in the middle of the green section.
The AGC will then have only small corrections to make and that setting should remain satisfactory.

<img width="619" height="313" alt="Screenshot_20260825_233703" src="https://github.com/user-attachments/assets/9aeb6ecb-e4a7-4411-8aca-2f824ae60060" />
