### PR TITLE
Add logic to prevent FIFO sizes that are too small to allow TX thread to function.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -949,7 +949,8 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 ## V2.4.1 TBD 2026
 
-TBD
+1. Bugfixes:
+    * Add logic to prevent FIFO sizes that are too small to allow TX thread to function. (PR #1474)
 
 ## V2.4.0 August 2026
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -561,7 +561,7 @@ int FreeDVInterface::getTxNNomModemSamples() const FREEDV_NONBLOCKING
         // Verified that rade_api.c from librade has no unbounded operations
         // as of 2025-10-03.
         FREEDV_BEGIN_VERIFIED_SAFE
-        return std::max(rade_n_tx_out(rade_), radeTxStep_->eooLengthInSamples());
+        return std::max(rade_n_tx_out(rade_), radeTxStep_ != nullptr ? radeTxStep_->eooLengthInSamples() : rade_n_tx_eoo_out(rade_));
         FREEDV_END_VERIFIED_SAFE
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3291,12 +3291,24 @@ void MainFrame::startRxStream()
         constexpr int MAX_INCOMING_AUDIO_SEC = 75;
         int m_fifoSize_ms = wxGetApp().appConfiguration.fifoSizeMs;
         int soundCard1InFifoSizeSamples = MAX_INCOMING_AUDIO_SEC * wxGetApp().appConfiguration.audioConfiguration.soundCard1In.sampleRate;
-        int soundCard1OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000;
+
+        // Guards against FIFO sizes accidentally being too small to fit an entier TX block.
+        // Theoretically allows up to three TX packets to be queued at a time at minimum
+        // (depending on mode).
+        int soundCard1OutFifoSizeSamples = std::max(
+            3 * (freedvInterface.getTxNNomModemSamples() * wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate) / freedvInterface.getTxModemSampleRate(),
+            m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard1Out.sampleRate / 1000);
 
         if (g_nSoundCards == 2)
         {
             int soundCard2InFifoSizeSamples = MAX_INCOMING_AUDIO_SEC * wxGetApp().appConfiguration.audioConfiguration.soundCard2In.sampleRate;
-            int soundCard2OutFifoSizeSamples = m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000;
+
+            // Guards against FIFO sizes accidentally being too small to fit an entier TX block.
+            // Theoretically allows up to three RX packets to be queued at a time at minimum
+            // (depending on mode).
+            int soundCard2OutFifoSizeSamples = std::max(
+                3 * (freedvInterface.getRxNumSpeechSamples() * wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate) / freedvInterface.getRxSpeechSampleRate(),
+                m_fifoSize_ms*wxGetApp().appConfiguration.audioConfiguration.soundCard2Out.sampleRate / 1000);
             g_rxUserdata->outfifo1 = new GenericFIFO<short>(soundCard1OutFifoSizeSamples);
             g_rxUserdata->infifo2 = new GenericFIFO<short>(soundCard2InFifoSizeSamples);
             g_rxUserdata->infifo1 = new GenericFIFO<short>(soundCard1InFifoSizeSamples);


### PR DESCRIPTION
When the FIFO size in Tools->Options->Debugging is set too small for the mode in use, it can prevent the TX thread from modulating the input audio. This PR ensures that the FIFO size is always at least large enough for a TX packet, regardless of the user's configuration.