### PR TITLE
Remove reliable text lock from audio threads.

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -957,6 +957,7 @@ LDPC | Low Density Parity Check Codes - a family of powerful FEC codes
     * Fix potential equalizer bug that could introduce corrupted audio. (PR #1480)
     * Fix uninitialized value read during waterfall plot render. (PR #1481)
     * Match std::atomic memory ordering to what each atomic actually synchronises. (PR #1482)
+    * Remove use of mutexes in audio path during callsign decode. (PR #1486)
 2. Other:
     * Waterfall and other plot performance improvements. (PR #1481)
 

--- a/src/freedv_interface.cpp
+++ b/src/freedv_interface.cpp
@@ -81,7 +81,8 @@ FreeDVInterface::FreeDVInterface() :
     lpcnetEncState_(nullptr),
     radeTxStep_(nullptr),
     sync_(0),
-    radeTextPtr_(nullptr)
+    radeTextPtr_(nullptr),
+    reliableTextFifo_(RELIABLE_TEXT_FIFO_SIZE + 1)
 {
     // empty
 }
@@ -104,10 +105,11 @@ void FreeDVInterface::OnReliableTextRx_(reliable_text_t rt, const char* txt_ptr,
     FreeDVInterface* obj = (FreeDVInterface*)state;
     assert(obj != nullptr);
     
-    {
-        std::unique_lock<std::mutex> lock(obj->reliableTextMutex_);
-        obj->receivedReliableText_ = txt_ptr;
-    }
+    char tmpBuf[RELIABLE_TEXT_FIFO_SIZE];
+    memset(tmpBuf, 0, RELIABLE_TEXT_FIFO_SIZE);
+    strncpy(tmpBuf, txt_ptr, RELIABLE_TEXT_FIFO_SIZE);
+    obj->reliableTextFifo_.write(tmpBuf, RELIABLE_TEXT_FIFO_SIZE);
+
     reliable_text_reset(rt);
 }
 
@@ -118,10 +120,10 @@ void FreeDVInterface::OnRadeTextRx_(rade_text_t, const char* txt_ptr, int, void*
     FreeDVInterface* obj = (FreeDVInterface*)state;
     assert(obj != nullptr);
     
-    {
-        std::unique_lock<std::mutex> lock(obj->reliableTextMutex_);
-        obj->receivedReliableText_ = txt_ptr;
-    }
+    char tmpBuf[RELIABLE_TEXT_FIFO_SIZE];
+    memset(tmpBuf, 0, RELIABLE_TEXT_FIFO_SIZE);
+    strncpy(tmpBuf, txt_ptr, RELIABLE_TEXT_FIFO_SIZE);
+    obj->reliableTextFifo_.write(tmpBuf, RELIABLE_TEXT_FIFO_SIZE);
 }
 
 float FreeDVInterface::GetMinimumSNR_(int mode)
@@ -677,12 +679,21 @@ void FreeDVInterface::resetReliableText()
     {
         std::unique_lock<std::mutex> lock(reliableTextMutex_);
         receivedReliableText_ = "";
+        reliableTextFifo_.reset();
     }
 }
 
 const char* FreeDVInterface::getReliableText()
-{
+{    
     std::unique_lock<std::mutex> lock(reliableTextMutex_);
+    
+    if (reliableTextFifo_.numUsed() > 0)
+    {
+        char tmpBuf[RELIABLE_TEXT_FIFO_SIZE];
+        reliableTextFifo_.read(tmpBuf, RELIABLE_TEXT_FIFO_SIZE);
+        receivedReliableText_ = tmpBuf;
+    }
+    
     char* ret = new char[receivedReliableText_.size() + 1];
     assert(ret != nullptr);
     

--- a/src/freedv_interface.h
+++ b/src/freedv_interface.h
@@ -59,6 +59,7 @@ extern "C"
 #include "util/IRealtimeHelper.h"
 #include "freedv_sanitizers.h"
 #include "util/realtime_fp.h"
+#include "util/GenericFIFO.h"
 
 class IPipelineStep;
 class ParallelStep;
@@ -213,6 +214,9 @@ private:
     std::atomic<int> sync_;
     std::atomic<int> radeSnr_;
     rade_text_t radeTextPtr_;
+    
+    static constexpr int RELIABLE_TEXT_FIFO_SIZE = 64;
+    GenericFIFO<char> reliableTextFifo_;
     
     int preProcessRxFn_(ParallelStep* ps) FREEDV_NONBLOCKING;
     int postProcessRxFn_(ParallelStep* ps) FREEDV_NONBLOCKING;


### PR DESCRIPTION
Removes use of lock in audio threads when handling decoded callsigns in favor of preexisting FIFO objects.