### PR TITLE
Match std::atomic memory ordering to what each atomic actually synchronises

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -956,6 +956,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * macOS: Fix dyld error on startup when enabling sanitizers in build. (PR #1478)
     * Fix potential equalizer bug that could introduce corrupted audio. (PR #1480)
     * Fix uninitialized value read during waterfall plot render. (PR #1481)
+    * Match std::atomic memory ordering to what each atomic actually synchronises. (PR #1482)
 2. Other:
     * Waterfall and other plot performance improvements. (PR #1481)
 

--- a/src/gui/dialogs/dlg_options.cpp
+++ b/src/gui/dialogs/dlg_options.cpp
@@ -1546,10 +1546,10 @@ void OptionsDlg::OnDebugConsole(wxScrollEvent&) {
 
 void OptionsDlg::OnFifoReset(wxCommandEvent&)
 {
-    g_infifo1_full.store(0, std::memory_order_release);
-    g_outfifo1_empty.store(0, std::memory_order_release);
-    g_infifo2_full.store(0, std::memory_order_release);
-    g_outfifo2_empty.store(0, std::memory_order_release);
+    g_infifo1_full.store(0, std::memory_order_relaxed);
+    g_outfifo1_empty.store(0, std::memory_order_relaxed);
+    g_infifo2_full.store(0, std::memory_order_relaxed);
+    g_outfifo2_empty.store(0, std::memory_order_relaxed);
     for (int i=0; i<4; i++) {
         g_AEstatus1[i] = g_AEstatus2[i] = 0;
     }
@@ -1803,7 +1803,7 @@ void OptionsDlg::exitPTTCaptureMode_(bool accept, int keyCode)
 void OptionsDlg::DisplayFifoPACounters() {
     if (IsShownOnScreen())
     {
-        wxString fifo_counters = wxString::Format(wxT("Fifos: infull1: %d outempty1: %d infull2: %d outempty2: %d"), g_infifo1_full.load(std::memory_order_acquire), g_outfifo1_empty.load(std::memory_order_acquire), g_infifo2_full.load(std::memory_order_acquire), g_outfifo2_empty.load(std::memory_order_acquire));
+        wxString fifo_counters = wxString::Format(wxT("Fifos: infull1: %d outempty1: %d infull2: %d outempty2: %d"), g_infifo1_full.load(std::memory_order_relaxed), g_outfifo1_empty.load(std::memory_order_relaxed), g_infifo2_full.load(std::memory_order_relaxed), g_outfifo2_empty.load(std::memory_order_relaxed));
         m_textFifos->SetLabel(fifo_counters);
 
         // input: underflow overflow output: underflow overflow

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3569,10 +3569,10 @@ void MainFrame::startRxStream()
 
         // reset debug stats for FIFOs
 
-        g_infifo1_full.store(0, std::memory_order_release);
-        g_outfifo1_empty.store(0, std::memory_order_release);
-        g_infifo2_full.store(0, std::memory_order_release);
-        g_outfifo2_empty.store(0, std::memory_order_release);
+        g_infifo1_full.store(0, std::memory_order_relaxed);
+        g_outfifo1_empty.store(0, std::memory_order_relaxed);
+        g_infifo2_full.store(0, std::memory_order_relaxed);
+        g_outfifo2_empty.store(0, std::memory_order_relaxed);
         for (int i=0; i<4; i++) {
             g_AEstatus1[i] = g_AEstatus2[i] = 0;
         }
@@ -3670,7 +3670,7 @@ void MainFrame::startRxStream()
                 auto toRead = std::min((size_t)cbData->outfifo1->numUsed(), size);
                 if (toRead < size)
                 {
-                    g_outfifo1_empty.fetch_add(1, std::memory_order_release);
+                    g_outfifo1_empty.fetch_add(1, std::memory_order_relaxed);
                 }
 
                 cbData->outfifo1->read(tmpOutput, toRead);
@@ -4102,7 +4102,7 @@ void MainFrame::OnTxInAudioData_(IAudioDevice& dev, void* data, size_t size, voi
         }
         if (isModemRunning.load(std::memory_order_acquire) && cbData->infifo2->write(tmpInput, size)) 
         {
-            g_infifo2_full.fetch_add(1, std::memory_order_release);
+            g_infifo2_full.fetch_add(1, std::memory_order_relaxed);
         }
     }
 }
@@ -4117,7 +4117,7 @@ void MainFrame::OnTxOutAudioData_(IAudioDevice& dev, void* data, size_t size, vo
     auto isTuning = cbData->isTuning.load(std::memory_order_acquire);
     if (toRead < size && !isTuning)
     {
-        g_outfifo1_empty.fetch_add(1, std::memory_order_release);
+        g_outfifo1_empty.fetch_add(1, std::memory_order_relaxed);
     }
     else
     {
@@ -4193,7 +4193,7 @@ void MainFrame::OnRxInAudioData_(IAudioDevice& dev, void* data, size_t size, voi
     }
     if (isModemRunning.load(std::memory_order_acquire) && cbData->infifo1->write(tmpInput, size)) 
     {
-        g_infifo1_full.fetch_add(1, std::memory_order_release);
+        g_infifo1_full.fetch_add(1, std::memory_order_relaxed);
     }
 }
 
@@ -4206,7 +4206,7 @@ void MainFrame::OnRxOutAudioData_(IAudioDevice& dev, void* data, size_t size, vo
     auto toRead = std::min((size_t)cbData->outfifo2->numUsed(), size);
     if (toRead < size)
     {
-        g_outfifo2_empty.fetch_add(1, std::memory_order_release);
+        g_outfifo2_empty.fetch_add(1, std::memory_order_relaxed);
     }
     else
     {

--- a/src/ongui.cpp
+++ b/src/ongui.cpp
@@ -1505,12 +1505,12 @@ void MainFrame::togglePTT(void) {
             }
         }
 
-        int sample = g_outfifo1_empty;
+        int sample = g_outfifo1_empty.load(std::memory_order_relaxed);
         before = highResClock.now();
         while(true)
         {
             auto diff = highResClock.now() - before;
-            auto tmp = g_outfifo1_empty.load(std::memory_order_acquire);
+            auto tmp = g_outfifo1_empty.load(std::memory_order_relaxed);
             if (diff >= std::chrono::milliseconds(1000) || (tmp != sample))
             {
                 log_info("All TX finished (diff = %d ms, fifo_empty = %d, sample = %d), going out of PTT", (int)std::chrono::duration_cast<std::chrono::milliseconds>(diff).count(), tmp, sample);

--- a/src/pipeline/TxRxThread.cpp
+++ b/src/pipeline/TxRxThread.cpp
@@ -299,7 +299,7 @@ void TxRxThread::initializePipeline_()
         auto bypassRecordModulated = new AudioPipeline(outputSampleRate_, outputSampleRate_);
         
         auto eitherOrRecordModulated = new EitherOrStep(
-            +[]() FREEDV_NONBLOCKING { return g_recFileFromModulator && (g_sfRecFileFromModulator != NULL); },
+            +[]() FREEDV_NONBLOCKING { return g_recFileFromModulator.load(std::memory_order_acquire) && (g_sfRecFileFromModulator.load(std::memory_order_acquire) != NULL); },
             recordModulatedTapPipeline,
             bypassRecordModulated);
         pipeline_->appendPipelineStep(eitherOrRecordModulated);
@@ -624,9 +624,9 @@ void* TxRxThread::Entry() noexcept
     startSem_.wait();
     clearFifos_();
 
-    while (m_run)
+    while (m_run.load(std::memory_order_acquire))
     {
-        if (!m_run) break;
+        if (!m_run.load(std::memory_order_acquire)) break;
         
         //log_info("thread woken up: m_tx=%d", (int)m_tx);
         helper->startRealTimeWork();

--- a/src/pipeline/TxRxThread.h
+++ b/src/pipeline/TxRxThread.h
@@ -95,7 +95,7 @@ public:
 
     void stop()
     {
-        m_run = false;
+        m_run.store(false, std::memory_order_release);
         if (thread_.joinable())
         {
             thread_.join();


### PR DESCRIPTION
## Summary

Two related tidy-ups to how `std::atomic` orderings are specified. **Neither changes behaviour** — the point is that the ordering should document the actual synchronisation, because right now it doesn't.

## 1. FIFO debug counters were over-ordered (18 sites)

`g_infifo1_full`, `g_outfifo1_empty`, `g_infifo2_full`, `g_outfifo2_empty` used acquire/release throughout. They publish nothing — incremented in the audio callbacks, read only to display a count (options dialog, PTT drain poll). No reader dereferences memory whose visibility depends on them.

`release` on those `fetch_add`s advertises a happens-before relationship that nothing consumes. That's actively misleading when you're working out what guards what in the real-time path. `relaxed` is what they need.

## 2. Three accesses were silently taking `seq_cst`

Written bare rather than via `.load()`/`.store()`:

- **`TxRxThread.cpp:302`** — the playback-record predicate read `g_recFileFromModulator` and `g_sfRecFileFromModulator` implicitly, while the structurally identical predicate a hundred lines above spells out `acquire` on `g_playFileToMicIn`/`g_sfPlayFile`. These genuinely *do* publish data (the opened `SNDFILE` must be visible to the RX/TX thread), so they stay `acquire` — just explicitly, and now consistent with their neighbour. This one runs on **every 20 ms frame**.
- **`m_run`** — read as `while (m_run)`, written as `m_run = false`.
- **`ongui.cpp:1508`** — sampled `g_outfifo1_empty` by implicit conversion.

## Deliberately left alone

- The `SNDFILE*`/bool publishing pairs (`g_sfPlayFile`, `g_sfRecDecoderFile`, …) — the acquire/release is exactly what makes the opened file visible to the real-time thread.
- `isModemRunning`, `ParallelStep::exitingThread`, and the `endingTx`/`g_eoo_enqueued` handshake — all order access to other memory, and the last spans two atomics.
- `tuneSineWaveSampleNumber` and `numRealTimeWorkers_` — relaxable in principle (pure counters), but they're part of the callback and workgroup protocols and run at most twice per callback. Low reward, non-zero risk.

## No performance claim

On arm64 the affected operations do change instruction — verified locally: `ldaddl`→`ldadd`, `ldar`→`ldapr`, `stlr`→`str`. But every one runs at most a few times per 20 ms frame, and **no atomic in this codebase sits inside a per-sample loop** — those were hoisted out already, with a comment at `main.cpp` saying so. Any measurable speedup here would be a rounding error, and this PR shouldn't be read as claiming one.

## Testing

`test_rade_loss.sh` passes (loss 0.099), including a clean thread start/stop cycle — which is the part the `m_run` change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADMCssMazpW1igtvMHXNWZ