### PR TITLE
Fix RX/TX level-meter gauge contamination

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -951,6 +951,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 
 1. Bugfixes:
     * Add logic to prevent FIFO sizes that are too small to allow TX thread to function. (PR #1474)
+    * Fix RX/TX level-meter gauge contamination. (PR #1475) - thanks @barjac!
 
 ## V2.4.0 August 2026
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1846,7 +1846,7 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
     }
     
     // Most plots don't need TX/sync state.
-    if (timerId == ID_TIMER_UPDATE_OTHER || timerId == ID_TIMER_SNR)
+    if (timerId == ID_TIMER_UPDATE_OTHER || timerId == ID_TIMER_SNR || timerId == ID_TIMER_DEMOD_IN)
     {
         txState = g_tx.load(std::memory_order_relaxed);
         halfDuplexState = g_half_duplex.load(std::memory_order_relaxed);
@@ -2398,15 +2398,9 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         // Level Gauge -----------------------------------------------------------------------
 
         bool updated = false;
-        if (timerId == ID_TIMER_DEMOD_IN && !g_tx.load(std::memory_order_relaxed) && m_RxRunning)
+        if (timerId == ID_TIMER_DEMOD_IN && !txState && m_RxRunning)
         {
             // receive mode - display From Radio peaks
-            // Note: txState is a per-call local only populated when timerId
-            // is ID_TIMER_UPDATE_OTHER/ID_TIMER_SNR, so it's stale (always
-            // false) here -- read g_tx directly instead, otherwise this
-            // branch also fires during TX and stomps the TX mic reading
-            // with demod-in (RX) peaks.
-            // peak from this DT sampling period
             int maxDemodIn = 0;
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)
                 if (maxDemodIn < abs(demodInPlotSamples[i]))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2398,9 +2398,14 @@ void MainFrame::OnTimer(wxTimerEvent &evt)
         // Level Gauge -----------------------------------------------------------------------
 
         bool updated = false;
-        if (timerId == ID_TIMER_DEMOD_IN && !txState && m_RxRunning)
+        if (timerId == ID_TIMER_DEMOD_IN && !g_tx.load(std::memory_order_relaxed) && m_RxRunning)
         {
             // receive mode - display From Radio peaks
+            // Note: txState is a per-call local only populated when timerId
+            // is ID_TIMER_UPDATE_OTHER/ID_TIMER_SNR, so it's stale (always
+            // false) here -- read g_tx directly instead, otherwise this
+            // branch also fires during TX and stomps the TX mic reading
+            // with demod-in (RX) peaks.
             // peak from this DT sampling period
             int maxDemodIn = 0;
             for(int i=0; i<WAVEFORM_PLOT_BUF; i++)


### PR DESCRIPTION
## Summary

- `MainFrame::OnTimer()`'s RX ("From Radio") level-meter branch checks `!txState`, but `txState` is a per-call local only populated when `timerId == ID_TIMER_UPDATE_OTHER || ID_TIMER_SNR` — on `ID_TIMER_DEMOD_IN` dispatches it's always stale/false, so the RX branch also fired during TX and let demod-in (received) peaks refresh the TX level meter alongside the mic peaks.
- Fixed by reading `g_tx.load(std::memory_order_relaxed)` directly instead of the stale local.
- Split out as its own small fix, split off from ongoing level-meter design discussion on #1459/#1464, per request there to land this independently while that's still being worked out.

## Note

With RX/TX correctly isolated, TX peaks now decay uninterrupted through the existing `LEVEL_BETA = 0.99`/tick multiplicative decay — this exposes that decay as quite slow (roughly 20+ seconds for a full decay), previously masked by the bug's frequent RX-triggered peak resets. Worth being aware of when evaluating this fix; not something this PR attempts to address.