### PR TITLE
Reduce waterfall and scalar plot paint cost; fix uninitialised heatmap LUT entry

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -955,6 +955,9 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix Hamlib-related build failure with Hamlib 5.0~git. (PR #1477)
     * macOS: Fix dyld error on startup when enabling sanitizers in build. (PR #1478)
     * Fix potential equalizer bug that could introduce corrupted audio. (PR #1480)
+    * Fix uninitialized value read during waterfall plot render. (PR #1481)
+2. Other:
+    * Waterfall and other plot performance improvements. (PR #1481)
 
 ## V2.4.0 August 2026
 

--- a/src/gui/controls/plot_scalar.cpp
+++ b/src/gui/controls/plot_scalar.cpp
@@ -289,8 +289,6 @@ void PlotScalar::draw(wxGraphicsContext* ctx, bool repaintDataOnly)
         lineMap_[index].y2 = INT_MIN;
     }
 
-    ctx->BeginLayer(1.0);
-
     int x, y;
 
     for(i = 0; i < m_samples; i++) {
@@ -403,8 +401,15 @@ void PlotScalar::draw(wxGraphicsContext* ctx, bool repaintDataOnly)
     }
 
     plotAreaDC_->SelectObject(wxNullBitmap);
-    ctx->DrawBitmap(*plotArea_, plotX, plotY, plotWidth, plotHeight); 
-    ctx->EndLayer();
+
+    // Composite through a wxGraphicsBitmap rather than handing the wxBitmap straight to
+    // DrawBitmap. On macOS the wxBitmap overload allocates a fresh NSImage per call and
+    // draws via -[NSImage drawInRect:]; the wxGraphicsBitmap one uses CGContextDrawImage.
+    // The conversion has to happen every frame here since plotArea_ is redrawn above, but
+    // it is still far cheaper than the NSImage round trip. Same idea as plotLinesBMP_ in
+    // drawGraticuleFast(), which has always taken this path.
+    wxGraphicsBitmap plotAreaBMP = ctx->CreateBitmap(*plotArea_);
+    ctx->DrawBitmap(plotAreaBMP, plotX, plotY, plotWidth, plotHeight);
 
     addedPoints_ = 0;
     drawGraticuleFast(ctx, repaintDataOnly);

--- a/src/gui/controls/plot_spectrum.cpp
+++ b/src/gui/controls/plot_spectrum.cpp
@@ -172,7 +172,6 @@ void PlotSpectrum::draw(wxGraphicsContext* ctx, bool repaintDataOnly)
 
     auto freq_hz_to_px = (float)m_rGrid.GetWidth()/(MAX_F_HZ-MIN_F_HZ);
 
-    ctx->BeginLayer(1.0);
     wxGraphicsPath path = ctx->CreatePath();
     for(index = 0; index < m_n_magdB; index++)
     {
@@ -216,7 +215,6 @@ void PlotSpectrum::draw(wxGraphicsContext* ctx, bool repaintDataOnly)
         prev_x = x;
     }
     ctx->StrokePath(path);
-    ctx->EndLayer();
 
     // and finally draw Graticule
     drawGraticuleFast(ctx, repaintDataOnly);

--- a/src/gui/controls/plot_waterfall.cpp
+++ b/src/gui/controls/plot_waterfall.cpp
@@ -64,7 +64,11 @@ PlotWaterfall::PlotWaterfall(wxWindow* parent, float* magDb, bool graticule, int
     // for e.g. numbers. Thus, we only need to override layout direction.
     SetLayoutDirection(wxLayout_LeftToRight);
     
-    for(int i = 0; i < 255; i++)
+    // Note the bound: plotPixelData() clamps intensity to 255 and reaches it whenever a
+    // bin sits at the top of the current range, which happens on essentially every frame
+    // carrying signal. Filling only 0..254 left the last entry holding indeterminate
+    // memory, and the hottest pixels took their colour from it.
+    for(int i = 0; i < 256; i++)
     {
         m_heatmap_lut[i] = heatmap((float)i, 0.0, 255.0);
     }
@@ -81,6 +85,7 @@ PlotWaterfall::PlotWaterfall(wxWindow* parent, float* magDb, bool graticule, int
     dy_ = 0;
     tmpImage_ = nullptr;
     leftOffset_ = 0;
+    graticuleLabelsValid_ = false;
 
     SetLabelSize(10.0);
 
@@ -126,8 +131,11 @@ void PlotWaterfall::OnSize(wxSizeEvent& event)
     // Reset waterfall to black.
     cleanupSlices_();
 
+    // Label positions depend on the geometry we just recalculated.
+    graticuleLabelsValid_ = false;
+
     m_dT = DT;
-    
+
     event.Skip();
 }
 
@@ -252,17 +260,16 @@ void PlotWaterfall::draw(wxGraphicsContext* gc, bool repaintDataOnly)
     if(m_newdata)
     {
         m_newdata = false;
-        plotPixelData();
-    } 
-    
-    int yOffset = 0;
-    gc->BeginLayer(1.0);
-    for (auto& bmp : waterfallSlices_)
-    {
-        gc->DrawBitmap(*bmp, PLOT_BORDER + leftOffset_, yOffset + PLOT_BORDER + YBOTTOM_OFFSET, m_imgWidth, bmp->GetHeight());
-        yOffset += bmp->GetHeight();
+        plotPixelData(gc);
     }
-    gc->EndLayer();
+
+    int yOffset = 0;
+    for (auto& slice : waterfallSlices_)
+    {
+        int sliceHeight = slice.bitmap->GetHeight();
+        gc->DrawBitmap(slice.gfxBitmap, PLOT_BORDER + leftOffset_, yOffset + PLOT_BORDER + YBOTTOM_OFFSET, m_imgWidth, sliceHeight);
+        yOffset += sliceHeight;
+    }
 
     if (yOffset < m_imgHeight)
     {
@@ -280,36 +287,46 @@ void PlotWaterfall::draw(wxGraphicsContext* gc, bool repaintDataOnly)
 }
 
 //-------------------------------------------------------------------------
-// drawGraticule()
+// rebuildGraticuleLabels_()
+//
+// Lays out the axis labels and caches where each one goes. Only the control's
+// geometry decides that, so this runs on resize rather than on every frame --
+// GetTextExtent() is expensive enough (wxWindowMac::DoGetTextExtent builds and
+// tears down a wxGraphicsContext per call) to be worth keeping out of the
+// per-frame path.
 //-------------------------------------------------------------------------
-void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
+void PlotWaterfall::rebuildGraticuleLabels_()
 {
-    int      x, y, text_w, text_h;
-    char     buf[STR_LENGTH];
-    float    f, time, freq_hz_to_px;
+    int   text_w, text_h;
+    char  buf[STR_LENGTH];
+    float f, time;
 
-    wxBrush ltGraphBkgBrush;
-    wxColour foregroundColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
-    ltGraphBkgBrush.SetStyle(wxBRUSHSTYLE_TRANSPARENT);
-    ltGraphBkgBrush.SetColour(foregroundColor);
-    ctx->SetBrush(ltGraphBkgBrush);
-    ctx->SetPen(wxPen(foregroundColor, 1));
-    
-    wxGraphicsFont tmpFont = ctx->CreateFont(GetFont(), GetForegroundColour());
-    ctx->SetFont(tmpFont);
-    
-    freq_hz_to_px = (float)m_imgWidth/(MAX_F_HZ-MIN_F_HZ);
+    freqLabels_.clear();
+    timeLabels_.clear();
 
-    // upper LH coords of plot area are (PLOT_BORDER + leftOffset_, PLOT_BORDER)
-    // lower RH coords of plot area are (PLOT_BORDER + leftOffset_ + m_rGrid.GetWidth(), 
-    //                                   PLOT_BORDER + m_rGrid.GetHeight())
+    float freq_hz_to_px = (float)m_imgWidth/(MAX_F_HZ-MIN_F_HZ);
 
     // Check if small screen size means text will overlap
-
     int textXStep = STEP_F_HZ * freq_hz_to_px;
     snprintf(buf, STR_LENGTH, "%.1fk", ((float)MAX_F_HZ - STEP_F_HZ)/1000.0f);
     GetTextExtent(buf, &text_w, &text_h);
-    int overlappedX = (text_w > textXStep);
+    bool overlappedX = (text_w > textXStep);
+
+    if (!overlappedX)
+    {
+        for(f=STEP_F_HZ; f<MAX_F_HZ; f+=STEP_F_HZ)
+        {
+            int x = f*freq_hz_to_px;
+            x += PLOT_BORDER + leftOffset_;
+
+            snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
+            GetTextExtent(buf, &text_w, &text_h);
+            freqLabels_.push_back({
+                wxString(buf),
+                x - text_w/2,
+                (PLOT_BORDER + YBOTTOM_OFFSET / 2 - text_h) / 2 });
+        }
+    }
 
     // Pick the coarsest Y label interval that still shows at least 4 labels
     static const int labelStepPresets[] = {5, 2, 1};
@@ -323,7 +340,54 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         }
     }
 
-    // Major Vertical gridlines and legend
+    int dataY0   = PLOT_BORDER + YBOTTOM_OFFSET;
+    int dataYEnd = dataY0 + m_imgHeight;
+    for(int y = dataY0, t = 0; y < dataYEnd; t++, y += Y_PER_SECOND)
+    {
+        time = (float)t;
+        if ((int)(time + 0.5f) % labelSecs != 0) continue;
+
+        snprintf(buf, STR_LENGTH, "%3.0fs", time);
+        GetTextExtent(buf, &text_w, &text_h);
+        timeLabels_.push_back({
+            wxString(buf),
+            PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET,
+            y - text_h / 2 });
+    }
+
+    graticuleLabelsValid_ = true;
+}
+
+//-------------------------------------------------------------------------
+// drawGraticule()
+//-------------------------------------------------------------------------
+void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
+{
+    int      x, y;
+    float    f, time, freq_hz_to_px;
+
+    wxBrush ltGraphBkgBrush;
+    wxColour foregroundColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    ltGraphBkgBrush.SetStyle(wxBRUSHSTYLE_TRANSPARENT);
+    ltGraphBkgBrush.SetColour(foregroundColor);
+    ctx->SetBrush(ltGraphBkgBrush);
+    ctx->SetPen(wxPen(foregroundColor, 1));
+
+    wxGraphicsFont tmpFont = ctx->CreateFont(GetFont(), GetForegroundColour());
+    ctx->SetFont(tmpFont);
+
+    if (!graticuleLabelsValid_)
+    {
+        rebuildGraticuleLabels_();
+    }
+
+    freq_hz_to_px = (float)m_imgWidth/(MAX_F_HZ-MIN_F_HZ);
+
+    // upper LH coords of plot area are (PLOT_BORDER + leftOffset_, PLOT_BORDER)
+    // lower RH coords of plot area are (PLOT_BORDER + leftOffset_ + m_rGrid.GetWidth(),
+    //                                   PLOT_BORDER + m_rGrid.GetHeight())
+
+    // Major Vertical gridlines
     for(f=STEP_F_HZ; f<MAX_F_HZ; f+=STEP_F_HZ)
     {
         x = f*freq_hz_to_px;
@@ -333,11 +397,6 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
             ctx->StrokeLine(x, m_imgHeight + PLOT_BORDER, x, PLOT_BORDER);
         else
             ctx->StrokeLine(x, PLOT_BORDER + YBOTTOM_OFFSET, x, PLOT_BORDER + YBOTTOM_OFFSET / 2);
-
-        snprintf(buf, STR_LENGTH, "%.1fk", f/1000.0f);
-        GetTextExtent(buf, &text_w, &text_h);
-        if (!overlappedX)
-            ctx->DrawText(buf, x - text_w/2, (PLOT_BORDER + YBOTTOM_OFFSET / 2 - text_h) / 2);
     }
 
     for(f=STEP_MINOR_F_HZ; f<MAX_F_HZ; f+=STEP_MINOR_F_HZ)
@@ -345,6 +404,12 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         x = f*freq_hz_to_px;
         x += PLOT_BORDER + leftOffset_;
         ctx->StrokeLine(x, PLOT_BORDER + YBOTTOM_OFFSET, x, PLOT_BORDER + YBOTTOM_OFFSET * 3 / 4);
+    }
+
+    // Frequency legend
+    for (const auto& label : freqLabels_)
+    {
+        ctx->DrawText(label.text, label.x, label.y);
     }
 
     int dataY0   = PLOT_BORDER + YBOTTOM_OFFSET;
@@ -361,7 +426,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
                         (m_rGrid.GetWidth() + PLOT_BORDER + leftOffset_), y);
     }
 
-    // Y axis ticks and labels at 1s intervals
+    // Y axis ticks at 1s intervals
     ctx->SetPen(wxPen(foregroundColor, 1));
     for(y = dataY0, time=0;
         y < dataYEnd;
@@ -370,14 +435,14 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
         bool isMajor = (fmodf(time, (float)WATERFALL_SECS_STEP) < 0.5f);
         ctx->StrokeLine(PLOT_BORDER + leftOffset_, y,
                         PLOT_BORDER + leftOffset_ + (isMajor ? 8 : 4), y);
-
-        snprintf(buf, STR_LENGTH, "%3.0fs", time);
-        GetTextExtent(buf, &text_w, &text_h);
-        if ((int)(time + 0.5f) % labelSecs == 0)
-            ctx->DrawText(buf, PLOT_BORDER + leftOffset_ - text_w - XLEFT_TEXT_OFFSET,
-                          y - text_h / 2);
     }
-   
+
+    // Y axis labels
+    for (const auto& label : timeLabels_)
+    {
+        ctx->DrawText(label.text, label.x, label.y);
+    }
+
    float verticalBarLength = PLOT_BORDER + YBOTTOM_TEXT_OFFSET + 5;
    
    float sum = 0.0;
@@ -405,7 +470,7 @@ void PlotWaterfall::drawGraticule(wxGraphicsContext* ctx)
 //-------------------------------------------------------------------------
 // plotPixelData()
 //-------------------------------------------------------------------------
-void PlotWaterfall::plotPixelData()
+void PlotWaterfall::plotPixelData(wxGraphicsContext* gc)
 {
     float       intensity_per_dB;
     float       px_per_sec;
@@ -529,33 +594,38 @@ void PlotWaterfall::plotPixelData()
     if (dy > 0)
     {
         tmpImage_->SetData(dyImageData_, true);
-        wxBitmap* tmpBmp = nullptr;
-        wxBitmap* destBmp = nullptr;
+
+        WaterfallSlice slice;
         if (waterfallSlices_.size() >= (size_t)(m_imgHeight / dy))
         {
-            tmpBmp = waterfallSlices_[waterfallSlices_.size() - 1];
+            // Recycle the oldest block's bitmap as the render target for the newest one.
+            // Its cached gfxBitmap goes with it and is rebuilt below.
+            slice.bitmap = waterfallSlices_.back().bitmap;
             waterfallSlices_.pop_back();
-            destBmp = tmpBmp;
-            
-            tmpBmp = new wxBitmap(*tmpImage_);
         }
         else
         {
-            destBmp = new wxBitmap(m_imgWidth, dy);
-            tmpBmp = new wxBitmap(*tmpImage_);
+            slice.bitmap = new wxBitmap(m_imgWidth, dy);
         }
 
-        wxMemoryDC sourceDC;
-        sourceDC.SelectObjectAsSource(*tmpBmp);
-        wxMemoryDC destDC(*destBmp);
-        
-        destDC.StretchBlit(0, 0, m_imgWidth, tmpBmp->GetHeight(), &sourceDC, 0, 0, baseRowWidthPixels, tmpBmp->GetHeight());
-        waterfallSlices_.push_front(destBmp);
-        
-        if (tmpBmp != nullptr)
+        wxBitmap srcBmp(*tmpImage_);
         {
-            delete tmpBmp;
+            // Scoped so both DCs release the bitmaps before the graphics bitmap is made
+            // from slice.bitmap -- a bitmap still selected into a wxMemoryDC is under raw
+            // access and cannot be handed to the renderer.
+            wxMemoryDC sourceDC;
+            sourceDC.SelectObjectAsSource(srcBmp);
+            wxMemoryDC destDC(*slice.bitmap);
+
+            destDC.StretchBlit(0, 0, m_imgWidth, srcBmp.GetHeight(), &sourceDC, 0, 0, baseRowWidthPixels, srcBmp.GetHeight());
         }
+
+        // Convert once, here, rather than on every paint: a block's pixels never change
+        // again after this blit, and it will be composited on each of the frames it spends
+        // scrolling down the screen.
+        slice.gfxBitmap = gc->CreateBitmap(*slice.bitmap);
+
+        waterfallSlices_.push_front(slice);
     }
 }
 
@@ -668,9 +738,9 @@ void PlotWaterfall::OnMouseMiddleDown(wxMouseEvent&)
 
 void PlotWaterfall::cleanupSlices_()
 {
-    for (auto& bmp : waterfallSlices_)
+    for (auto& slice : waterfallSlices_)
     {
-        delete bmp;
+        delete slice.bitmap;
     }
     waterfallSlices_.clear();
 

--- a/src/gui/controls/plot_waterfall.h
+++ b/src/gui/controls/plot_waterfall.h
@@ -22,6 +22,7 @@
 #define __FDMDV2_PLOT_WATERFALL__
 
 #include <deque>
+#include <vector>
 #include <wx/graphics.h>
 
 #include "plot.h"
@@ -71,7 +72,7 @@ class PlotWaterfall : public PlotPanel
         void        OnShow(wxShowEvent& event) override;
         void        drawGraticule(wxGraphicsContext* ctx) override;
         void        draw(wxGraphicsContext* gc, bool repaintDataOnly = false) override;
-        void        plotPixelData();
+        void        plotPixelData(wxGraphicsContext* gc);
         void        OnMouseLeftDoubleClick(wxMouseEvent& event);
         void        OnMouseRightDoubleClick(wxMouseEvent& event);
         void        OnMouseMiddleDown(wxMouseEvent& event);
@@ -98,12 +99,42 @@ class PlotWaterfall : public PlotPanel
         
         int      leftOffset_;
 
-        std::deque<wxBitmap*> waterfallSlices_;
-        
+        // One "block" of the waterfall: dy pixel rows of spectrum.
+        //
+        // bitmap is the render target plotPixelData() blits into; gfxBitmap is the
+        // renderer-native copy that draw() actually composites. Compositing the wxBitmap
+        // directly is what we're avoiding here: on macOS
+        // wxGraphicsContext::DrawBitmap(wxBitmap) wraps it in a freshly allocated NSImage
+        // every call (wxBitmapRefData::GetImage() caches nothing) and draws through
+        // -[NSImage drawInRect:], whereas the wxGraphicsBitmap overload goes straight to
+        // CGContextDrawImage. At one call per block and m_imgHeight/dy blocks on screen,
+        // that wrapper was the bulk of the paint.
+        struct WaterfallSlice
+        {
+            wxBitmap* bitmap;
+            wxGraphicsBitmap gfxBitmap;
+        };
+        std::deque<WaterfallSlice> waterfallSlices_;
+
+        // Graticule labels only move when the control is resized, but drawGraticule() runs
+        // on every frame. Measuring them there is not cheap -- wxWindowMac::DoGetTextExtent
+        // builds and destroys a whole wxGraphicsContext per call -- so the laid out text is
+        // cached and rebuilt only when the geometry changes.
+        struct GraticuleLabel
+        {
+            wxString text;
+            int x;
+            int y;
+        };
+        std::vector<GraticuleLabel> freqLabels_;
+        std::vector<GraticuleLabel> timeLabels_;
+        bool graticuleLabelsValid_;
+
         void        OnDoubleClickCommon(wxMouseEvent& event);
 
         void cleanupSlices_();
-        
+        void rebuildGraticuleLabels_();
+
         DECLARE_EVENT_TABLE()
 };
 


### PR DESCRIPTION
## Summary

Cuts the per-frame cost of the plot panels, and fixes an uninitialised read in the waterfall's colour lookup table found along the way.

The common thread: on macOS `wxGraphicsContext::DrawBitmap(wxBitmap)` is much more expensive than the `wxGraphicsBitmap` overload. `wxBitmapRefData::GetImage()` caches nothing, so every call allocates a fresh `NSImage` and draws through `-[NSImage drawInRect:]`, where the `wxGraphicsBitmap` path goes straight to `CGContextDrawImage`. The waterfall made one such call *per pixel block* — `m_imgHeight/dy`, about 200 on a 600px tall plot — on each of its 10 frames per second.

## Changes

- **Waterfall blocks are held as `{wxBitmap, wxGraphicsBitmap}` pairs.** The `wxBitmap` remains the `StretchBlit` target; the renderer-native copy is made once when the block is filled, instead of on every frame it spends scrolling down the screen.
- **`PlotScalar` composites its plot area the same way.** The conversion is per-frame here since `plotArea_` is redrawn each time, but it still beats the `NSImage` round trip. (`plotLinesBMP_` in `drawGraticuleFast()` has always taken this path — this just applies it to the data bitmap too.)
- **Waterfall graticule labels are laid out once per resize.** `wxWindowMac::DoGetTextExtent` builds and destroys a whole `wxGraphicsContext` per call, and `drawGraticule()` was making ~25 of them per frame for text that only moves on resize. It also measured every 1-second tick *before* checking whether that tick gets a label, discarding most of the work.
- **Dropped `BeginLayer(1.0)`/`EndLayer`** from the waterfall, scalar and spectrum plots — at opacity 1.0 the transparency layer allocates and composites an offscreen buffer to produce exactly what drawing directly produces.
- **Fixed `m_heatmap_lut`**, which was filled over `0..254` while `plotPixelData()` clamps intensity to 255 and reaches it whenever a bin sits at the top of the current range. The hottest pixels took their colour from indeterminate memory on essentially every frame carrying signal.

## Measurements

Timed in-process, driving `draw()` on each panel's real in-app repaint path:

| | master | this branch | |
|---|---|---|---|
| Waterfall 700×600 (full repaint) | 1.648 ms | **0.453 ms** | 3.6× |
| Frm Mic 700×200 (data-only repaint) | 0.381 ms | **0.205 ms** | 1.9× |

## Verification

Rendered both panels offscreen through `draw()` and diffed against master over **400 frames** — enough to fill the waterfall and exercise block recycling ~200 times, which is the risky part of the change since a recycled `wxBitmap` gets blitted into while older `wxGraphicsBitmap`s may still reference it:

- master vs. performance changes alone: **0 differing pixels** out of 420,000 (waterfall) and 140,000 (Frm Mic)
- performance changes vs. + LUT fix: **1,665 pixels**, all in the peak signal column, moving from `RGB(15,0,0)` / `RGB(62,0,0)` / `RGB(220,0,0)` to the intended full-scale red. That is the bug being fixed, and confirms the bad entry was genuinely being read.

`test_rade_loss.sh` passes, but it cannot really speak to these changes — it exercises no plotting, and it fails intermittently on master on the same machine (master 5 pass / 1 fail, this branch 4 pass / 3 fail across interleaved runs of the two builds).

## Notes

The `wxGraphicsBitmap` change is verified for macOS only; the label caching and transparency-layer removal should help on all platforms. `PlotWaterfall::refreshData()` and `PlotSpectrum::refreshData()` are still dead (the timers call `Refresh()` directly) — left alone deliberately, since `m_rxFreq` is `FDMDV_FCENTRE - g_RxFreqOffsetHz` and so never 0 in normal use, meaning wiring them up would change nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADMCssMazpW1igtvMHXNWZ