### PR TITLE
Equalizer: make sure number of output samples is correct.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -954,6 +954,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix RX/TX level-meter gauge contamination. (PR #1475) - thanks @barjac!
     * Fix Hamlib-related build failure with Hamlib 5.0~git. (PR #1477)
     * macOS: Fix dyld error on startup when enabling sanitizers in build. (PR #1478)
+    * Fix potential equalizer bug that could introduce corrupted audio. (PR #1480)
 
 ## V2.4.0 August 2026
 

--- a/src/pipeline/EqualizerStep.cpp
+++ b/src/pipeline/EqualizerStep.cpp
@@ -71,6 +71,7 @@ int EqualizerStep::getOutputSampleRate() const FREEDV_NONBLOCKING
 short* EqualizerStep::execute(short* inputSamples, int numInputSamples, int* numOutputSamples) FREEDV_NONBLOCKING
 {
     bool copiedToOutput = false;
+    *numOutputSamples = numInputSamples;
 
     // Note: if we can't lock, an update is in progress. Just assume no filters enabled
     // until update completes.
@@ -80,7 +81,6 @@ short* EqualizerStep::execute(short* inputSamples, int numInputSamples, int* num
         {
             memcpy(outputSamples_.get(), inputSamples, sizeof(short)*numInputSamples);
             copiedToOutput = true;
-            *numOutputSamples = numInputSamples;
             sox_biquad_filter(*volFilter_, outputSamples_.get(), outputSamples_.get(), numInputSamples);
         }
     
@@ -115,7 +115,6 @@ short* EqualizerStep::execute(short* inputSamples, int numInputSamples, int* num
     }
     else
     {
-        *numOutputSamples = numInputSamples;
         return inputSamples;
     }
 }


### PR DESCRIPTION
There may be a scenario where `EqualizerStep` doesn't properly set the number of output samples. This ensures that we're always setting the number of output samples to a valid value.