### PR TITLE
CI: Use macos-26 for running tests

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -316,7 +316,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]  # ARM64, ARM64, ARM64
+        os: [macos-14, macos-15, macos-26]  # ARM64, ARM64, ARM64
 
     runs-on: ${{ matrix.os }}
     needs: ['dist-pgo-build']

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - uses: actions/checkout@v6
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15]  # ARM64
+        os: [macos-26]  # ARM64
         sanitizer: [WITH_ASAN=0, WITH_ASAN=1, WITH_TSAN=1, WITH_UBSAN=1]
 
     runs-on: ${{ matrix.os }}
@@ -316,7 +316,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-26]  # ARM64, ARM64, ARM64
+        os: [macos-26]  # ARM64, ARM64, ARM64
 
     runs-on: ${{ matrix.os }}
     needs: ['dist-pgo-build']

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -952,6 +952,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
 1. Bugfixes:
     * Add logic to prevent FIFO sizes that are too small to allow TX thread to function. (PR #1474)
     * Fix RX/TX level-meter gauge contamination. (PR #1475) - thanks @barjac!
+    * macOS: Fix dyld error on startup when enabling sanitizers in build. (PR #1478)
 
 ## V2.4.0 August 2026
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,7 @@ if(APPLE)
         POST_BUILD
         COMMAND rm -rf dist_tmp FreeDV.dmg || true
         COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${portaudio_BINARY_DIR}:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/ -i /usr/lib -s ${CODEC2_BUILD_DIR}/src -s ${CMAKE_BINARY_DIR}/codec2_build/src ${PORTAUDIO_BUNDLE_ARG} -s ${rade_BINARY_DIR}/src -s `dirname ${CLANG_SANITIZER_FILE}` -ns
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/clean-duplicate-rpaths.sh FreeDV.app/Contents/MacOS/FreeDV
         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
         COMMAND rm ARGS -rf FreeDV.app/Contents/Frameworks
         COMMAND mkdir ARGS FreeDV.app/Contents/Frameworks

--- a/src/clean-duplicate-rpaths.sh
+++ b/src/clean-duplicate-rpaths.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in `otool -l $1 | grep -A2 LC_RPATH | grep path | awk '{ print $2; }' | tail +2`; do
+    install_name_tool -delete_rpath "$i" $1
+done


### PR DESCRIPTION
Updates CI workflow to use macos-26 for running more extensive tests. As part of this, this PR also adds a workaround for a `dyld` problem encountered while running sanitized builds on macos-26.